### PR TITLE
Canonical subobjects and quotient objects for generalized morphisms

### DIFF
--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -51,7 +51,7 @@ DeclareAttribute( "UnderlyingHonestObject",
 #! The output is its domain $d \hookrightarrow a \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( d, a )$
 #! @Arguments alpha
-DeclareAttribute( "DomainOfGeneralizedMorphism",
+DeclareAttribute( "DomainEmbedding",
                   IsGeneralizedMorphism );
 
 #! @Description

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -65,7 +65,7 @@ DeclareAttribute( "GeneralizedImageEmbedding",
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its defect $d \hookrightarrow b \in \mathbf{A}$.
-#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( d, b )$
 #! @Arguments alpha
 DeclareAttribute( "DefectEmbedding",
                   IsGeneralizedMorphism );
@@ -73,7 +73,7 @@ DeclareAttribute( "DefectEmbedding",
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its generalized kernel $k \hookrightarrow a \in \mathbf{A}$.
-#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( k, a )$
 #! @Arguments alpha
 DeclareAttribute( "GeneralizedKernelEmbedding",
                   IsGeneralizedMorphism );
@@ -86,6 +86,30 @@ DeclareAttribute( "GeneralizedKernelEmbedding",
 DeclareAttribute( "CodomainProjection",
                   IsGeneralizedMorphism );
 
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized cokernel $b \twoheadrightarrow c \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( b, c )$
+#! @Arguments alpha
+DeclareAttribute( "GeneralizedCokernelProjection",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its codefect $a \twoheadrightarrow c \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( a, c )$
+#! @Arguments alpha
+DeclareAttribute( "CodefectProjection",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized coimage $a \twoheadrightarrow c \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( a, c )$
+#! @Arguments alpha
+DeclareAttribute( "GeneralizedCoimageProjection",
+                  IsGeneralizedMorphism );
+                  
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its associated morphism $d \rightarrow c \in \mathbf{A}$.

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -56,6 +56,30 @@ DeclareAttribute( "DomainEmbedding",
 
 #! @Description
 #! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized image $i \hookrightarrow b \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
+DeclareAttribute( "GeneralizedImageEmbedding",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its defect $d \hookrightarrow b \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
+DeclareAttribute( "DefectEmbedding",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized kernel $k \hookrightarrow a \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
+DeclareAttribute( "GeneralizedKernelEmbedding",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
 #! The output is its codomain $b \twoheadrightarrow c \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( b, c )$
 #! @Arguments alpha
@@ -281,31 +305,6 @@ DeclareOperation( "GeneralizedMorphismWithRangeAid",
 #!  by span, depending on the standard.
 DeclareOperation( "GeneralizedMorphismWithSourceAid",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
-
-#! @Description
-#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
-#! The output is its generalized image $i \hookrightarrow b \in \mathbf{A}$.
-#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
-#! @Arguments alpha
-DeclareAttribute( "GeneralizedImageEmbedding",
-                  IsGeneralizedMorphism );
-
-#! @Description
-#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
-#! The output is its defect $d \hookrightarrow b \in \mathbf{A}$.
-#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
-#! @Arguments alpha
-DeclareAttribute( "DefectEmbedding",
-                  IsGeneralizedMorphism );
-
-#! @Description
-#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
-#! The output is its generalized kernel $k \hookrightarrow a \in \mathbf{A}$.
-#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
-#! @Arguments alpha
-DeclareAttribute( "GeneralizedKernelEmbedding",
-                  IsGeneralizedMorphism );
-
 
 ####################################
 ##

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -282,7 +282,7 @@ DeclareOperation( "GeneralizedMorphismWithRangeAid",
 DeclareOperation( "GeneralizedMorphismWithSourceAid",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
 
-DeclareAttribute( "CombinedImageEmbedding",
+DeclareAttribute( "GeneralizedImageEmbedding",
                   IsGeneralizedMorphism );
 
 ####################################

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -290,6 +290,23 @@ DeclareOperation( "GeneralizedMorphismWithSourceAid",
 DeclareAttribute( "GeneralizedImageEmbedding",
                   IsGeneralizedMorphism );
 
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its defect $d \hookrightarrow b \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
+DeclareAttribute( "DefectEmbedding",
+                  IsGeneralizedMorphism );
+
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized kernel $k \hookrightarrow a \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
+DeclareAttribute( "GeneralizedKernelEmbedding",
+                  IsGeneralizedMorphism );
+
+
 ####################################
 ##
 #! @Section Tools to propagate attributes

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -282,6 +282,11 @@ DeclareOperation( "GeneralizedMorphismWithRangeAid",
 DeclareOperation( "GeneralizedMorphismWithSourceAid",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
 
+#! @Description
+#! The argument is a generalized morphism $\alpha: a \rightarrow b$.
+#! The output is its generalized image $i \hookrightarrow b \in \mathbf{A}$.
+#! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( i, b )$
+#! @Arguments alpha
 DeclareAttribute( "GeneralizedImageEmbedding",
                   IsGeneralizedMorphism );
 

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gd
@@ -59,7 +59,7 @@ DeclareAttribute( "DomainEmbedding",
 #! The output is its codomain $b \twoheadrightarrow c \in \mathbf{A}$.
 #! @Returns a morphism in $\mathrm{Hom}_{\mathbf{A}}( b, c )$
 #! @Arguments alpha
-DeclareAttribute( "Codomain",
+DeclareAttribute( "CodomainProjection",
                   IsGeneralizedMorphism );
 
 #! @Description

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
@@ -16,7 +16,7 @@ Domain := function( arg )
   
   if Length( arg ) = 1 and IsGeneralizedMorphism( arg[1] ) then
       
-      return DomainOfGeneralizedMorphism( arg[ 1 ] );
+      return DomainEmbedding( arg[ 1 ] );
       
   fi;
   
@@ -24,7 +24,7 @@ Domain := function( arg )
   
 end;
 
-InstallMethod( DomainOfGeneralizedMorphism,
+InstallMethod( DomainEmbedding,
                [ IsGeneralizedMorphism ],
                
   function( generalized_morphism )

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
@@ -139,6 +139,7 @@ InstallMethod( IsTotal,
                [ IsGeneralizedMorphism ],
                HasFullDomain );
 
+##
 InstallMethod( GeneralizedImageEmbedding,
                [ IsGeneralizedMorphism ],
                
@@ -148,6 +149,26 @@ InstallMethod( GeneralizedImageEmbedding,
     triple := DomainAssociatedMorphismCodomainTriple( generalized_morphism );
     
     return ProjectionInFactorOfFiberProduct( [ ImageEmbedding( triple[ 2 ] ), triple[ 3 ] ], 2 );
+    
+end );
+
+##
+InstallMethod( DefectEmbedding,
+               [ IsGeneralizedMorphism ],
+               
+  function( generalized_morphism )
+    
+    return KernelEmbedding( CodomainProjection( generalized_morphism ) );
+    
+end );
+
+##
+InstallMethod( GeneralizedKernelEmbedding,
+               [ IsGeneralizedMorphism ],
+               
+  function( generalized_morphism )
+    
+    return DefectEmbedding( PseudoInverse( generalized_morphism ) );
     
 end );
 

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
@@ -139,7 +139,7 @@ InstallMethod( IsTotal,
                [ IsGeneralizedMorphism ],
                HasFullDomain );
 
-InstallMethod( CombinedImageEmbedding,
+InstallMethod( GeneralizedImageEmbedding,
                [ IsGeneralizedMorphism ],
                
   function( generalized_morphism )

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
@@ -173,6 +173,36 @@ InstallMethod( GeneralizedKernelEmbedding,
 end );
 
 ##
+InstallMethod( GeneralizedCokernelProjection,
+               [ IsGeneralizedMorphism ],
+               
+  function( generalized_morphism )
+    
+    return CokernelProjection( GeneralizedImageEmbedding( generalized_morphism ) );
+    
+end );
+
+##
+InstallMethod( GeneralizedCoimageProjection,
+               [ IsGeneralizedMorphism ],
+               
+  function( generalized_morphism )
+    
+    return CokernelProjection( GeneralizedKernelEmbedding( generalized_morphism ) );
+    
+end );
+
+##
+InstallMethod( CodefectProjection,
+               [ IsGeneralizedMorphism ],
+               
+  function( generalized_morphism )
+    
+    return CokernelProjection( DomainEmbedding( generalized_morphism ) );
+    
+end );
+
+##
 InstallValue( PROPAGATION_LIST_FROM_GENERALIZED_TO_ASSOCIATED_MORPHISM,
         [
          "IsMonomorphism",

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategory.gi
@@ -56,7 +56,7 @@ InstallMethod( AssociatedMorphism,
     
 end );
 
-InstallMethod( Codomain,
+InstallMethod( CodomainProjection,
                [ IsGeneralizedMorphism ],
                
   function( generalized_morphism )

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
@@ -547,7 +547,7 @@ InstallMethodWithCacheFromObject( CommonRestrictionOp,
 end : ArgumentNumber := 2 );
 
 ##
-InstallMethod( CombinedImageEmbedding,
+InstallMethod( GeneralizedImageEmbedding,
                [ IsGeneralizedMorphismBySpan ],
                
   function( morphism )

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -40,9 +40,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_GENERALIZED_MORPHISM_BY_THREE_ARROW
       function( generalized_morphism1, generalized_morphism2 )
         local subobject1, subobject2, factorobject1, factorobject2, isomorphism_of_subobjects, isomorphism_of_factorobjects;
         
-        subobject1 := DomainOfGeneralizedMorphism( generalized_morphism1 );
+        subobject1 := DomainEmbedding( generalized_morphism1 );
         
-        subobject2 := DomainOfGeneralizedMorphism( generalized_morphism2 );
+        subobject2 := DomainEmbedding( generalized_morphism2 );
         
         if not IsEqualAsSubobjects( subobject1, subobject2 ) then
           
@@ -441,7 +441,7 @@ InstallMethod( HonestRepresentative,
   function( generalized_morphism )
     
     return PreCompose(
-             PreCompose( Inverse( DomainOfGeneralizedMorphism( generalized_morphism ) ), AssociatedMorphism( generalized_morphism ) ), 
+             PreCompose( Inverse( DomainEmbedding( generalized_morphism ) ), AssociatedMorphism( generalized_morphism ) ), 
              Inverse( Codomain( generalized_morphism ) ) 
            );
     
@@ -469,7 +469,7 @@ end );
 
 ###########################
 ##
-## DomainOfGeneralizedMorphism, Associated Morphism, Codomain
+## DomainEmbedding, Associated Morphism, Codomain
 ##
 ###########################
 
@@ -617,7 +617,7 @@ InstallMethodWithCacheFromObject( CommonRestrictionOp,
         
     fi;
     
-    source_aid_list := List( morphism_list, DomainOfGeneralizedMorphism );
+    source_aid_list := List( morphism_list, DomainEmbedding );
     
     associated_compose_list := [ ];
     

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -50,9 +50,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_GENERALIZED_MORPHISM_BY_THREE_ARROW
           
         fi;
         
-        factorobject1 := Codomain( generalized_morphism1 );
+        factorobject1 := CodomainProjection( generalized_morphism1 );
         
-        factorobject2 := Codomain( generalized_morphism2 );
+        factorobject2 := CodomainProjection( generalized_morphism2 );
         
         if not IsEqualAsFactorobjects( factorobject1, factorobject2 ) then
         
@@ -442,7 +442,7 @@ InstallMethod( HonestRepresentative,
     
     return PreCompose(
              PreCompose( Inverse( DomainEmbedding( generalized_morphism ) ), AssociatedMorphism( generalized_morphism ) ), 
-             Inverse( Codomain( generalized_morphism ) ) 
+             Inverse( CodomainProjection( generalized_morphism ) ) 
            );
     
 end );
@@ -453,7 +453,7 @@ InstallMethod( HasFullCodomain,
                
   function( generalized_morphism )
     
-    return IsIsomorphism( Codomain( generalized_morphism ) );
+    return IsIsomorphism( CodomainProjection( generalized_morphism ) );
     
 end );
 
@@ -469,7 +469,7 @@ end );
 
 ###########################
 ##
-## DomainEmbedding, Associated Morphism, Codomain
+## DomainEmbedding, Associated Morphism, CodomainProjection
 ##
 ###########################
 
@@ -703,7 +703,7 @@ InstallMethodWithCacheFromObject( CommonCoastrictionOp,
         
     fi;
     
-    codomain_list := List( morphism_list, Codomain );
+    codomain_list := List( morphism_list, CodomainProjection );
     
     associated_compose_list := [ ];
     

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -296,7 +296,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPERATIONS_FOR_SERRE_QUOTIENT_BY_THREE_ARROWS"
         
         cokernel_mor := CokernelProjection( AssociatedMorphism( underlying_general ) );
         
-        cokernel_mor := PreCompose( Codomain( underlying_general ), cokernel_mor );
+        cokernel_mor := PreCompose( CodomainProjection( underlying_general ), cokernel_mor );
         
         return AsSerreQuotientCategoryByThreeArrowsMorphism( category, cokernel_mor );
         

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -266,7 +266,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPERATIONS_FOR_SERRE_QUOTIENT_BY_THREE_ARROWS"
         
         kernel_mor := KernelEmbedding( AssociatedMorphism( underlying_general ) );
         
-        kernel_mor := PreCompose( kernel_mor, DomainOfGeneralizedMorphism( underlying_general ) );
+        kernel_mor := PreCompose( kernel_mor, DomainEmbedding( underlying_general ) );
         
         return AsSerreQuotientCategoryByThreeArrowsMorphism( category, kernel_mor );
         

--- a/GradedModulePresentationsForCAP/gap/GradedModuleFunctors.gi
+++ b/GradedModulePresentationsForCAP/gap/GradedModuleFunctors.gi
@@ -697,7 +697,7 @@ InstallMethod( PurityFiltrationBySpectralSequence,
     
     embedding_list := Reversed( embedding_list );
     
-    combined_image_embeddings := List( embedding_list, CombinedImageEmbedding );
+    combined_image_embeddings := List( embedding_list, GeneralizedImageEmbedding );
     
     functors := ValueOption( "Functors" );
     if functors <> fail then

--- a/HomologicalAlgebraForCAP/gap/HomologicalAlgebraAlgorithms.gi
+++ b/HomologicalAlgebraForCAP/gap/HomologicalAlgebraAlgorithms.gi
@@ -81,7 +81,7 @@ end );
 #     
 #     composition := PreCompose( composition, cokernel_proj );
     
-#     domain := DomainOfGeneralizedMorphism( composition );
+#     domain := DomainEmbedding( composition );
 #     
 #     inverse_domain := Inverse( domain );
     
@@ -127,7 +127,7 @@ InstallMethodWithCacheFromObject( GetSpectralSequenceObjectFromConsecutiveGenera
   function( generalized_morphism_into_entry, generalized_morphism_from_entry )
     local mono, epi, image_embedding;
     
-    mono := DomainOfGeneralizedMorphism( generalized_morphism_from_entry );
+    mono := DomainEmbedding( generalized_morphism_from_entry );
     
     epi := Codomain( generalized_morphism_into_entry );
     
@@ -146,7 +146,7 @@ InstallMethodWithCacheFromObject( GetSpectralSequenceDifferentialFromConsecutive
     
     source_epi := GeneralizedInverse( Codomain( generalized_morphism_into_source ) );
     
-    range_mono := GeneralizedInverse( DomainOfGeneralizedMorphism( generalized_morphism_from_range ) );
+    range_mono := GeneralizedInverse( DomainEmbedding( generalized_morphism_from_range ) );
     
     generalized_morphism := PreCompose( source_epi, PreCompose( generalized_differential, range_mono ) );
     

--- a/HomologicalAlgebraForCAP/gap/HomologicalAlgebraAlgorithms.gi
+++ b/HomologicalAlgebraForCAP/gap/HomologicalAlgebraAlgorithms.gi
@@ -87,7 +87,7 @@ end );
     
     
 #     
-#     codomain := Codomain( composition );
+#     codomain := CodomainProjection( composition );
 #     
 #     inverse_codomain := Inverse( codomain );
 #     
@@ -129,7 +129,7 @@ InstallMethodWithCacheFromObject( GetSpectralSequenceObjectFromConsecutiveGenera
     
     mono := DomainEmbedding( generalized_morphism_from_entry );
     
-    epi := Codomain( generalized_morphism_into_entry );
+    epi := CodomainProjection( generalized_morphism_into_entry );
     
     image_embedding := ImageEmbedding( PreCompose( mono, epi ) );
     
@@ -144,7 +144,7 @@ InstallMethodWithCacheFromObject( GetSpectralSequenceDifferentialFromConsecutive
   function( generalized_morphism_into_source, generalized_differential, generalized_morphism_from_range )
     local source_epi, range_mono, generalized_morphism;
     
-    source_epi := GeneralizedInverse( Codomain( generalized_morphism_into_source ) );
+    source_epi := GeneralizedInverse( CodomainProjection( generalized_morphism_into_source ) );
     
     range_mono := GeneralizedInverse( DomainEmbedding( generalized_morphism_from_range ) );
     

--- a/ToricSheaves/gap/CoverByLocallyFreeObject.gi
+++ b/ToricSheaves/gap/CoverByLocallyFreeObject.gi
@@ -27,7 +27,7 @@ InstallMethod( CoverByProjectiveWithLift,
   function( morphism )
     local cimage_embedding, cimage_embedding_inverse, cover_of_source, cover, restricted_morphism, lift;
     
-    cimage_embedding := CombinedImageEmbedding( UnderlyingGeneralizedMorphism( morphism ) );
+    cimage_embedding := GeneralizedImageEmbedding( UnderlyingGeneralizedMorphism( morphism ) );
     
     cimage_embedding := AsSerreQuotientCategoryMorphism( CapCategory( morphism ), cimage_embedding );
     


### PR DESCRIPTION
For a generalized morphism, there are 4 canonical subobjects:
- generalized image
- generalized kernel
- defect
- domain

There are also 4 canonical quotient objects:
- generalized coimage
- generalized cokernel
- codefect
- codomain.

I implemented all of them and gave them consistent names.
For this, I had to rename the following already existing functions:
- `DomainOfGeneralizedMorphism` -> `DomainEmbedding`
- `Codomain` -> `CodomainProjection`
- `CombinedImageEmbedding` -> `GeneralizedImageEmbedding`

Now, the commands for all of the canonical subobjects
are of the form

`XEmbedding`

and all of the canonical quotient objects are of the form

`XProjection`.

Furthermore, I followed the terminology introduced in my PhD thesis
to determine the `X` (this is why I called the `CombinedImageEmbedding`
a `GeneralizedImageEmbedding`).