### PR TITLE
Morphismbetweendirectsums

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -11,7 +11,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2018.01.26", ## Sebas' version
   ## this line prevents merge conflicts
-  "2018.02.02", ## Sepp's version
+  "2018.02.07", ## Sepp's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1117,6 +1117,32 @@ AddDerivationToCAP( ComponentOfMorphismFromDirectSum,
     
 end : Description := "ComponentOfMorphismFromDirectSum by composing with the direct sum injection" );
 
+##
+AddDerivationToCAP( MorphismBetweenDirectSums,
+                    
+  function( S, morphism_matrix, T )
+    local diagram_direct_sum_source, diagram_direct_sum_range, test_diagram_product, test_diagram_coproduct;
+    
+    if morphism_matrix = [ ] or morphism_matrix[1] = [ ] then
+        return ZeroMorphism( S, T );
+    fi;
+    
+    diagram_direct_sum_source := List( morphism_matrix, row -> Source( row[1] ) );
+    
+    diagram_direct_sum_range := List( morphism_matrix[1], entry -> Range( entry ) );
+    
+    test_diagram_coproduct := [ ];
+    
+    for test_diagram_product in morphism_matrix do
+      
+      Add( test_diagram_coproduct, UniversalMorphismIntoDirectSumWithGivenDirectSum( diagram_direct_sum_range, test_diagram_product, T ) );
+      
+    od;
+    
+    return UniversalMorphismFromDirectSumWithGivenDirectSum( diagram_direct_sum_source, test_diagram_coproduct, S );
+    
+end : Description := "MorphismBetweenDirectSums using universal morphisms of direct sums" );
+
 ###########################
 ##
 ## Methods returning a morphism with source or range constructed within the method!

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2513,8 +2513,17 @@ ComponentOfMorphismFromDirectSum := rec(
   io_type := [ [ "alpha", "S", "i" ], [ "T", "alpha_range" ] ],
   cache_name := "ComponentOfMorphismFromDirectSum",
   return_type := "morphism",
-  dual_operation := "ComponentOfMorphismIntoDirectSum" )
+  dual_operation := "ComponentOfMorphismIntoDirectSum" ),
 
+MorphismBetweenDirectSums := rec(
+  installation_name := "MorphismBetweenDirectSums",
+  filter_list := [ "object", IsList, "object" ],
+  io_type := [ [ "S", "mat", "T" ], [ "S", "T" ] ],
+  cache_name := "MorphismBetweenDirectSums",
+  return_type := "morphism",
+  dual_operation := "MorphismBetweenDirectSums",
+  dual_arguments_reversed := true
+),
   ) );
 
 InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -1390,8 +1390,8 @@ DeclareOperation( "IsomorphismFromCoproductToDirectSumOp",
 #! is a list of lists of morphisms.
 #! @Arguments M
 #! @Group MorphismBetweenDirectSums
-DeclareOperationWithCache( "MorphismBetweenDirectSums",
-                           [ IsList ] );
+DeclareOperation( "MorphismBetweenDirectSums",
+                  [ IsList ] );
 
 #! @Description
 #! The output is the morphism
@@ -1404,8 +1404,27 @@ DeclareOperationWithCache( "MorphismBetweenDirectSums",
 #! @Returns a morphism in $\mathrm{Hom}(\bigoplus_{i=1}^{m}A_i, \bigoplus_{j=1}^n B_j)$
 #! @Arguments S, M, T
 #! @Group MorphismBetweenDirectSums
-DeclareOperationWithCache( "MorphismBetweenDirectSums",
-                           [ IsCapCategoryObject, IsList, IsCapCategoryObject ] );
+DeclareOperation( "MorphismBetweenDirectSums",
+                  [ IsCapCategoryObject, IsList, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>MorphismBetweenDirectSums</C>.
+#! $F: (\bigoplus_{i=1}^{m}A_i, M, \bigoplus_{j=1}^n B_j) \mapsto (\bigoplus_{i=1}^{m}A_i \rightarrow \bigoplus_{j=1}^n B_j)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddMorphismBetweenDirectSums",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddMorphismBetweenDirectSums",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddMorphismBetweenDirectSums",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddMorphismBetweenDirectSums",
+                  [ IsCapCategory, IsList ] );
 
 #! @Description
 #! The arguments are a list

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -443,38 +443,33 @@ InstallMethod( MorphismBetweenDirectSums,
                [ IsList ],
                
   function( morphism_matrix )
-    local morphism_matrix_listlist, row, rows, cols;
+    local nr_rows, nr_cols;
     
-    morphism_matrix_listlist := [ ];
+    nr_rows := Size( morphism_matrix );
     
-    for row in morphism_matrix do
-      
-      Append( morphism_matrix_listlist, row );
-      
-    od;
-    
-    rows := Length( morphism_matrix );
-    
-    cols := Length( morphism_matrix[1] );
-    
-    return MorphismBetweenDirectSumsOp( morphism_matrix_listlist, rows, cols, morphism_matrix[1][1] );
-    
-end );
-
-##
-InstallMethod( MorphismBetweenDirectSums,
-               [ IsCapCategoryObject, IsList, IsCapCategoryObject ],
-               
-  function( S, morphism_matrix, T )
-    
-    if morphism_matrix = [ ] or morphism_matrix[1] = [ ] then
-        return ZeroMorphism( S, T );
+    if nr_rows = 0 then
+        
+        Error( "The given matrix must not be empty" );
+        
     fi;
     
-    return MorphismBetweenDirectSums( morphism_matrix );
+    nr_cols := Size( morphism_matrix[1] );
+    
+    if nr_cols = 0 then
+        
+        Error( "The given matrix must not be empty" );
+        
+    fi;
+    
+    return MorphismBetweenDirectSums(
+             DirectSum( List( morphism_matrix, row -> Source( row[1] ) ) ),
+             morphism_matrix,
+             DirectSum( List( morphism_matrix[1], col -> Range( col ) ) )
+           );
     
 end );
 
+## TODO: is this deprecated?
 ##
 InstallMethodWithCacheFromObject( MorphismBetweenDirectSumsOp,
                                   [ IsList, IsInt, IsInt, IsCapCategoryMorphism ],
@@ -490,19 +485,7 @@ InstallMethodWithCacheFromObject( MorphismBetweenDirectSumsOp,
       
     od;
     
-    diagram_direct_sum_source := List( morphism_matrix, row -> Source( row[1] ) );
-    
-    diagram_direct_sum_range := List( morphism_matrix[1], entry -> Range( entry ) );
-    
-    test_diagram_coproduct := [ ];
-    
-    for test_diagram_product in morphism_matrix do
-      
-      Add( test_diagram_coproduct, UniversalMorphismIntoDirectSum( diagram_direct_sum_range, test_diagram_product ) );
-      
-    od;
-    
-    return UniversalMorphismFromDirectSum( diagram_direct_sum_source, test_diagram_coproduct );
+    return MorphismBetweenDirectSums( morphism_matrix );
     
 end: ArgumentNumber := 4 );
 

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -15,7 +15,7 @@ Subtitle := "Category of Matrices over a Field for CAP",
 Version := Maximum( [
   "2017.12.30", ## Sebas' version
   ## this line prevents merge conflicts
-  "2018.02.02", ## Sepp's version
+  "2018.02.07", ## Sepp's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -88,8 +88,8 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.6",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "MatricesForHomalg", ">= 2017.05.24" ],
-                           [ "CAP", ">= 2018.02.02" ],
+                           [ "MatricesForHomalg", ">= 2018.02.04" ],
+                           [ "CAP", ">= 2018.02.07" ],
                            [ "ToolsForHomalg", ">=2015.09.18" ]
                            ],
   SuggestedOtherPackages := [ ],

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -430,6 +430,23 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
     end );
     
+    ##
+    AddMorphismBetweenDirectSums( category,
+      function( S, morphism_matrix, T )
+        local underlying_matrix;
+        
+        if morphism_matrix = [ ] or morphism_matrix[1] = [ ] then
+            return ZeroMorphism( S, T );
+        fi;
+        
+        underlying_matrix := List( morphism_matrix, row -> List( row, UnderlyingMatrix ) );
+        
+        underlying_matrix := List( underlying_matrix, row -> UnionOfColumns( row ) );
+        
+        return VectorSpaceMorphism( S, UnionOfRows( underlying_matrix ), T );
+        
+    end );
+    
     ## Basic Operations for an Abelian category
     ##
     AddKernelObject( category,


### PR DESCRIPTION
I turned MorphismBetweenDirectSums into a CAP primitive.
This allows us to install more specific versions
(like for vector spaces).