### PR TITLE
added missing rules in PropositionsForAdditiveCategories.tex

### DIFF
--- a/CAP/LogicForCategories/PropositionsForAdditiveCategories.tex
+++ b/CAP/LogicForCategories/PropositionsForAdditiveCategories.tex
@@ -1,0 +1,12 @@
+\begin{sequent}
+\begin{align*}
+   a: \Obj ~|~ \IsZero \big( a \big) \vdash \IsZero \big( \IdentityMorphism( a ) \big)
+\end{align*}
+\end{sequent}
+
+\begin{sequent}
+\begin{align*}
+   a: \Obj, b: \Obj ~|~ \IsZero \big( a \big), \IsZero \big( b \big) \\
+   \vdash & \IsZero \big( \DirectSum( [ a, b ] ) \big)
+\end{align*}
+\end{sequent}

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2017.05.30", ## Mohamed's version
+  "2017.06.02", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts


### PR DESCRIPTION
added:

IsZero( a ) => IsZero( IdentityMorphism( a ) )

IsZero( a ) and IsZero( b ) => IsZero( DirectSum( [ a, b ] ) )