### PR TITLE
Derivations for lifts

### DIFF
--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1097,7 +1097,7 @@ AddDerivationToCAP( ColiftAlongEpimorphism,
                       [ Inverse, 1 ] ],
                     
   function( epimorphism, test_morphism )
-    local kernel_emb, cokernel_colift_to_range_of_epimorphism, cokernel_colift_to_range_of_test_morphism, inverse;
+    local kernel_emb, cokernel_colift_to_range_of_epimorphism, cokernel_colift_to_range_of_test_morphism;
     
     kernel_emb := KernelEmbedding( epimorphism );
     
@@ -1111,6 +1111,30 @@ AddDerivationToCAP( ColiftAlongEpimorphism,
     
 end : CategoryFilter := IsAbelianCategory, 
       Description := "ColiftAlongEpimorphism by inverting the cokernel colift from the cokernel of the kernel to the range of a given epimorphism");
+
+##
+AddDerivationToCAP( LiftAlongMonomorphism,
+                    [ [ CokernelProjection, 1 ],
+                      [ KernelLift, 2 ],
+                      [ PreCompose, 1 ],
+                      [ Inverse, 1 ] ],
+                    
+  function( monomorphism, test_morphism )
+    local cokernel_proj, kernel_lift_from_source_of_monomorphism, kernel_lift_from_source_of_test_morphism;
+    
+    cokernel_proj := CokernelProjection( monomorphism );
+    
+    kernel_lift_from_source_of_monomorphism :=
+      KernelLift( cokernel_proj, monomorphism );
+      
+    kernel_lift_from_source_of_test_morphism :=
+      KernelLift( cokernel_proj, test_morphism );
+    
+    return PreCompose( kernel_lift_from_source_of_test_morphism, Inverse( kernel_lift_from_source_of_monomorphism ) );
+    
+end : CategoryFilter := IsAbelianCategory, 
+      Description := "LiftAlongMonomorphism by inverting the kernel lift from the source to the kernel of the cokernel of a given monomorphism");
+
 
 ##
 AddDerivationToCAP( ComponentOfMorphismIntoDirectSum,

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1089,6 +1089,7 @@ AddDerivationToCAP( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
     
 end : Description := "IsomorphismFromPushoutToCokernelOfDiagonalDifference as the inverse of IsomorphismFromCokernelOfDiagonalDifferenceToPushout" );
 
+##
 AddDerivationToCAP( ColiftAlongEpimorphism,
                     [ [ KernelEmbedding, 1 ],
                       [ CokernelColift, 2 ],
@@ -1108,7 +1109,8 @@ AddDerivationToCAP( ColiftAlongEpimorphism,
     
     return PreCompose( Inverse( cokernel_colift_to_range_of_epimorphism ), cokernel_colift_to_range_of_test_morphism );
     
-end );
+end : CategoryFilter := IsAbelianCategory, 
+      Description := "ColiftAlongEpimorphism by inverting the cokernel colift from the cokernel of the kernel to the range of a given epimorphism");
 
 ##
 AddDerivationToCAP( ComponentOfMorphismIntoDirectSum,


### PR DESCRIPTION
I added a missing derivation for LiftAlongMonomorphism to CAP.
Moreover, the analogous ColiftAlongEpimorphism derivation
depends on the category being abelian.