### PR TITLE
Made argument_list contain all arguments

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -9,7 +9,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts
-  "2017.06.23", ## Sebas' version
+  "2017.07.17", ## Sebas' version
   ## this line prevents merge conflicts
   "2017.02.15", ## Sepp's version
 ] ),

--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -132,6 +132,8 @@ The record can have the following components, used as described:
 
 * argument_list (optional): A list containing integers, which defines which arguments should be used for the additional functions, (e.g redirect, pre, ...).
                             This is important for the Op method contructions. If no argument list is given, all arguments are used.
+                            Please note that if you have a method selection argument for your function, you need to give the argument_list
+                            to explicitly state which argument is the method selection argument.
 
 * return_type (optional): The return type can be object, morphism, or twocell. If it is one of those, the correct add function (see above) is
                           used for the result of the computation. Otherwise, no add function is used after all.

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -539,13 +539,16 @@ InstallGlobalFunction( CAP_INTERNAL_INSTALL_ADDS_FROM_RECORD,
         fi;
         
         
+#         if not IsBound( current_rec.argument_list ) then
+#             if Length( current_rec.filter_list ) > 1 and
+#               ForAll( [ 1 .. Length( current_rec.filter_list ) - 1 ], i -> current_rec.filter_list[ i ] = IsInt or current_rec.filter_list[ i ] = IsList ) then
+#                 current_rec.argument_list := [ 1 .. Length( current_rec.filter_list ) - 1 ];
+#             else
+#                 current_rec.argument_list := [ 1 .. Length( current_rec.filter_list ) ];
+#             fi;
+#         fi;
         if not IsBound( current_rec.argument_list ) then
-            if Length( current_rec.filter_list ) > 1 and
-              ForAll( [ 1 .. Length( current_rec.filter_list ) - 1 ], i -> current_rec.filter_list[ i ] = IsInt or current_rec.filter_list[ i ] = IsList ) then
-                current_rec.argument_list := [ 1 .. Length( current_rec.filter_list ) - 1 ];
-            else
-                current_rec.argument_list := [ 1 .. Length( current_rec.filter_list ) ];
-            fi;
+            current_rec.argument_list := [ 1 .. Length( current_rec.filter_list ) ];
         fi;
         
         if IsBound( current_rec.universal_type ) and not IsBound( current_rec.universal_object_position ) then


### PR DESCRIPTION
unless explicitly stated otherwise. Up to now,
if all but the last argument were lists or int,
and no argument_list was given, it was implicitly
assumed that the last argument is a method selection argument.
This was the wrong behaviour. Please note, as stated in the
manual, if there is a method selection argument, the argument_list
has to be stated explicitly in the method record.