### PR TITLE
Replace DeclareAttributeWithToDoForIsWellDefined

### DIFF
--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -51,24 +51,24 @@ DeclareAttribute( "UnderlyingHonestObject",
 #! The output is its domain $d \hookrightarrow a \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( d, a )$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "DomainOfGeneralizedMorphism",
-                                          IsGeneralizedMorphism );
+DeclareAttribute( "DomainOfGeneralizedMorphism",
+                  IsGeneralizedMorphism );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its codomain $b \twoheadrightarrow c \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( b, c )$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "Codomain",
-                                          IsGeneralizedMorphism );
+DeclareAttribute( "Codomain",
+                  IsGeneralizedMorphism );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its associated morphism $d \rightarrow c \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( d, c )$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "AssociatedMorphism",
-                                          IsGeneralizedMorphism );
+DeclareAttribute( "AssociatedMorphism",
+                  IsGeneralizedMorphism );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
@@ -85,8 +85,8 @@ DeclareAttribute( "DomainAssociatedMorphismCodomainTriple",
 #! if it exists, otherwise an error is thrown.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( a, b )$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "HonestRepresentative",
-                                          IsGeneralizedMorphism );
+DeclareAttribute( "HonestRepresentative",
+                  IsGeneralizedMorphism );
 
 ##
 ## When calling this method on a generalized morphism, the effect

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gd
@@ -101,8 +101,8 @@ DeclareAttribute( "UnderlyingHonestObject",
 #! The output is its source aid $a \leftarrow b$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}(b,a)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "SourceAid",
-                                          IsGeneralizedMorphismByThreeArrows );
+DeclareAttribute( "SourceAid",
+                  IsGeneralizedMorphismByThreeArrows );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha$ by
@@ -110,8 +110,8 @@ DeclareAttributeWithToDoForIsWellDefined( "SourceAid",
 #! The output is its range aid $c \leftarrow d$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}(d,c)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "RangeAid",
-                                          IsGeneralizedMorphismByThreeArrows );
+DeclareAttribute( "RangeAid",
+                   IsGeneralizedMorphismByThreeArrows );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha$ by
@@ -119,8 +119,8 @@ DeclareAttributeWithToDoForIsWellDefined( "RangeAid",
 #! The output is its range aid $b \rightarrow c$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}(b,c)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "Arrow",
-                                          IsGeneralizedMorphismByThreeArrows );
+DeclareAttribute( "Arrow",
+                  IsGeneralizedMorphismByThreeArrows );
 
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$ by
@@ -128,16 +128,16 @@ DeclareAttributeWithToDoForIsWellDefined( "Arrow",
 #! The output is its pseudo inverse $b \rightarrow a$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{G(A)}}(b,a)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "PseudoInverse",
-                                          IsGeneralizedMorphismByThreeArrows );
+DeclareAttribute( "PseudoInverse",
+                  IsGeneralizedMorphismByThreeArrows );
 
 #! @Description
 #! The argument is a morphism $\alpha: a \rightarrow b \in \mathbf{A}$.
 #! The output is its generalized inverse $b \rightarrow a$ by three arrows.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{G(A)}}(b,a)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "GeneralizedInverseByThreeArrows",
-                                          IsCapCategoryMorphism );
+DeclareAttribute( "GeneralizedInverseByThreeArrows",
+                  IsCapCategoryMorphism );
 
 #! @Description
 #! The argument is a subobject $\alpha: a \hookrightarrow b \in \mathbf{A}$.
@@ -240,8 +240,8 @@ DeclareOperation( "GeneralizedMorphismByThreeArrowsWithRangeAid",
 #! The output is the honest generalized morphism by three arrows defined by $\alpha$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{G(A)}}(a,b)$
 #! @Arguments alpha
-DeclareAttributeWithToDoForIsWellDefined( "AsGeneralizedMorphismByThreeArrows",
-                                          IsCapCategoryMorphism );
+DeclareAttribute( "AsGeneralizedMorphismByThreeArrows",
+                  IsCapCategoryMorphism );
 
 #! @Description
 #! The argument is an abelian category $\mathbf{A}$.
@@ -257,5 +257,5 @@ DeclareAttribute( "GeneralizedMorphismCategoryByThreeArrows",
 #! whose underlying honest object is $a$.
 #! @Returns an object in $\mathbf{G(A)}$
 #! @Arguments a
-DeclareAttributeWithToDoForIsWellDefined( "GeneralizedMorphismByThreeArrowsObject",
-                                          IsCapCategoryObject );
+DeclareAttribute( "GeneralizedMorphismByThreeArrowsObject",
+                  IsCapCategoryObject );


### PR DESCRIPTION
in generalized morphism category.

DeclareAttributeWithToDoForIsWellDefined is deprecated since
we agreed on only using IsWellDefined as a Debug Tool.