### PR TITLE
Implementation of a 2-arrow data structure (with applications to module categories)

### DIFF
--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -76,6 +76,12 @@ biased_w := CategoryOfRowsMorphism( S3, HomalgMatrix( "[x,0,0,0,x,0,0,0,x]", 3, 
 biased_h := CategoryOfRowsMorphism( S3, HomalgMatrix( "[x*y, x*z, y^2]", 3, 3, S ), S3 );
 BiasedWeakFiberProduct( biased_h, biased_w );
 ProjectionOfBiasedWeakFiberProduct( biased_h, biased_w );
+IsCongruentForMorphisms(
+   PreCompose( UniversalMorphismIntoBiasedWeakFiberProduct( biased_h, biased_w, biased_h ), ProjectionOfBiasedWeakFiberProduct( biased_h, biased_w ) ),
+   biased_h
+);
+#true
+
 
 k := FreydCategoryObject( mor );
 w := EpimorphismFromSomeProjectiveObjectForKernelObject( UniversalMorphismIntoZeroObject( k ) );

--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -80,7 +80,12 @@ IsCongruentForMorphisms(
    PreCompose( UniversalMorphismIntoBiasedWeakFiberProduct( biased_h, biased_w, biased_h ), ProjectionOfBiasedWeakFiberProduct( biased_h, biased_w ) ),
    biased_h
 );
-#true
+# true
+IsCongruentForMorphisms(
+  PreCompose( InjectionOfBiasedWeakPushout( biased_h, biased_w ), UniversalMorphismFromBiasedWeakPushout( biased_h, biased_w, biased_h )),
+  biased_h
+);
+# true
 
 
 k := FreydCategoryObject( mor );

--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -72,10 +72,16 @@ Rows_S := CategoryOfRows( S );
 S3 := CategoryOfRowsObject( 3, Rows_S );
 S1 := CategoryOfRowsObject( 1, Rows_S );
 mor := CategoryOfRowsMorphism( S3, HomalgMatrix( "[x,y,z]", 3, 1, S ), S1 );
+biased_w := CategoryOfRowsMorphism( S3, HomalgMatrix( "[x,0,0,0,x,0,0,0,x]", 3, 3, S ), S3 );
+biased_h := CategoryOfRowsMorphism( S3, HomalgMatrix( "[x*y, x*z, y^2]", 3, 3, S ), S3 );
+BiasedWeakFiberProduct( biased_h, biased_w );
+ProjectionOfBiasedWeakFiberProduct( biased_h, biased_w );
+
 k := FreydCategoryObject( mor );
 w := EpimorphismFromSomeProjectiveObjectForKernelObject( UniversalMorphismIntoZeroObject( k ) );
 k := KernelEmbedding( w );
 ColiftAlongEpimorphism( CokernelProjection( k ), CokernelProjection( k ) );
+
 
 ## Homomorphism structures
 a := InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( gamma );

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -36,4 +36,5 @@ UniversalMorphismFromDirectSum( [ nu, nu ] );
 ProjectionInFactorOfDirectSum( [ S, S, S ], 2 );
 InjectionOfCofactorOfDirectSum( [ S, S, S, S ], 4 );
 
+CokernelColift( nu, CokernelProjection( nu ) );
 #! @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -1,0 +1,15 @@
+#! @Chapter Examples and Tests
+
+#! @Section Cokernel image closure 
+
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "RingsForHomalg" );
+
+#! @Example
+R := HomalgFieldOfRationalsInSingular() * "x,y,z";
+RowsR := CategoryOfRows( R );
+m := AsCategoryOfRowsMorphism( 
+    HomalgMatrix( "[[x],[y],[z]]", 3, 1, R )
+);
+mu := AsCokernelImageClosureMorphism( m );
+#! @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -12,4 +12,21 @@ m := AsCategoryOfRowsMorphism(
     HomalgMatrix( "[[x],[y],[z]]", 3, 1, R )
 );
 mu := AsCokernelImageClosureMorphism( m );
+
+n := AsCategoryOfRowsMorphism( 
+    HomalgMatrix( "[[x,y],[y^2,z]]", 2, 2, R )
+);
+nu := AsCokernelImageClosureMorphism( n );
+nu2 := PreCompose( nu, nu );
+IsWellDefined( nu2 );
+IsCongruentForMorphisms( nu, nu2 );
+nu + nu;
+nu2 - nu;
+cat := CapCategory( nu );
+ZeroObject( cat );
+ZeroMorphism( Source( nu ), Source( mu ) );
+UniversalMorphismIntoZeroObject( Source( nu ) );
+UniversalMorphismFromZeroObject( Source( nu ) );
+# true
+
 #! @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -27,6 +27,13 @@ ZeroObject( cat );
 ZeroMorphism( Source( nu ), Source( mu ) );
 UniversalMorphismIntoZeroObject( Source( nu ) );
 UniversalMorphismFromZeroObject( Source( nu ) );
-# true
+
+S := Source( mu );
+DirectSum( [S, S, S ] );
+DirectSumFunctorial( [ nu2, nu ] );
+UniversalMorphismIntoDirectSum( [ nu, nu ] );
+UniversalMorphismFromDirectSum( [ nu, nu ] );
+ProjectionInFactorOfDirectSum( [ S, S, S ], 2 );
+InjectionOfCofactorOfDirectSum( [ S, S, S, S ], 4 );
 
 #! @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -48,4 +48,9 @@ IsCongruentForMorphisms( nu, PreCompose( CoastrictionToImage( nu ), u ) );
 IsCongruentForMorphisms( u, ImageEmbedding( nu ) );
 # true
 
+kernel := KernelObject( mu );
+emb := KernelEmbedding( mu );
+p := PreCompose( EpimorphismFromSomeProjectiveObject( kernel ), KernelEmbedding( mu ) );
+KernelLift( mu, p );
+LiftAlongMonomorphism( emb, p );
 #! @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -37,4 +37,15 @@ ProjectionInFactorOfDirectSum( [ S, S, S ], 2 );
 InjectionOfCofactorOfDirectSum( [ S, S, S, S ], 4 );
 
 CokernelColift( nu, CokernelProjection( nu ) );
+
+IsCongruentForMorphisms( nu, PreCompose( CoastrictionToImage( nu ), ImageEmbedding( nu ) ) );
+# true
+u := UniversalMorphismFromImage( nu, [ nu, IdentityMorphism( Range( nu ) ) ] );
+IsWellDefined( u );
+# true
+IsCongruentForMorphisms( nu, PreCompose( CoastrictionToImage( nu ), u ) );
+# true
+IsCongruentForMorphisms( u, ImageEmbedding( nu ) );
+# true
+
 #! @EndExample

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -6,28 +6,6 @@
 ##
 #############################################################################
 
-DeclareRepresentation( "IsAdditiveClosureObjectRep",
-                       IsAdditiveClosureObject and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfAdditiveClosureObjects",
-        NewFamily( "TheFamilyOfAdditiveClosureObjects" ) );
-
-BindGlobal( "TheTypeOfAdditiveClosureObjects",
-        NewType( TheFamilyOfAdditiveClosureObjects,
-                IsAdditiveClosureObjectRep ) );
-
-DeclareRepresentation( "IsAdditiveClosureMorphismRep",
-                       IsAdditiveClosureMorphism and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfAdditiveClosureMorphisms",
-        NewFamily( "TheFamilyOfAdditiveClosureMorphisms" ) );
-
-BindGlobal( "TheTypeOfAdditiveClosureMorphisms",
-        NewType( TheFamilyOfAdditiveClosureMorphisms,
-                IsAdditiveClosureMorphismRep ) );
-
 ####################################
 ##
 ## Constructors
@@ -54,6 +32,12 @@ InstallMethod( AdditiveClosure,
     SetIsAdditiveCategory( category, true );
     
     SetUnderlyingCategory( category, underlying_category );
+    
+    AddObjectRepresentation( category, IsAdditiveClosureObject );
+    
+    AddMorphismRepresentation( category, IsAdditiveClosureMorphism );
+    
+    DisableAddForCategoricalOperations( category );
     
     INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE( category );
     
@@ -84,7 +68,8 @@ InstallMethodWithCache( AdditiveClosureObject,
     
     additive_closure_object := rec( );
     
-    ObjectifyWithAttributes( additive_closure_object, TheTypeOfAdditiveClosureObjects,
+    ObjectifyObjectForCAPWithAttributes( 
+                             additive_closure_object, category,
                              ObjectList, list_of_objects
     );
 
@@ -113,17 +98,20 @@ InstallMethod( AdditiveClosureMorphism,
                [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ],
                
   function( source, matrix, range )
-    local additive_closure_morphism;
+    local additive_closure_morphism, category;
     
     additive_closure_morphism := rec( );
     
-    ObjectifyWithAttributes( additive_closure_morphism, TheTypeOfAdditiveClosureMorphisms,
+    category := CapCategory( source );
+
+    ObjectifyMorphismForCAPWithAttributes( 
+                             additive_closure_morphism, category,
                              Source, source,
                              Range, range,
                              MorphismMatrix, matrix
     );
 
-    Add( CapCategory( source ), additive_closure_morphism );
+    Add( category, additive_closure_morphism );
     
     return additive_closure_morphism;
     

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -506,17 +506,16 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         
     end );
     
-    ## bias in the first injection (for the performance of the Freyd category)
-    ## this will become InjectionOfFirstCofactorOfBiasedWeakBiPushout
-#     AddInjectionOfFirstCofactorOfWeakBiPushout( category,
-#         function( morphism_1, morphism_2 )
-#         local homalg_matrix, weak_cokernel_object;
-#         
-#         homalg_matrix := ReducedSyzygiesOfColumns( UnderlyingMatrix( morphism_1 ), UnderlyingMatrix( morphism_2 ) );
-#         
-#         return CategoryOfRowsMorphism( Range( morphism_1 ), homalg_matrix, CategoryOfRowsObject( NrColumns( homalg_matrix ), category ) );
-#         
-#     end );
+    ##
+    AddInjectionOfBiasedWeakPushout( category,
+        function( morphism_1, morphism_2 )
+        local homalg_matrix, weak_cokernel_object;
+        
+        homalg_matrix := ReducedSyzygiesOfColumns( UnderlyingMatrix( morphism_1 ), UnderlyingMatrix( morphism_2 ) );
+        
+        return CategoryOfRowsMorphism( Range( morphism_1 ), homalg_matrix, CategoryOfRowsObject( NrColumns( homalg_matrix ), category ) );
+        
+    end );
     
     ##
     AddColift( category,

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -6,28 +6,6 @@
 ##
 #############################################################################
 
-DeclareRepresentation( "IsCategoryOfRowsObjectRep",
-                       IsCategoryOfRowsObject and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfCategoryOfRowsObjects",
-        NewFamily( "TheFamilyOfCategoryOfRowsObjects" ) );
-
-BindGlobal( "TheTypeOfCategoryOfRowsObjects",
-        NewType( TheFamilyOfCategoryOfRowsObjects,
-                IsCategoryOfRowsObjectRep ) );
-
-DeclareRepresentation( "IsCategoryOfRowsMorphismRep",
-                       IsCategoryOfRowsMorphism and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfCategoryOfRowsMorphisms",
-        NewFamily( "TheFamilyOfCategoryOfRowsMorphisms" ) );
-
-BindGlobal( "TheTypeOfCategoryOfRowsMorphisms",
-        NewType( TheFamilyOfCategoryOfRowsMorphisms,
-                IsCategoryOfRowsMorphismRep ) );
-
 ####################################
 ##
 ## Constructors
@@ -48,6 +26,12 @@ InstallMethod( CategoryOfRows,
     SetIsAdditiveCategory( category, true );
     
     SetUnderlyingRing( category, homalg_ring );
+    
+    AddObjectRepresentation( category, IsCategoryOfRowsObject );
+    
+    AddMorphismRepresentation( category, IsCategoryOfRowsMorphism );
+
+    DisableAddForCategoricalOperations( category );
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS( category );
     
@@ -74,8 +58,9 @@ InstallMethodWithCache( CategoryOfRowsObject,
     
     category_of_rows_object := rec( );
     
-    ObjectifyWithAttributes( category_of_rows_object, TheTypeOfCategoryOfRowsObjects,
-                             RankOfObject, rank
+    ObjectifyObjectForCAPWithAttributes( category_of_rows_object, 
+                                         category,
+                                         RankOfObject, rank
     );
 
     Add( category, category_of_rows_object );
@@ -138,10 +123,10 @@ InstallMethod( CategoryOfRowsMorphism,
     
     category_of_rows_morphism := rec( );
     
-    ObjectifyWithAttributes( category_of_rows_morphism, TheTypeOfCategoryOfRowsMorphisms,
-                             Source, source,
-                             Range, range,
-                             UnderlyingMatrix, homalg_matrix
+    ObjectifyMorphismForCAPWithAttributes( category_of_rows_morphism, category,
+                                           Source, source,
+                                           Range, range,
+                                           UnderlyingMatrix, homalg_matrix
     );
 
     Add( category, category_of_rows_morphism );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -493,17 +493,16 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         
     end );
     
-    ## bias in the first projection (for the performance of the Freyd category)
-    ## this will become ProjectionInFirstFactorOfBiasedWeakBiFiberProduct
-#     AddProjectionInFirstFactorOfWeakBiFiberProduct( category,
-#       function( morphism_1, morphism_2 )
-#         local homalg_matrix, weak_cokernel_object;
-#         
-#         homalg_matrix := ReducedSyzygiesOfRows( UnderlyingMatrix( morphism_1 ), UnderlyingMatrix( morphism_2 ) );
-#         
-#         return CategoryOfRowsMorphism( CategoryOfRowsObject( NrRows( homalg_matrix ), category ), homalg_matrix, Source( morphism_1 ) );
-#         
-#     end );
+    ##
+    AddProjectionOfBiasedWeakFiberProduct( category,
+      function( morphism_1, morphism_2 )
+        local homalg_matrix, weak_cokernel_object;
+        
+        homalg_matrix := ReducedSyzygiesOfRows( UnderlyingMatrix( morphism_1 ), UnderlyingMatrix( morphism_2 ) );
+        
+        return CategoryOfRowsMorphism( CategoryOfRowsObject( NrRows( homalg_matrix ), category ), homalg_matrix, Source( morphism_1 ) );
+        
+    end );
     
     ##
     AddLift( category,

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gd
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gd
@@ -1,0 +1,75 @@
+#############################################################################
+##
+##     FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+##
+##  Copyright 2018, Sebastian Posur, University of Siegen
+##
+#! @Chapter Cokernel image closure
+#!
+#############################################################################
+
+####################################
+##
+#! @Section GAP Categories
+##
+####################################
+
+DeclareCategory( "IsCokernelImageClosureObject",
+                 IsCapCategoryObject );
+
+DeclareCategory( "IsCokernelImageClosureMorphism",
+                 IsCapCategoryMorphism );
+
+DeclareCategory( "IsCokernelImageClosure",
+                 IsCapCategory );
+
+DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE" );
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareAttribute( "CokernelImageClosure",
+                  IsCapCategory );
+
+DeclareOperation( "CokernelImageClosureObject",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "CokernelImageClosureMorphism",
+                  [ IsCokernelImageClosureObject, IsCapCategoryMorphism, IsCokernelImageClosureObject ] );
+
+DeclareAttribute( "AsCokernelImageClosureObject",
+                  IsCapCategoryObject );
+
+DeclareAttribute( "AsCokernelImageClosureMorphism",
+                  IsCapCategoryMorphism );
+
+####################################
+##
+#! @Section Attributes
+##
+####################################
+
+DeclareAttribute( "UnderlyingCategory",
+                  IsCokernelImageClosure );
+
+DeclareAttribute( "GeneratorMorphism",
+                  IsCokernelImageClosureObject );
+
+DeclareAttribute( "RelationMorphism",
+                  IsCokernelImageClosureObject );
+
+## this exists if the underlying category has biased weak pullbacks
+DeclareAttribute( "RelationOfGeneratorMorphism",
+                  IsCokernelImageClosureObject );
+
+DeclareAttribute( "MorphismDatum",
+                  IsCokernelImageClosureMorphism );
+
+DeclareAttribute( "MorphismWitness",
+                  IsCokernelImageClosureMorphism );
+
+DeclareAttribute( "WitnessForBeingCongruentToZero",
+                  IsCokernelImageClosureMorphism );

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -187,6 +187,26 @@ InstallMethod( RelationOfGeneratorMorphism,
     
 end );
 
+##
+InstallMethod( WitnessForBeingCongruentToZero,
+               [ IsCokernelImageClosureMorphism ],
+
+  function( morphism )
+    local range;
+    
+    range := Range( morphism );
+
+    return
+    Lift(
+        PreCompose(
+            MorphismDatum( morphism ),
+            GeneratorMorphism( range )
+        ),
+        RelationMorphism( range )
+    );
+
+end );
+
 ####################################
 ##
 ## Basic operations
@@ -260,6 +280,41 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
         
     end );
 
+    ## Equality Basic Operations for Objects and Morphisms
+    ##
+    AddIsEqualForObjects( category,
+      function( object_1, object_2 )
+
+        return IsEqualForMorphismsOnMor( RelationMorphism( object_1 ), RelationMorphism( object_2 ) ) 
+               and 
+               IsEqualForMorphismsOnMor( GeneratorMorphism( object_1 ), GeneratorMorphism( object_2) );
+
+    end );
+    
+    ##
+    AddIsEqualForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        
+        return IsEqualForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) );
+        
+    end );
+    
+    ##
+    AddIsCongruentForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        
+        if WitnessForBeingCongruentToZero( SubtractionForMorphisms( morphism_1, morphism_2 ) ) = fail then
+            
+            return false;
+            
+        else
+            
+            return true;
+            
+        fi;
+        
+    end );
+
     AddIdentityMorphism( category,
       function( object )
 
@@ -271,6 +326,117 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
 
     end );
 
+    ##
+    AddPreCompose( category,
+      
+      function( morphism_1, morphism_2 )
+        local composition;
+        
+        composition := PreCompose( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) );
+        
+        composition := CokernelImageClosureMorphism( Source( morphism_1 ), composition, Range( morphism_2 ) );
+        
+        return composition;
+        
+    end );
+
+    ##
+    AddAdditionForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        local addition;
+        
+        addition := CokernelImageClosureMorphism(
+                      Source( morphism_1 ),
+                      AdditionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
+                      Range( morphism_1 )
+                    );
+        
+        return addition;
+        
+    end );
+
+    ##
+    AddSubtractionForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        local substraction;
+        
+        substraction := CokernelImageClosureMorphism(
+                      Source( morphism_1 ),
+                      SubtractionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
+                      Range( morphism_1 )
+                    );
+        
+        return substraction;
+        
+    end );
+    
+    ##
+    AddAdditiveInverseForMorphisms( category,
+      function( morphism )
+        local additive_inverse;
+        
+        additive_inverse := CokernelImageClosureMorphism(
+                              Source( morphism ),
+                              AdditiveInverseForMorphisms( MorphismDatum( morphism ) ),
+                              Range( morphism )
+                            );
+        
+        return additive_inverse;
+        
+    end );
+    
+    ##
+    AddZeroMorphism( category,
+      function( source, range )
+        local zero_morphism;
+        
+        zero_morphism := CokernelImageClosureMorphism(
+                           source,
+                           ZeroMorphism( Source( GeneratorMorphism( source ) ), Source( GeneratorMorphism( range ) ) ),
+                           range
+                         );
+        
+        return zero_morphism;
+        
+    end );
+    
+    ##
+    AddZeroObject( category,
+      function( )
+        
+        return AsCokernelImageClosureObject( ZeroObject( underlying_category ) );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( category,
+      function( sink, zero_object )
+        local universal_morphism;
+        
+        universal_morphism := CokernelImageClosureMorphism(
+                                sink,
+                                UniversalMorphismIntoZeroObject( Source( GeneratorMorphism( sink ) ) ),
+                                zero_object
+                              );
+        
+        return universal_morphism;
+        
+    end );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( category,
+      function( source, zero_object )
+        local universal_morphism;
+        
+        universal_morphism := CokernelImageClosureMorphism(
+                                zero_object,
+                                UniversalMorphismFromZeroObject( Source( GeneratorMorphism( source ) ) ),
+                                source
+                              );
+        
+        return universal_morphism;
+        
+    end );
 end );
 
 ####################################

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -437,6 +437,82 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
         return universal_morphism;
         
     end );
+
+    ##
+    AddDirectSum( category,
+      function( object_list )
+        
+        return CokernelImageClosureObject( 
+                DirectSumFunctorial( List( object_list, GeneratorMorphism ) ),
+                DirectSumFunctorial( List( object_list, RelationMorphism ) )
+        );
+        
+    end );
+    
+    ##
+    AddDirectSumFunctorialWithGivenDirectSums( category,
+      function( direct_sum_source, diagram, direct_sum_range )
+        
+        return CokernelImageClosureMorphism(
+                    direct_sum_source,
+                    DirectSumFunctorial( List( diagram, MorphismDatum ) ),
+                    direct_sum_range 
+        );
+        
+    end );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
+      function( object_list, projection_number, direct_sum_object )
+        
+        return CokernelImageClosureMorphism( 
+                direct_sum_object,
+                ProjectionInFactorOfDirectSum( List( object_list, obj -> Source( GeneratorMorphism( obj ) ) ), projection_number ),
+                object_list[projection_number]
+        );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
+      function( diagram, source, direct_sum_object )
+        
+        return CokernelImageClosureMorphism(
+                Source( source[1] ),
+                UniversalMorphismIntoDirectSum(
+                    List( diagram, obj -> Source( GeneratorMorphism( obj ) ) ),
+                    List( source, mor -> MorphismDatum( mor ) ) 
+                ),
+                direct_sum_object
+        );
+        
+    end );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
+      function( object_list, injection_number, direct_sum_object )
+        
+        return CokernelImageClosureMorphism(
+                object_list[injection_number],
+                InjectionOfCofactorOfDirectSum( List( object_list, obj -> Source( GeneratorMorphism( obj ) ) ), injection_number ),
+                direct_sum_object
+        );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
+      function( diagram, sink, direct_sum_object )
+        
+        return CokernelImageClosureMorphism(
+                direct_sum_object,
+                UniversalMorphismFromDirectSum( List( diagram, obj -> Source( GeneratorMorphism( obj ) ) ),
+                List( sink, mor -> MorphismDatum( mor ) ) ),
+                Range( sink[1] )
+        );
+        
+    end );
+
 end );
 
 ####################################

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -558,6 +558,69 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
             );
         
     end );
+    
+    ##
+    AddImageObject( category,
+      
+      function( morphism )
+        local range;
+
+        range := Range( morphism );
+
+        return 
+            CokernelImageClosureObject( 
+                PreCompose( MorphismDatum( morphism ), GeneratorMorphism( range ) ),
+                RelationMorphism( range )
+            );
+    end );
+
+    ##
+    AddImageEmbeddingWithGivenImageObject( category,
+      
+      function( morphism, image )
+        
+        return
+            CokernelImageClosureMorphism(
+                image,
+                MorphismDatum( morphism ),
+                Range( morphism )
+            );
+    end );
+
+    ##
+    AddCoastrictionToImageWithGivenImageObject( category,
+      
+      function( morphism, image )
+        local source;
+
+        source := Source( morphism );
+
+        return
+            CokernelImageClosureMorphism(
+                source,
+                IdentityMorphism( Source( GeneratorMorphism( source ) ) ),
+                image
+            );
+        
+    end );
+
+    ##
+    AddUniversalMorphismFromImageWithGivenImageObject( category,
+      
+      function( morphism, test_factorization, image )
+        local tau;
+
+        tau := test_factorization[1];
+
+        return
+            CokernelImageClosureMorphism(
+                image,
+                MorphismDatum( tau ),
+                Range( tau )
+            );
+        
+    end );
+
 
 end );
 

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -621,6 +621,115 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
         
     end );
 
+    if ForAll( [ "ProjectionOfBiasedWeakFiberProduct", "UniversalMorphismIntoBiasedWeakFiberProduct" ], f -> CanCompute( underlying_category, f ) ) then
+
+        ##
+        AddKernelEmbedding( category,
+          
+          function( morphism )
+            local range, projection, source, kernel;
+
+            range := Range( morphism );
+
+            projection := 
+                ProjectionOfBiasedWeakFiberProduct(
+                    PreCompose( MorphismDatum( morphism ), GeneratorMorphism( range ) ),
+                    RelationMorphism( range )
+                );
+            
+            source := Source( morphism );
+
+            kernel := CokernelImageClosureObject(
+                PreCompose( projection, GeneratorMorphism( source ) ),
+                RelationMorphism( source )
+            );
+
+            return
+                CokernelImageClosureMorphism(
+                    kernel,
+                    projection,
+                    source
+                );
+        end );
+
+        ##
+        AddKernelLiftWithGivenKernelObject( category,
+          
+          function( morphism, test_morphism, kernel )
+            local range, u;
+
+            range := Range( morphism );
+
+            u := UniversalMorphismIntoBiasedWeakFiberProduct(
+                PreCompose( MorphismDatum( morphism ), GeneratorMorphism( range ) ),
+                RelationMorphism( range ),
+                MorphismDatum( test_morphism )
+            );
+            
+            return
+                CokernelImageClosureMorphism(
+                    Source( test_morphism ),
+                    u,
+                    kernel
+                );
+        end );
+
+        ##
+        AddEpimorphismFromSomeProjectiveObject( category,
+          
+          function( object ) 
+            local proj_object;
+
+            proj_object := Source( GeneratorMorphism( object ) );
+
+            return
+                CokernelImageClosureMorphism(
+                    AsCokernelImageClosureObject( proj_object ),
+                    IdentityMorphism( proj_object ),
+                    object
+                );
+        end );
+
+        ##
+        AddLiftAlongMonomorphism( category,
+          
+          function( alpha, tau )
+            local A,B, gamma_B, rho_B, lift, Au, RBu;
+
+            A := Source( alpha );
+
+            B := Range( alpha );
+
+            gamma_B := GeneratorMorphism( B );
+
+            rho_B := RelationMorphism( B );
+
+            lift := Lift(
+                PreCompose( MorphismDatum( tau ), gamma_B ),
+                UniversalMorphismFromDirectSum(
+                    [ PreCompose( MorphismDatum( alpha ), gamma_B ), rho_B ]
+                )
+            );
+
+            Au := Source( GeneratorMorphism( A ) );
+
+            RBu := Source( RelationMorphism( B ) );
+
+            lift := ComponentOfMorphismIntoDirectSum( lift, [ Au, RBu ], 1 );
+
+            return
+                CokernelImageClosureMorphism(
+                    Source( tau ),
+                    lift,
+                    A
+                );
+            
+        end );
+    
+    fi;
+
+    
+
 
 end );
 

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -513,6 +513,52 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE,
         
     end );
 
+    ##
+    AddCokernelProjection( category,
+                     
+      function( morphism )
+        local range, relation_morphism, generator_morphism, cokernel_object, cokernel_projection;
+        
+        range := Range( morphism );
+        
+        relation_morphism := RelationMorphism( range );
+
+        generator_morphism := GeneratorMorphism( range );
+        
+        cokernel_object := 
+            CokernelImageClosureObject(
+                GeneratorMorphism( range ),
+                UniversalMorphismFromDirectSum( [ 
+                    relation_morphism,
+                    PreCompose( MorphismDatum( morphism ), generator_morphism ) 
+                ] ) 
+            );
+        
+        cokernel_projection := 
+            CokernelImageClosureMorphism(
+                range,
+                IdentityMorphism( Source( generator_morphism ) ),
+                cokernel_object 
+            );
+        
+        return cokernel_projection;
+        
+    end );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( category,
+      
+      function( morphism, test_morphism, cokernel_object )
+        
+        return 
+            CokernelImageClosureMorphism( 
+                cokernel_object,
+                MorphismDatum( test_morphism ),
+                Range( test_morphism ) 
+            );
+        
+    end );
+
 end );
 
 ####################################

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -491,3 +491,28 @@ AddFinalDerivation( UniversalMorphismFromWeakBiPushout,
     
 end : Description := "UniversalMorphismFromWeakBiPushout using WeakCokernelColift" );
 
+
+## Final derivation for biased weak fiber products and biased weak pushouts.
+## Decision: we use a derivation from weak fiber products and weak pushouts
+
+##
+AddFinalDerivation( ProjectionOfBiasedWeakFiberProduct,
+                    [ [ ProjectionInFirstFactorOfWeakBiFiberProduct, 1 ] ],
+                    [ BiasedWeakFiberProduct ],
+                    
+  function( alpha, beta )
+    
+    return ProjectionInFirstFactorOfWeakBiFiberProduct( alpha, beta );
+
+end : Description := "ProjectionOfBiasedWeakFiberProduct using ProjectionInFirstFactorOfWeakBiFiberProduct" );
+
+##
+AddFinalDerivation( InjectionOfBiasedWeakPushout,
+                    [ [ InjectionOfFirstCofactorOfWeakBiPushout, 1 ] ],
+                    [ BiasedWeakPushout ],
+                    
+  function( alpha, beta )
+    
+    return InjectionOfFirstCofactorOfWeakBiPushout( alpha, beta );
+
+end : Description := "ProjectioInjectionOfBiasedWeakPushoutnOfBiasedWeakFiberProduct using InjectionOfFirstCofactorOfWeakBiPushout" );

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -72,6 +72,17 @@ AddWithGivenDerivationPairToCAP( UniversalMorphismIntoWeakBiFiberProduct,
 end : Description := "UniversalMorphismIntoWeakBiFiberProduct using Lift" );
 
 ##
+AddWithGivenDerivationPairToCAP( UniversalMorphismIntoBiasedWeakFiberProduct,
+                                 
+  function( alpha, beta, test_mor )
+    
+    return Lift( test_mor,
+                 ProjectionOfBiasedWeakFiberProduct( alpha, beta ) );
+    
+end : Description := "UniversalMorphismIntoBiasedWeakFiberProduct using Lift" );
+
+
+##
 AddWithGivenDerivationPairToCAP( UniversalMorphismFromWeakBiPushout,
                                  
   function( alpha, beta, test_mor_1, test_mor_2 )
@@ -85,6 +96,16 @@ AddWithGivenDerivationPairToCAP( UniversalMorphismFromWeakBiPushout,
                    UniversalMorphismFromDirectSum( [ test_mor_1, test_mor_2 ] ) );
     
 end : Description := "UniversalMorphismFromWeakBiPushout using Colift" );
+
+##
+AddWithGivenDerivationPairToCAP( UniversalMorphismFromBiasedWeakPushout,
+                                 
+  function( alpha, beta, test_mor )
+    
+    return Colift( InjectionOfBiasedWeakPushout( alpha, beta ),
+                   test_mor );
+    
+end : Description := "UniversalMorphismFromBiasedWeakPushout using Colift" );
 
 ##
 AddWithGivenDerivationPairToCAP( WeakKernelLift,

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -143,6 +143,16 @@ AddDerivationToCAP( WeakBiFiberProduct,
 end : Description := "WeakBiFiberProduct as the source of ProjectionInSecondFactorOfWeakBiFiberProduct" );
 
 ##
+AddDerivationToCAP( BiasedWeakFiberProduct,
+                    
+  function( alpha, beta )
+    
+    return Source( ProjectionOfBiasedWeakFiberProduct( alpha, beta ) );
+    
+end : Description := "BiasedWeakFiberProduct as the source of ProjectionOfBiasedWeakFiberProduct" );
+
+
+##
 AddDerivationToCAP( WeakBiPushout,
                     
   function( alpha, beta )
@@ -159,6 +169,16 @@ AddDerivationToCAP( WeakBiPushout,
     return Range( InjectionOfSecondCofactorOfWeakBiPushout( alpha, beta ) );
     
 end : Description := "WeakBiPushout as the range of InjectionOfSecondCofactorOfWeakBiPushout" );
+
+##
+AddDerivationToCAP( BiasedWeakPushout,
+                    
+  function( alpha, beta )
+    
+    return Range( InjectionOfBiasedWeakPushout( alpha, beta ) );
+    
+end : Description := "BiasedWeakPushout as the range of InjectionOfBiasedWeakPushout" );
+
 
 ## abelian derivations
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -21,6 +21,10 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_WEAK_BI_PUSHOUT_PREFUNCTION" );
 
 DeclareGlobalFunction( "INSTALL_HOMOMORPHISM_STRUCTURE_FOR_OPPOSITE_CATEGORY" );
 
+DeclareGlobalFunction( "UNIVERSAL_MORPHISM_INTO_BIASED_WEAK_FIBER_PRODUCT_PREFUNCTION" );
+
+DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION" );
+
 ##TODO: Adjust documentation
 
 ####################################
@@ -536,6 +540,129 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 
 ####################################
 ##
+#! @Section Biased weak fiber product
+##
+####################################
+
+
+## Main Operations and Attributes
+
+
+DeclareOperation( "BiasedWeakFiberProduct",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "ProjectionOfBiasedWeakFiberProduct",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "ProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+DeclareOperation( "UniversalMorphismIntoBiasedWeakFiberProduct",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "UniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+## Add Operations
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>FiberProduct</C>.
+#! $F: ( (\beta_i: P_i \rightarrow B)_{i = 1 \dots n} ) \mapsto P$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>ProjectionInFactorOfFiberProduct</C>.
+#! $F: ( (\beta_i: P_i \rightarrow B)_{i = 1 \dots n}, k ) \mapsto \pi_k$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>ProjectionInFactorOfFiberProductWithGivenFiberProduct</C>.
+#! $F: ( (\beta_i: P_i \rightarrow B)_{i = 1 \dots n}, k,P ) \mapsto \pi_k$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>UniversalMorphismIntoFiberProduct</C>.
+#! $F: ( (\beta_i: P_i \rightarrow B)_{i = 1 \dots n}, \tau  ) \mapsto u(\tau)$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>UniversalMorphismIntoFiberProductWithGivenFiberProduct</C>.
+#! $F: ( (\beta_i: P_i \rightarrow B)_{i = 1 \dots n}, \tau, P  ) \mapsto u(\tau)$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+                  [ IsCapCategory, IsList ] );
+
+####################################
+##
 #! @Section Weak bi-pushout
 ##
 ####################################
@@ -699,6 +826,126 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 
 DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
                   [ IsCapCategory, IsList ] );
+
+####################################
+##
+#! @Section Biased weak pushout
+##
+####################################
+
+
+DeclareOperation( "BiasedWeakPushout",
+                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "InjectionOfBiasedWeakPushout",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "InjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+DeclareOperation( "UniversalMorphismFromBiasedWeakPushout",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "UniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+## Add Operations
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>Pushout</C>.
+#! $F: ( (\beta_i: B \rightarrow I_i)_{i = 1 \dots n} ) \mapsto I$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddBiasedWeakPushout",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddBiasedWeakPushout",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>InjectionOfCofactorOfPushout</C>.
+#! $F: ( (\beta_i: B \rightarrow I_i)_{i = 1 \dots n}, k ) \mapsto \iota_k$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInjectionOfBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushout",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushout",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>InjectionOfCofactorOfPushoutWithGivenPushout</C>.
+#! $F: ( (\beta_i: B \rightarrow I_i)_{i = 1 \dots n}, k, I ) \mapsto \iota_k$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>UniversalMorphismFromPushout</C>.
+#! $F: ( (\beta_i: B \rightarrow I_i)_{i = 1 \dots n}, \tau ) \mapsto u(\tau)$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushout",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushout",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>UniversalMorphismFromPushout</C>.
+#! $F: ( (\beta_i: B \rightarrow I_i)_{i = 1 \dots n}, \tau, I ) \mapsto u(\tau)$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddUniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+                  [ IsCapCategory, IsList ] );
+
 
 ####################################
 ##

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gi
@@ -53,6 +53,33 @@ InstallGlobalFunction( UNIVERSAL_MORPHISM_INTO_WEAK_BI_FIBER_PRODUCT_PREFUNCTION
 );
 
 ##
+InstallGlobalFunction( UNIVERSAL_MORPHISM_INTO_BIASED_WEAK_FIBER_PRODUCT_PREFUNCTION,
+  function( morphism_1, morphism_2, test_morphism, arg... )
+    local current_value;
+    
+    current_value := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
+    
+    if current_value = fail then
+        return [ false, "cannot decide whether the first two morphisms have equal ranges" ];
+    elif current_value = false then
+        return [ false, "the first two morphisms must have equal ranges" ];
+    fi;
+    
+    current_value := IsEqualForObjects( Source( morphism_1 ), Range( test_morphism ) );
+    
+    if current_value = fail then
+        return [ false, "cannot decide whether the range of the test morphism is equal to the source of the first morphism " ];
+    elif current_value = false then
+        return [ false, "the range of the test morphism must equal the source of the first morphism" ];
+    fi;
+    
+    return [ true ];
+    
+  end
+);
+
+
+##
 InstallGlobalFunction( WEAK_BI_PUSHOUT_PREFUNCTION,
   function( morphism_1, morphism_2, arg... )
     local current_value;
@@ -96,6 +123,31 @@ InstallGlobalFunction( UNIVERSAL_MORPHISM_FROM_WEAK_BI_PUSHOUT_PREFUNCTION,
   end
 );
 
+##
+InstallGlobalFunction( UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION,
+  function( morphism_1, morphism_2, test_morphism, arg... )
+    local current_value;
+    
+    current_value := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
+    
+    if current_value = fail then
+        return [ false, "cannot decide whether the first two morphisms have equal sources" ];
+    elif current_value = false then
+        return [ false, "the first two morphisms must have equal sources" ];
+    fi;
+    
+    current_value := IsEqualForObjects( Range( morphism_1 ), Source( test_morphism ) );
+    
+    if current_value = fail then
+        return [ false, "cannot decide whether the range of the first morphism equals the source of the test morphism" ];
+    elif current_value = false then
+        return [ false, "the range of the first morphism must equal the source of the test morphism" ];
+    fi;
+    
+    return [ true ];
+    
+  end
+);
 
 InstallValue( FREYD_CATEGORIES_METHOD_NAME_RECORD, rec(
 
@@ -399,6 +451,135 @@ DirectSumMorphismToWeakBiPushout := rec(
   return_type := "morphism",
   dual_operation := "WeakBiFiberProductMorphismToDirectSum",
   no_with_given := true ),
+
+## biased weak fiber product
+## FIXME: create universal_type substitute
+
+BiasedWeakFiberProduct := rec(
+  installation_name := "BiasedWeakFiberProduct",
+  filter_list := [ "morphism", "morphism" ],
+  cache_name := "BiasedWeakFiberProduct",
+  universal_type := "Limit",
+  dual_operation := "BiasedWeakPushout",
+  pre_function := WEAK_BI_FIBER_PRODUCT_PREFUNCTION,
+  return_type := "object",
+  is_merely_set_theoretic := true ),
+
+ProjectionOfBiasedWeakFiberProduct := rec(
+  installation_name := "ProjectionOfBiasedWeakFiberProduct",
+  filter_list := [ "morphism", "morphism" ],
+  io_type := [ [ "a", "b" ], [ "P", "a_source" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "ProjectionOfBiasedWeakFiberProduct",
+  universal_object_position := "Source",
+  universal_type := "Limit",
+  dual_operation := "InjectionOfBiasedWeakPushout",
+  pre_function := WEAK_BI_FIBER_PRODUCT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+ProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct := rec(
+  installation_name := "ProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  filter_list := [ "morphism", "morphism", "object" ],
+  io_type := [ [ "a", "b", "P" ], [ "P", "a_source" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "ProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  universal_object_position := "Source",
+  universal_type := "Limit",
+  dual_operation := "InjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  pre_function := WEAK_BI_FIBER_PRODUCT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+UniversalMorphismIntoBiasedWeakFiberProduct := rec(
+  installation_name := "UniversalMorphismIntoBiasedWeakFiberProduct",
+  filter_list := [ "morphism", "morphism", "morphism" ],
+  io_type := [ [ "a", "b", "t" ], [ "t_source", "P" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "UniversalMorphismIntoBiasedWeakFiberProduct",
+  universal_object_position := "Range",
+  universal_type := "Limit",
+  dual_operation := "UniversalMorphismFromBiasedWeakPushout",
+  pre_function := UNIVERSAL_MORPHISM_INTO_BIASED_WEAK_FIBER_PRODUCT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+UniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct := rec(
+  installation_name := "UniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  filter_list := [ "morphism", "morphism", "morphism", "object" ],
+  io_type := [ [ "a", "b", "t", "P", ], [ "t_source", "P" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "UniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  universal_type := "Limit",
+  dual_operation := "UniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  pre_function := UNIVERSAL_MORPHISM_INTO_BIASED_WEAK_FIBER_PRODUCT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+## biased weak pushout
+
+## Weak pushouts
+
+BiasedWeakPushout := rec(
+  installation_name := "BiasedWeakPushout",
+  filter_list := [ "morphism", "morphism" ],
+  cache_name := "BiasedWeakPushout",
+  universal_type := "Colimit",
+  dual_operation := "BiasedWeakFiberProduct",
+  pre_function := WEAK_BI_PUSHOUT_PREFUNCTION,
+  return_type := "object",
+  is_merely_set_theoretic := true ),
+
+InjectionOfBiasedWeakPushout := rec(
+  installation_name := "InjectionOfBiasedWeakPushout",
+  filter_list := [ "morphism", "morphism" ],
+  io_type := [ [ "a", "b" ], [ "a_range", "P" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "InjectionOfBiasedWeakPushout",
+  universal_object_position := "Range",
+  universal_type := "Colimit",
+  dual_operation := "ProjectionOfBiasedWeakFiberProduct",
+  pre_function := WEAK_BI_PUSHOUT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+InjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout := rec(
+  installation_name := "InjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  filter_list := [ "morphism", "morphism", "object" ],
+  io_type := [ [ "a", "b", "P" ], [ "a_range", "P" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "InjectionOfBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  universal_object_position := "Range",
+  universal_type := "Colimit",
+  dual_operation := "ProjectionOfBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  pre_function := WEAK_BI_PUSHOUT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+UniversalMorphismFromBiasedWeakPushout := rec(
+  installation_name := "UniversalMorphismFromBiasedWeakPushout",
+  filter_list := [ "morphism", "morphism", "morphism" ],
+  io_type := [ [ "a", "b", "t", "s" ], [ "P", "t_range" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "UniversalMorphismFromBiasedWeakPushout",
+  universal_object_position := "Source",
+  universal_type := "Colimit",
+  dual_operation := "UniversalMorphismIntoBiasedWeakFiberProduct",
+  pre_function := UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
+
+UniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout := rec(
+  installation_name := "UniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  filter_list := [ "morphism", "morphism", "morphism", "object" ],
+  io_type := [ [ "a", "b", "t", "P", ], [ "P", "t_range" ] ],
+  number_of_diagram_arguments := 2,
+  cache_name := "UniversalMorphismFromBiasedWeakPushoutWithGivenBiasedWeakPushout",
+  universal_type := "Colimit",
+  dual_operation := "UniversalMorphismIntoBiasedWeakFiberProductWithGivenBiasedWeakFiberProduct",
+  pre_function := UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION,
+  return_type := "morphism",
+  is_merely_set_theoretic := true ),
 
 ## an abelian construction
 SomeProjectiveObjectForKernelObject := rec(

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -545,7 +545,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
         
     end );
     
-    if ForAll( [ "WeakKernelEmbedding", "WeakKernelLift" ], f -> CanCompute( underlying_category, f ) ) then
+    if ForAll( [ "ProjectionOfBiasedWeakFiberProduct", "UniversalMorphismIntoBiasedWeakFiberProduct" ], f -> CanCompute( underlying_category, f ) ) then
         
         ## Kernels: kernels in Freyd categories are based on weak fiber products in the underlying category and thus more expensive
         AddKernelEmbedding( category,
@@ -560,9 +560,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
             rho_A := RelationMorphism( Source( morphism ) );
             
             ## We use the bias in the first projection of weak fiber products
-            projection_1 := ProjectionInFirstFactorOfWeakBiFiberProduct( alpha, rho_B );
+            projection_1 := ProjectionOfBiasedWeakFiberProduct( alpha, rho_B );
             
-            projection_2 := ProjectionInFirstFactorOfWeakBiFiberProduct( projection_1, rho_A );
+            projection_2 := ProjectionOfBiasedWeakFiberProduct( projection_1, rho_A );
             
             kernel_object := FreydCategoryObject( projection_2 );
             
@@ -578,9 +578,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
           function( morphism, test_morphism, kernel_object )
             local sigma, alpha, rho_B, tau, morphism_datum;
             
-            ## witness computation
-            sigma := WitnessForBeingCongruentToZero( PreCompose( test_morphism, morphism ) );
-            
             ## for notational convenience
             alpha := MorphismDatum( morphism );
             
@@ -588,7 +585,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
             
             tau := MorphismDatum( test_morphism );
             
-            morphism_datum := UniversalMorphismIntoWeakBiFiberProduct( alpha, rho_B, tau, sigma );
+            morphism_datum := UniversalMorphismIntoBiasedWeakFiberProduct( alpha, rho_B, tau );
             
             return FreydCategoryMorphism( Source( test_morphism ),
                                           morphism_datum,
@@ -649,7 +646,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
         rho_B := RelationMorphism( Range( morphism ) );
         
         ## We use the bias in the first projection of weak fiber products
-        projection_1 := ProjectionInFirstFactorOfWeakBiFiberProduct( alpha, rho_B );
+        projection_1 := ProjectionOfBiasedWeakFiberProduct( alpha, rho_B );
         
         projective_object := AsFreydCategoryObject( Source( projection_1 ) );
         
@@ -825,8 +822,8 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
                      "SubtractionForMorphisms",
                      "PreCompose",
                      "Lift",
-                     "WeakKernelEmbedding",
-                     "WeakKernelLift"
+                     "ProjectionOfBiasedWeakFiberProduct",
+                     "UniversalMorphismIntoBiasedWeakFiberProduct"
                       ],
                    f -> CanCompute( underlying_category, f ) )  then
            

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -6,28 +6,6 @@
 ##
 #############################################################################
 
-DeclareRepresentation( "IsFreydCategoryObjectRep",
-                       IsFreydCategoryObject and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfFreydCategoryObjects",
-        NewFamily( "TheFamilyOfFreydCategoryObjects" ) );
-
-BindGlobal( "TheTypeOfFreydCategoryObjects",
-        NewType( TheFamilyOfFreydCategoryObjects,
-                IsFreydCategoryObjectRep ) );
-
-DeclareRepresentation( "IsFreydCategoryMorphismRep",
-                       IsFreydCategoryMorphism and IsAttributeStoringRep,
-                       [ ] );
-
-BindGlobal( "TheFamilyOfFreydCategoryMorphisms",
-        NewFamily( "TheFamilyOfFreydCategoryMorphisms" ) );
-
-BindGlobal( "TheTypeOfFreydCategoryMorphisms",
-        NewType( TheFamilyOfFreydCategoryMorphisms,
-                IsFreydCategoryMorphismRep ) );
-
 ####################################
 ##
 ## Constructors
@@ -81,6 +59,12 @@ InstallMethod( FreydCategory,
         
     fi;
     
+    DisableAddForCategoricalOperations( freyd_category );
+
+    AddObjectRepresentation( freyd_category, IsFreydCategoryObject );
+    
+    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism );
+    
     INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY( freyd_category );
     
     Finalize( freyd_category );
@@ -111,14 +95,16 @@ InstallMethod( FreydCategoryObject,
                [ IsCapCategoryMorphism ],
                
   function( relation_morphism )
-    local freyd_category_object;
+    local freyd_category_object, category;
     
     freyd_category_object := rec( );
     
-    ObjectifyWithAttributes( freyd_category_object, TheTypeOfFreydCategoryObjects,
-                             RelationMorphism, relation_morphism );
+    category := FreydCategory( CapCategory( relation_morphism ) );
+
+    ObjectifyObjectForCAPWithAttributes( freyd_category_object, category,
+                                         RelationMorphism, relation_morphism );
     
-    Add( FreydCategory( CapCategory( relation_morphism ) ), freyd_category_object );
+    Add( category, freyd_category_object );
     
     return freyd_category_object;
     
@@ -143,7 +129,7 @@ InstallMethod( FreydCategoryMorphism,
                [ IsFreydCategoryObject, IsCapCategoryMorphism, IsFreydCategoryObject ],
                
   function( source, morphism_datum, range )
-    local freyd_category_morphism;
+    local freyd_category_morphism, category;
     
     if not IsIdenticalObj( CapCategory( morphism_datum ), UnderlyingCategory( CapCategory( source ) ) ) then
         
@@ -165,13 +151,16 @@ InstallMethod( FreydCategoryMorphism,
     
     freyd_category_morphism := rec( );
     
-    ObjectifyWithAttributes( freyd_category_morphism, TheTypeOfFreydCategoryMorphisms,
+    category :=  CapCategory( source );
+
+    ObjectifyMorphismForCAPWithAttributes( 
+                             freyd_category_morphism, category,
                              Source, source,
                              Range, range,
                              MorphismDatum, morphism_datum
     );
 
-    Add( CapCategory( source ), freyd_category_morphism );
+    Add( category, freyd_category_morphism );
     
     return freyd_category_morphism;
     

--- a/FreydCategoriesForCAP/init.g
+++ b/FreydCategoriesForCAP/init.g
@@ -13,3 +13,5 @@ ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategory.gd" );
 ReadPackage( "FreydCategoriesForCAP", "gap/HomStructureForAlgebroids.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gd" );
+
+ReadPackage( "FreydCategoriesForCAP", "gap/CokernelImageClosure.gd" );

--- a/FreydCategoriesForCAP/read.g
+++ b/FreydCategoriesForCAP/read.g
@@ -14,3 +14,5 @@ ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategory.gi" );
 ReadPackage( "FreydCategoriesForCAP", "gap/HomStructureForAlgebroids.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gi" );
+
+ReadPackage( "FreydCategoriesForCAP", "gap/CokernelImageClosure.gi" );


### PR DESCRIPTION
As part of the package for Freyd categories,
I implemented a category under the working name
"CokernelImageClosure" that can be seen as an enhancement
of Freyd categories by images.