### PR TITLE
Implement the Adelman category of an additive category

### DIFF
--- a/FreydCategoriesForCAP/examples/AdelmanCategoryBasics.g
+++ b/FreydCategoriesForCAP/examples/AdelmanCategoryBasics.g
@@ -1,0 +1,111 @@
+#! @Chapter Examples and Tests
+
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "RingsForHomalg" );
+
+#! @Section Adelman category basics
+
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "RingsForHomalg" );
+
+#! @Example
+R := HomalgRingOfIntegers();;
+rows := CategoryOfRows( R );;
+adelman := AdelmanCategory( rows );;
+obj1 := CategoryOfRowsObject( 1, rows );;
+obj2 := CategoryOfRowsObject( 2, rows );;
+id := IdentityMorphism( obj2 );;
+alpha := CategoryOfRowsMorphism( obj1, HomalgMatrix( [ [ 1, 2 ] ], 1, 2, R ), obj2 );;
+beta := CategoryOfRowsMorphism( obj2, HomalgMatrix( [ [ 1, 2 ], [ 3, 4 ] ], 2, 2, R ), obj2 );;
+gamma := CategoryOfRowsMorphism( obj2, HomalgMatrix( [ [ 1, 3 ], [ 3, 4 ] ], 2, 2, R ), obj2 );;
+obj1_a := AsAdelmanCategoryObject( obj1 );;
+obj2_a := AsAdelmanCategoryObject( obj2 );;
+m := AsAdelmanCategoryMorphism( beta );;
+n := AsAdelmanCategoryMorphism( gamma );;
+IsWellDefined( m );
+#! true
+IsCongruentForMorphisms( PreCompose( m, n ), PreCompose( n, m ) );
+#! false
+IsCongruentForMorphisms( SubtractionForMorphisms( m, m ), ZeroMorphism( obj2_a, obj2_a ) );
+#! true
+IsCongruentForMorphisms( ZeroObjectFunctorial( adelman ),
+                         PreCompose( UniversalMorphismFromZeroObject( obj1_a), UniversalMorphismIntoZeroObject( obj1_a ) ) 
+                        );
+#! true
+d := [ obj1_a, obj2_a ];;
+pi1 := ProjectionInFactorOfDirectSum( d, 1 );;
+pi2 := ProjectionInFactorOfDirectSum( d, 2 );;
+id := IdentityMorphism( DirectSum( d ) );;
+iota1 := InjectionOfCofactorOfDirectSum( d, 1 );;
+iota2 := InjectionOfCofactorOfDirectSum( d, 2 );;
+IsCongruentForMorphisms( PreCompose( pi1, iota1 ) + PreCompose( pi2, iota2 ), id );
+#! true
+IsCongruentForMorphisms( UniversalMorphismIntoDirectSum( d, [ pi1, pi2 ] ), id );
+#! true
+IsCongruentForMorphisms( UniversalMorphismFromDirectSum( d, [ iota1, iota2 ] ), id );
+#! true
+c := CokernelProjection( m );;
+c2 := CokernelProjection( c );;
+IsCongruentForMorphisms( c2, ZeroMorphism( Source( c2 ), Range( c2 ) ) );
+#! true
+IsWellDefined( CokernelProjection( m ) );
+#! true
+IsCongruentForMorphisms( CokernelColift( m, CokernelProjection( m ) ), IdentityMorphism( CokernelObject( m ) ) );
+#! true
+k := KernelEmbedding( c );;
+IsZeroForMorphisms( PreCompose( k, c ) );
+#! true
+IsCongruentForMorphisms( KernelLift( m, KernelEmbedding( m ) ), IdentityMorphism( KernelObject( m ) ) );
+#! true
+
+
+quiver := RightQuiver( "Q(9)[a:1->2,b:2->3,c:1->4,d:2->5,e:3->6,f:4->5,g:5->6,h:4->7,i:5->8,j:6->9,k:7->8,l:8->9,m:2->7,n:3->8]" );;
+kQ := PathAlgebra( HomalgFieldOfRationals(), quiver );;
+Aoid := Algebroid( kQ, [ kQ.ad - kQ.cf, 
+                         kQ.dg - kQ.be, 
+                         kQ.("fi") - kQ.hk,
+                         kQ.gj - kQ.il,
+                         kQ.mk + kQ.bn - kQ.di ] );;
+INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID( Aoid );;
+mm := SetOfGeneratingMorphisms( Aoid );;
+CapCategorySwitchLogicOff( Aoid );;
+Acat := AdditiveClosure( Aoid );;
+a := AsAdditiveClosureMorphism( mm[1] );;
+b := AsAdditiveClosureMorphism( mm[2] );;
+c := AsAdditiveClosureMorphism( mm[3] );;
+d := AsAdditiveClosureMorphism( mm[4] );;
+e := AsAdditiveClosureMorphism( mm[5] );;
+f := AsAdditiveClosureMorphism( mm[6] );;
+g := AsAdditiveClosureMorphism( mm[7] );;
+h := AsAdditiveClosureMorphism( mm[8] );;
+i := AsAdditiveClosureMorphism( mm[9] );;
+j := AsAdditiveClosureMorphism( mm[10] );;
+k := AsAdditiveClosureMorphism( mm[11] );;
+l := AsAdditiveClosureMorphism( mm[12] );;
+m := AsAdditiveClosureMorphism( mm[13] );;
+n := AsAdditiveClosureMorphism( mm[14] );;
+Adel := AdelmanCategory( Acat );;
+A := AdelmanCategoryObject( a, b );;
+B := AdelmanCategoryObject( f, g );;
+alpha := AdelmanCategoryMorphism( A, d, B );;
+IsWellDefined( alpha );
+#! true
+IsWellDefined( KernelEmbedding( alpha ) );
+#! true
+IsWellDefined( CokernelProjection( alpha ) );
+#! true
+T := AdelmanCategoryObject( k, l );;
+tau := AdelmanCategoryMorphism( B, i, T );;
+IsZeroForMorphisms( PreCompose( alpha, tau ) );
+#! true
+colift := CokernelColift( alpha, tau );;
+IsWellDefined( colift );
+#! true
+IsCongruentForMorphisms( PreCompose( CokernelProjection( alpha ), colift ), tau );
+#! true
+lift := KernelLift( tau, alpha );;
+IsWellDefined( lift );
+#! true
+IsCongruentForMorphisms( PreCompose( lift, KernelEmbedding( tau ) ), alpha );
+#! true
+#! @EndExample

--- a/FreydCategoriesForCAP/examples/AdelmanCategoryBasics.g
+++ b/FreydCategoriesForCAP/examples/AdelmanCategoryBasics.g
@@ -57,8 +57,6 @@ IsZeroForMorphisms( PreCompose( k, c ) );
 #! true
 IsCongruentForMorphisms( KernelLift( m, KernelEmbedding( m ) ), IdentityMorphism( KernelObject( m ) ) );
 #! true
-
-
 quiver := RightQuiver( "Q(9)[a:1->2,b:2->3,c:1->4,d:2->5,e:3->6,f:4->5,g:5->6,h:4->7,i:5->8,j:6->9,k:7->8,l:8->9,m:2->7,n:3->8]" );;
 kQ := PathAlgebra( HomalgFieldOfRationals(), quiver );;
 Aoid := Algebroid( kQ, [ kQ.ad - kQ.cf, 
@@ -107,5 +105,7 @@ lift := KernelLift( tau, alpha );;
 IsWellDefined( lift );
 #! true
 IsCongruentForMorphisms( PreCompose( lift, KernelEmbedding( tau ) ), alpha );
+#! true
+IsCongruentForMorphisms( ColiftAlongEpimorphism( CokernelProjection( alpha ), tau ), colift );
 #! true
 #! @EndExample

--- a/FreydCategoriesForCAP/examples/AdelmanSnakeLemma.g
+++ b/FreydCategoriesForCAP/examples/AdelmanSnakeLemma.g
@@ -1,0 +1,46 @@
+#! @Chapter Examples and Tests
+
+#! @Section Adelman category basics
+
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "GeneralizedMorphismsForCAP" );;
+
+#! @Example
+SwitchGeneralizedMorphismStandard( "span" );;
+snake_quiver := RightQuiver( "Q(6)[a:1->2,b:2->3,c:3->4]" );;
+kQ := PathAlgebra( HomalgFieldOfRationals(), snake_quiver );;
+Aoid := Algebroid( kQ, [ kQ.abc ] );;
+CapCategorySwitchLogicOff( Aoid );;
+INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID( Aoid );;
+m := SetOfGeneratingMorphisms( Aoid );;
+a := m[1];;
+b := m[2];;
+c := m[3];;
+add := AdditiveClosure( Aoid );;
+adelman := AdelmanCategory( add );;
+a := AsAdditiveClosureMorphism( a );;
+b := AsAdditiveClosureMorphism( b );;
+c := AsAdditiveClosureMorphism( c );;
+aa := AsAdelmanCategoryMorphism( a );;
+bb := AsAdelmanCategoryMorphism( b );;
+cc := AsAdelmanCategoryMorphism( c );;
+dd := CokernelProjection( aa );;
+ee := CokernelColift( aa, PreCompose( bb, cc ) );;
+ff := KernelEmbedding( ee );;
+gg := KernelEmbedding( cc );;
+hh := KernelLift( cc, PreCompose( aa, bb ) );;
+ii := CokernelProjection( hh );;
+fff := AsGeneralizedMorphism( ff );;
+ddd := AsGeneralizedMorphism( dd );;
+bbb := AsGeneralizedMorphism( bb );;
+ggg := AsGeneralizedMorphism( gg );;
+iii := AsGeneralizedMorphism( ii );;
+p := PreCompose( [ fff, PseudoInverse( ddd ), bbb, PseudoInverse( ggg ), iii ] );;
+IsHonest( p );
+#! true
+jj := KernelObjectFunctorial( bb, dd, ee );;
+pp := HonestRepresentative( p );;
+comp := PreCompose( jj, pp );;
+IsZero( comp );
+#! true
+# @EndExample

--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -5,7 +5,7 @@
 LoadPackage( "FreydCategoriesForCAP" );;
 LoadPackage( "RingsForHomalg" );
 
-#! @Example
+# @Example
 R := HomalgRingOfIntegers();
 cat := CategoryOfRows( R );
 obj1 := CategoryOfRowsObject( 1, cat );
@@ -187,4 +187,4 @@ IsCongruentForMorphisms( PreCompose( l, f ), PreCompose( a, d ) );
 
 l := Colift( c, PreCompose( a, d ) );
 IsCongruentForMorphisms( PreCompose( c, l ), PreCompose( a, d ) );
-#! @EndExample
+# @EndExample

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -47,7 +47,6 @@ IsCongruentForMorphisms( nu, PreCompose( CoastrictionToImage( nu ), u ) );
 # true
 IsCongruentForMorphisms( u, ImageEmbedding( nu ) );
 # true
-
 kernel := KernelObject( mu );
 emb := KernelEmbedding( mu );
 p := PreCompose( EpimorphismFromSomeProjectiveObject( kernel ), KernelEmbedding( mu ) );

--- a/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
+++ b/FreydCategoriesForCAP/examples/CokernelImageClosureExample.gi
@@ -5,7 +5,7 @@
 LoadPackage( "FreydCategoriesForCAP" );;
 LoadPackage( "RingsForHomalg" );
 
-#! @Example
+# @Example
 R := HomalgFieldOfRationalsInSingular() * "x,y,z";
 RowsR := CategoryOfRows( R );
 m := AsCategoryOfRowsMorphism( 
@@ -53,4 +53,4 @@ emb := KernelEmbedding( mu );
 p := PreCompose( EpimorphismFromSomeProjectiveObject( kernel ), KernelEmbedding( mu ) );
 KernelLift( mu, p );
 LiftAlongMonomorphism( emb, p );
-#! @EndExample
+# @EndExample

--- a/FreydCategoriesForCAP/examples/TheoremAdelman.g
+++ b/FreydCategoriesForCAP/examples/TheoremAdelman.g
@@ -1,0 +1,25 @@
+#! @Chapter Examples and Tests
+
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "RingsForHomalg" );
+
+#! @Section Adelman category basics
+
+#! @Example
+quiver := RightQuiver( "Q(9)[a:1->2,b:3->2]" );;
+kQ := PathAlgebra( HomalgFieldOfRationals(), quiver );;
+Aoid := Algebroid( kQ );;
+INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID( Aoid );;
+mm := SetOfGeneratingMorphisms( Aoid );;
+CapCategorySwitchLogicOff( Aoid );;
+Acat := AdditiveClosure( Aoid );;
+a := AsAdditiveClosureMorphism( mm[1] );;
+b := AsAdditiveClosureMorphism( mm[2] );;
+a := AsAdelmanCategoryMorphism( a );;
+b := AsAdelmanCategoryMorphism( b );;
+pi1 := ProjectionInFactorOfFiberProduct( [ a, b ], 1 );;
+pi2 := ProjectionInFactorOfFiberProduct( [ a, b ], 1 );;
+c := CokernelColift( pi1, PreCompose( a, CokernelProjection( b ) ) );;
+IsMonomorphism( c );
+#! true
+#! @EndExample

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gd
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gd
@@ -1,0 +1,74 @@
+#############################################################################
+##
+##     FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+##
+##  Copyright 2018, Sebastian Posur, University of Siegen
+##
+#! @Chapter Adelman category
+#!
+#############################################################################
+
+####################################
+##
+#! @Section GAP Categories
+##
+####################################
+
+DeclareCategory( "IsAdelmanCategoryObject",
+                 IsCapCategoryObject );
+
+DeclareCategory( "IsAdelmanCategoryMorphism",
+                 IsCapCategoryMorphism );
+
+DeclareCategory( "IsAdelmanCategory",
+                 IsCapCategory );
+
+DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY" );
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareAttribute( "AdelmanCategory",
+                  IsCapCategory );
+
+DeclareOperation( "AdelmanCategoryObject",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+DeclareOperation( "AdelmanCategoryMorphism",
+                  [ IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ] );
+
+DeclareAttribute( "AsAdelmanCategoryObject",
+                  IsCapCategoryObject );
+
+DeclareAttribute( "AsAdelmanCategoryMorphism",
+                  IsCapCategoryMorphism );
+
+####################################
+##
+#! @Section Attributes
+##
+####################################
+
+DeclareAttribute( "UnderlyingCategory",
+                  IsAdelmanCategory );
+
+DeclareAttribute( "RelationMorphism",
+                  IsAdelmanCategoryObject );
+
+DeclareAttribute( "CorelationMorphism",
+                  IsAdelmanCategoryObject );
+
+DeclareAttribute( "MorphismDatum",
+                  IsAdelmanCategoryMorphism );
+
+DeclareAttribute( "RelationWitness",
+                  IsAdelmanCategoryMorphism );
+
+DeclareAttribute( "CorelationWitness",
+                  IsAdelmanCategoryMorphism );
+
+DeclareAttribute( "WitnessPairForBeingCongruentToZero",
+                  IsAdelmanCategoryMorphism );

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -1,0 +1,678 @@
+#############################################################################
+##
+##     FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+##
+##  Copyright 2018, Sebastian Posur, University of Siegen
+##
+#############################################################################
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallMethod( AdelmanCategory,
+               [ IsCapCategory ],
+
+  function( underlying_category )
+    local adelman_category;
+    
+    if not HasIsAdditiveCategory( underlying_category ) then
+        
+        Error( "The given category should be additive" );
+        
+    fi;
+    
+    if not IsCategoryWithHomomorphismStructure( underlying_category ) then
+        
+        Error( "The given category must have a homomorphism structure" );
+        
+    fi;
+    
+    if not CanCompute( CapCategory( DistinguishedObjectOfHomomorphismStructure( underlying_category ) ), "Lift" ) then
+        
+        Error( "The range category of the homomorphism structure of the given category should be able to compute Lift");
+        
+    fi;
+    
+    ## for IsCongruentForMorphisms to be correct
+    if not CanCompute( underlying_category, "Lift" ) then
+        
+        Error( "The given category should be able to compute Lift" );
+        
+    fi;
+    
+    if not CanCompute( underlying_category, "Colift" ) then
+        
+        Error( "The given category should be able to compute Colift" );
+        
+    fi;
+    
+    if not CanCompute( underlying_category, "SubtractionForMorphisms" ) then
+        
+        Error( "The given category should be able to compute SubtractionForMorphisms" );
+        
+    fi;
+    
+    if not CanCompute( underlying_category, "AdditionForMorphisms" ) then
+        
+        Error( "The given category should be able to compute AdditionForMorphisms" );
+        
+    fi;
+    
+    if not CanCompute( underlying_category, "PreCompose" ) then
+        
+        Error( "The given category should be able to compute PreCompose" );
+        
+    fi;
+    
+    adelman_category := CreateCapCategory( Concatenation( "Adelman category( ", Name( underlying_category ), " )" ) );
+    
+    SetFilterObj( adelman_category, IsAdelmanCategory );
+    
+    ## this is the purpose of the Adelman category
+    SetIsAbelianCategory( adelman_category, true );
+    
+    SetUnderlyingCategory( adelman_category, underlying_category );
+    
+    DisableAddForCategoricalOperations( adelman_category );
+    
+    AddObjectRepresentation( adelman_category, IsAdelmanCategoryObject );
+    
+    AddMorphismRepresentation( adelman_category, IsAdelmanCategoryMorphism );
+    
+    INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY( adelman_category );
+    
+    Finalize( adelman_category );
+    
+    return adelman_category;
+    
+end );
+
+
+##
+InstallMethod( AdelmanCategoryObject,
+               [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+
+  function( relation_morphism, corelation_morphism )
+    local adelman_category_object, category;
+    
+    if not IsEqualForObjects( Range( relation_morphism ), Source( corelation_morphism ) ) then
+    
+        Error ( "the range of the relation morphism has to be equal to the source of the corelation morphism" );
+    
+    fi;
+    
+    adelman_category_object := rec( );
+    
+    category := AdelmanCategory( CapCategory( relation_morphism ) );
+    
+    ObjectifyObjectForCAPWithAttributes( adelman_category_object, category,
+                                         RelationMorphism, relation_morphism,
+                                         CorelationMorphism, corelation_morphism );
+    
+    Add( category, adelman_category_object );
+    
+    return adelman_category_object;
+    
+end );
+
+##
+InstallMethod( AsAdelmanCategoryObject,
+               [ IsCapCategoryObject ],
+               
+  function( object )
+    local proj_inj_object;
+    
+    proj_inj_object := AdelmanCategoryObject( UniversalMorphismFromZeroObject( object ), UniversalMorphismIntoZeroObject( object ) );
+    
+    ## TODO: IsInjective and IsProjective
+    
+    return proj_inj_object;
+    
+end );
+
+##
+InstallMethod( AdelmanCategoryMorphism,
+               [ IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ],
+               
+  function( source, morphism_datum, range )
+    local adelman_category_morphism, category;
+    
+    if not IsIdenticalObj( CapCategory( morphism_datum ), UnderlyingCategory( CapCategory( source ) ) ) then
+        
+        Error( "The underlying category of the given morphism datum is not identical to the underlying category of the given source" );
+        
+    fi;
+    
+    if not IsEqualForObjects( Source( morphism_datum ), Source( CorelationMorphism( source ) ) ) then
+        
+        Error( "The source of the given morphism datum is not equal to the source of the corelation morphism of the given source object" );
+        
+    fi;
+    
+    if not IsEqualForObjects( Range( morphism_datum ), Source( CorelationMorphism( range ) ) ) then
+        
+        Error( "The range of the given morphism datum is not equal to the source of the corelation morphism of the given range object" );
+        
+    fi;
+    
+    adelman_category_morphism := rec( );
+    
+    category :=  CapCategory( source );
+    
+    ObjectifyMorphismForCAPWithAttributes( 
+                             adelman_category_morphism, category,
+                             Source, source,
+                             Range, range,
+                             MorphismDatum, morphism_datum
+    );
+    
+    Add( category, adelman_category_morphism );
+    
+    return adelman_category_morphism;
+    
+end );
+
+##
+InstallMethod( AsAdelmanCategoryMorphism,
+               [ IsCapCategoryMorphism ],
+               
+  function( morphism )
+    
+    return AdelmanCategoryMorphism(
+             AsAdelmanCategoryObject( Source( morphism ) ),
+             morphism,
+             AsAdelmanCategoryObject( Range( morphism ) )
+           );
+    
+end );
+
+####################################
+##
+## Attributes
+##
+####################################
+
+##
+InstallMethod( RelationWitness,
+               [ IsAdelmanCategoryMorphism ],
+               
+  function( morphism )
+    
+    return Lift( PreCompose( RelationMorphism( Source( morphism ) ), MorphismDatum( morphism ) ), RelationMorphism( Range( morphism ) ) );
+    
+end );
+
+##
+InstallMethod( CorelationWitness,
+               [ IsAdelmanCategoryMorphism ],
+               
+  function( morphism )
+    
+    return Colift( CorelationMorphism( Source( morphism ) ), PreCompose( MorphismDatum( morphism ), CorelationMorphism( Range( morphism ) ) ) );
+    
+end );
+
+##
+InstallMethod( WitnessPairForBeingCongruentToZero,
+               [ IsAdelmanCategoryMorphism ],
+               
+  function( morphism )
+    local datum, left_coeffs, right_coeffs;
+    
+    datum := MorphismDatum( morphism );
+    
+    left_coeffs :=
+        [ [ IdentityMorphism( Source( datum ) ), CorelationMorphism( Source( morphism ) ) ] ];
+    
+    right_coeffs :=
+        [ [ RelationMorphism( Range( morphism ) ), IdentityMorphism( Range( datum ) ) ] ];
+    
+    return SolveLinearSystemInAdditiveCategoryWithHomomorphismStructure( left_coeffs, right_coeffs, [ datum ] );
+    
+end );
+
+####################################
+##
+## Basic operations
+##
+####################################
+
+InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
+
+  function( category )
+    local underlying_category;
+    
+    underlying_category := UnderlyingCategory( category );
+    
+    ##
+    AddIsEqualForCacheForObjects( category,
+      IsIdenticalObj );
+    
+    ##
+    AddIsEqualForCacheForMorphisms( category,
+      IsIdenticalObj );
+    
+    ## Well-defined for objects and morphisms
+    ##
+    AddIsWellDefinedForObjects( category,
+      function( object )
+        local relation_morphism, corelation_morphism;
+        
+        relation_morphism := RelationMorphism( object );
+        
+        corelation_morphism := CorelationMorphism( object );
+        
+        if not IsWellDefined( relation_morphism ) 
+           or not IsWellDefined( corelation_morphism ) then
+            
+            return false;
+            
+        fi;
+        
+        if not IsEqualForObjects( Source( corelation_morphism ), Range( relation_morphism ) ) then
+            
+            return false;
+            
+        fi;
+        
+        # all tests passed, so it is well-defined
+        return true;
+        
+    end );
+    
+    ##
+    AddIsWellDefinedForMorphisms( category,
+      function( morphism )
+        
+        if RelationWitness( morphism ) = fail then
+            
+            return false;
+            
+        fi;
+        
+        if CorelationWitness( morphism ) = fail then
+            
+            return false;
+            
+        fi;
+        
+        # all tests passed, so it is well-defined
+        return true;
+        
+    end );
+    
+    ## Equality Basic Operations for Objects and Morphisms
+    ##
+    AddIsEqualForObjects( category,
+      function( object_1, object_2 )
+        
+        return IsEqualForMorphismsOnMor( RelationMorphism( object_1 ), RelationMorphism( object_2 ) )
+               and IsEqualForMorphismsOnMor( CorelationMorphism( object_1 ), CorelationMorphism( object_2 ) );
+        
+    end );
+    
+    ##
+    AddIsEqualForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        
+        return IsEqualForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) );
+        
+    end );
+    
+    ##
+    AddIsCongruentForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        
+        if WitnessPairForBeingCongruentToZero( SubtractionForMorphisms( morphism_1, morphism_2 ) ) = fail then
+            
+            return false;
+            
+        else
+            
+            return true;
+            
+        fi;
+        
+    end );
+    
+    ## Basic Operations for a Category
+    ##
+    AddIdentityMorphism( category,
+      
+      function( object )
+        
+        return AdelmanCategoryMorphism( object, IdentityMorphism( Range( RelationMorphism( object ) ) ), object );
+        
+    end );
+    
+    ##
+    AddPreCompose( category,
+      
+      function( morphism_1, morphism_2 )
+        local composition;
+        
+        composition := PreCompose( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) );
+        
+        return AdelmanCategoryMorphism( Source( morphism_1 ), composition, Range( morphism_2 ) );
+        
+    end );
+
+    ##
+    AddSubtractionForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        local subtraction;
+        
+        subtraction := AdelmanCategoryMorphism(
+                            Source( morphism_1 ),
+                            SubtractionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
+                            Range( morphism_1 )
+                        );
+        
+        return subtraction;
+        
+    end );
+    
+    ##
+    AddAdditionForMorphisms( category,
+      function( morphism_1, morphism_2 )
+        local addition;
+        
+        addition := AdelmanCategoryMorphism(
+                            Source( morphism_1 ),
+                            AdditionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
+                            Range( morphism_1 )
+                        );
+        
+        return addition;
+        
+    end );
+    
+    ##
+    AddAdditiveInverseForMorphisms( category,
+      function( morphism )
+        local additive_inverse;
+        
+        additive_inverse := AdelmanCategoryMorphism(
+                              Source( morphism ),
+                              AdditiveInverseForMorphisms( MorphismDatum( morphism ) ),
+                              Range( morphism )
+                            );
+        
+        return additive_inverse;
+        
+    end );
+    
+    ##
+    AddZeroMorphism( category,
+      function( source, range )
+        local zero_morphism;
+        
+        zero_morphism := AdelmanCategoryMorphism(
+                           source,
+                           ZeroMorphism( Range( RelationMorphism( source ) ), Range( RelationMorphism( range ) ) ),
+                           range
+                         );
+        
+        return zero_morphism;
+        
+    end );
+    
+    ##
+    AddZeroObject( category,
+      function( )
+        
+        return AsAdelmanCategoryObject( ZeroObject( underlying_category) );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( category,
+      function( sink, zero_object )
+        local universal_morphism;
+        
+        universal_morphism := AdelmanCategoryMorphism(
+                                sink,
+                                UniversalMorphismIntoZeroObject( Range( RelationMorphism( sink ) ) ),
+                                zero_object
+                              );
+        
+        return universal_morphism;
+        
+    end );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( category,
+      function( source, zero_object )
+        local universal_morphism;
+        
+        universal_morphism := AdelmanCategoryMorphism(
+                                zero_object,
+                                UniversalMorphismFromZeroObject( Range( RelationMorphism( source ) ) ),
+                                source
+                              );
+        
+        return universal_morphism;
+        
+    end );
+    
+    ##
+    AddDirectSum( category,
+      function( object_list )
+        
+        return AdelmanCategoryObject( DirectSumFunctorial( List( object_list, RelationMorphism ) ),
+                                      DirectSumFunctorial( List( object_list, CorelationMorphism ) ) );
+        
+    end );
+    
+    ##
+    AddDirectSumFunctorialWithGivenDirectSums( category,
+      function( direct_sum_source, diagram, direct_sum_range )
+        
+        return AdelmanCategoryMorphism( direct_sum_source,
+                                        DirectSumFunctorial( List( diagram, MorphismDatum ) ),
+                                        direct_sum_range );
+        
+    end );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
+      function( object_list, projection_number, direct_sum_object )
+        
+        return AdelmanCategoryMorphism( direct_sum_object,
+                                        ProjectionInFactorOfDirectSum( List( object_list, obj -> Range( RelationMorphism( obj ) ) ), projection_number ),
+                                        object_list[projection_number]
+                                      );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
+      function( diagram, source, direct_sum_object )
+        
+        return AdelmanCategoryMorphism( Source( source[1] ),
+                                        UniversalMorphismIntoDirectSum( List( diagram, obj -> Range( RelationMorphism( obj ) ) ),
+                                                                        List( source, mor -> MorphismDatum( mor ) ) ),
+                                        direct_sum_object
+                                      );
+        
+    end );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
+      function( object_list, injection_number, direct_sum_object )
+        
+        return AdelmanCategoryMorphism( object_list[injection_number],
+                                        InjectionOfCofactorOfDirectSum( List( object_list, obj -> Range( RelationMorphism( obj ) ) ), injection_number ),
+                                        direct_sum_object
+                                      );
+        
+    end );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
+      function( diagram, sink, direct_sum_object )
+        
+        return AdelmanCategoryMorphism( direct_sum_object,
+                                        UniversalMorphismFromDirectSum( List( diagram, obj -> Range( RelationMorphism( obj ) ) ),
+                                                                        List( sink, mor -> MorphismDatum( mor ) ) ),
+                                        Range( sink[1] )
+                                      );
+        
+    end );
+    
+    ##
+    AddCokernelProjection( category,
+                     
+      function( morphism )
+        local source, range, b, bp, ap, B, Bp, App, alpha, cokernel_object;
+        
+        source := Source( morphism );
+        
+        range := Range( morphism );
+        
+        b := RelationMorphism( range );
+        
+        bp := CorelationMorphism( range );
+        
+        ap := CorelationMorphism( source );
+        
+        B := Range( b );
+        
+        Bp := Source( b );
+        
+        App := Range( ap );
+        
+        alpha := MorphismDatum( morphism );
+        
+        cokernel_object :=
+            AdelmanCategoryObject(
+                MorphismBetweenDirectSums( [ [ b, ZeroMorphism( Bp, App ) ], [ alpha, ap ] ] ),
+                DirectSumFunctorial( [ bp, IdentityMorphism( App ) ] )
+            );
+        
+        return AdelmanCategoryMorphism( 
+            Range( morphism ),
+            InjectionOfCofactorOfDirectSum( [ B, App ], 1 ),
+            cokernel_object
+        );
+        
+    end );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( category,
+      
+      function( morphism, test_morphism, cokernel_object )
+        local witness_pair, datum;
+        
+        witness_pair := WitnessPairForBeingCongruentToZero( PreCompose( morphism, test_morphism ) );
+        
+        datum :=
+            UniversalMorphismFromDirectSum(
+                [ MorphismDatum( test_morphism ), -witness_pair[2] ]
+            );
+        
+        return AdelmanCategoryMorphism( cokernel_object,
+                                        datum,
+                                        Range( test_morphism ) );
+        
+    end );
+    
+    ##
+    AddKernelEmbedding( category,
+      
+      function( morphism )
+        local source, range, a, ap, alpha, b, Bp, App, A, kernel_object;
+        
+        source := Source( morphism );
+        
+        range := Range( morphism );
+        
+        a := RelationMorphism( source );
+        
+        ap := CorelationMorphism( source );
+        
+        alpha := MorphismDatum( morphism );
+        
+        b := RelationMorphism( range );
+        
+        Bp := Source( b );
+        
+        App := Range( ap );
+        
+        A := Source( alpha );
+        
+        kernel_object :=
+            AdelmanCategoryObject(
+                DirectSumFunctorial( [ a, IdentityMorphism( Bp ) ] ),
+                MorphismBetweenDirectSums( [ [ ap, alpha ], [ ZeroMorphism( Bp, App ), b ] ] )
+            );
+        
+        return AdelmanCategoryMorphism( 
+            kernel_object,
+            ProjectionInFactorOfDirectSum( [ A, Bp ], 1 ),
+            Source( morphism )
+        );
+        
+    end );
+    
+    ##
+    AddKernelLiftWithGivenKernelObject( category,
+      
+      function( morphism, test_morphism, kernel_object )
+        local witness_pair, datum;
+        
+        witness_pair := WitnessPairForBeingCongruentToZero( PreCompose( test_morphism, morphism ) );
+        
+        datum :=
+            UniversalMorphismIntoDirectSum(
+                [ MorphismDatum( test_morphism ), -witness_pair[1] ]
+            );
+        
+        return AdelmanCategoryMorphism( Source( test_morphism ),
+                                        datum,
+                                        kernel_object );
+        
+    end );
+    
+end );
+
+####################################
+##
+## View
+##
+####################################
+
+##
+InstallMethod( Display,
+               [ IsAdelmanCategoryMorphism ],
+               
+  function( morphism )
+    
+    Print( "Morphism datum:\n" );
+    
+    Display( MorphismDatum( morphism ) );
+    
+end );
+
+
+##
+InstallMethod( Display,
+               [ IsAdelmanCategoryObject ],
+               
+  function( object )
+    
+    Print( "Relation morphism:\n" );
+    
+    Display( RelationMorphism( object ) );
+    
+    Print( "\n--------------------\n" );
+    
+    Print( "Corelation morphism:\n" );
+    
+    Display( CorelationMorphism( object ) );
+    
+end );

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -582,6 +582,52 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     end );
     
     ##
+    AddColiftAlongEpimorphism( category,
+      
+      function( alpha, tau )
+        local witness_alpha, sigma78, sigma56, witness_test, sigma12, range_alpha, b2, datum_tau, A, B, Bp, App, sigma8, sigma6, sigma5, sigma2, sigma1;
+        
+        witness_alpha := WitnessPairForBeingCongruentToZero( CokernelProjection( alpha ) );
+        
+        sigma78 := witness_alpha[1];
+        
+        sigma56 := witness_alpha[2];
+        
+        witness_test := WitnessPairForBeingCongruentToZero( PreCompose( KernelEmbedding( alpha ), tau ) );
+        
+        sigma12 := witness_test[2];
+        
+        range_alpha := Range( alpha );
+        
+        b2 := CorelationMorphism( range_alpha );
+        
+        datum_tau := MorphismDatum( tau );
+        
+        A := Source( datum_tau );
+        
+        B := Source( b2 );
+        
+        Bp := Source( RelationMorphism( range_alpha) );
+        
+        App := Range( CorelationMorphism( Source( alpha ) ) );
+        
+        sigma8 := ComponentOfMorphismIntoDirectSum( sigma78, [ Bp, A ] , 2 );
+        
+        sigma6 := ComponentOfMorphismIntoDirectSum( sigma56, [ B, App ] , 2 );
+        
+        sigma5 := ComponentOfMorphismIntoDirectSum( sigma56, [ B, App ] , 1 );
+        
+        sigma2 := ComponentOfMorphismFromDirectSum( sigma12, [ App, B ], 2 );
+        
+        sigma1 := ComponentOfMorphismFromDirectSum( sigma12, [ App, B ], 1 );
+        
+        return AdelmanCategoryMorphism( range_alpha,
+                                        PreCompose( sigma8, datum_tau ) + PreCompose( [ b2, sigma6, sigma1 ] ) + PreCompose( [ b2, sigma5, sigma2 ] ),
+                                        Range( tau ) );
+        
+    end );
+    
+    ##
     AddKernelEmbedding( category,
       
       function( morphism )

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -1124,7 +1124,24 @@ DeclareOperationWithCache( "InterpretMorphismFromDinstinguishedObjectToHomomorph
 ##
 ####################################
 
-##
+#! @Description
+#! This methods works for additive categories with a homomorphism structure such
+#! that the range category of the homomorphism structure can compute lifts.
+#! The arguments are three lists $\alpha$, $\beta$, and $\gamma$.
+#! The first list $\alpha$ (the left coefficients) is a list of list of morphisms $\alpha_{ij}: A_i \rightarrow B_j$,
+#! where $i = 1 \dots m$ and $j = 1 \dots n$ for integers $m,n$.
+#! The second list $\beta$ (the right coefficients) is a list of list of morphisms $\beta_{ij}: C_j \rightarrow D_i$,
+#! where $i = 1 \dots m$ and $j = 1 \dots n$.
+#! The third list $\gamma$ (the right side) is a list of morphisms $\gamma_i: A_i \rightarrow D_i$,
+#! where $i = 1, \dots, m$.
+#! The output is either
+#! a list of morphisms $X_j: B_j \rightarrow C_j$ for $j=1\dots n$ solving the linear system
+#! defined by $\alpha$, $\beta$, $\gamma$, i.e.,
+#! $\sum_{j = 1}^n \alpha_{ij}\cdot X_j \cdot \beta_{ij} = \gamma_j$
+#! for all $i = 1 \dots m$,
+#! or $\texttt{fail}$ if no such solution exists.
+#! @Returns a list of morphisms $[X_1, \dots, X_n]$
+#! @Arguments alpha, beta, gamma
 DeclareOperation( "SolveLinearSystemInAdditiveCategoryWithHomomorphismStructure",
                   [ IsList, IsList, IsList ] );
 

--- a/FreydCategoriesForCAP/gap/HomStructureForAlgebroids.gi
+++ b/FreydCategoriesForCAP/gap/HomStructureForAlgebroids.gi
@@ -112,13 +112,27 @@ InstallGlobalFunction( INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID,
         
         images := [ ];
         
-        for path in basis_elements_source do
+        if IsQuotientOfPathAlgebraElement( elem_alpha ) then
             
-            Add( images,
-              CoefficientsOfPaths( basis_elements_range, Representative( elem_alpha * PathAsAlgebraElement( quiver_algebra, path ) * elem_beta ) )
-            );
+            for path in basis_elements_source do
+                
+                Add( images,
+                  CoefficientsOfPaths( basis_elements_range, Representative( elem_alpha * PathAsAlgebraElement( quiver_algebra, path ) * elem_beta ) )
+                );
+                
+            od;
             
-        od;
+        else
+        
+            for path in basis_elements_source do
+                
+                Add( images,
+                  CoefficientsOfPaths( basis_elements_range, ( elem_alpha * PathAsAlgebraElement( quiver_algebra, path ) * elem_beta ) )
+                );
+                
+            od;
+            
+        fi;
         
         return morphism_constructor( HomalgMatrix( images, size_source, size_range, ring ) );
         
@@ -139,7 +153,7 @@ InstallGlobalFunction( INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID,
                    [ IsCapCategoryMorphism and MorphismFilter( bialgebroid ) ],
                    
       function( alpha )
-        local a, b, basis_elements, size_basis;
+        local a, b, basis_elements, size_basis, element;
         
         a := VertexNumber( UnderlyingVertex( Source( alpha ) ) );
         
@@ -155,9 +169,21 @@ InstallGlobalFunction( INSTALL_HOMOMORPHISM_STRUCTURE_FOR_BIALGEBROID,
             
         fi;
         
-        return morphism_constructor(
-                 HomalgMatrix( CoefficientsOfPaths( basis_elements, Representative( UnderlyingQuiverAlgebraElement( alpha ) ) ), 1, size_basis, ring )
-               );
+        element := UnderlyingQuiverAlgebraElement( alpha );
+        
+        if IsQuotientOfPathAlgebraElement( element ) then
+            
+            return morphism_constructor(
+                    HomalgMatrix( CoefficientsOfPaths( basis_elements, Representative( element ) ), 1, size_basis, ring )
+                  );
+            
+        else
+            
+            return morphism_constructor(
+                    HomalgMatrix( CoefficientsOfPaths( basis_elements, element ), 1, size_basis, ring )
+                  );
+            
+        fi;
         
     end );
     

--- a/FreydCategoriesForCAP/init.g
+++ b/FreydCategoriesForCAP/init.g
@@ -15,3 +15,5 @@ ReadPackage( "FreydCategoriesForCAP", "gap/HomStructureForAlgebroids.gd" );
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CokernelImageClosure.gd" );
+
+ReadPackage( "FreydCategoriesForCAP", "gap/AdelmanCategory.gd" );

--- a/FreydCategoriesForCAP/makedoc.g
+++ b/FreydCategoriesForCAP/makedoc.g
@@ -12,6 +12,7 @@ AutoDoc( "FreydCategoriesForCAP" : scaffold := true, autodoc :=
                               "LoadPackage( \"FreydCategoriesForCAP\" );",
                               "LoadPackage( \"RingsForHomalg\" );",
                               "LoadPackage( \"GaussForHomalg\" );",
+                              "LoadPackage( \"GeneralizedMorphismsForCAP\" );",
                               "HOMALG_IO.show_banners := false;",
                               "HOMALG_IO.suppress_PID := true;",
                               "HOMALG_IO.use_common_stream := true;",

--- a/FreydCategoriesForCAP/makedoc.g
+++ b/FreydCategoriesForCAP/makedoc.g
@@ -9,6 +9,8 @@ AutoDoc( "FreydCategoriesForCAP" : scaffold := true, autodoc :=
          maketest := rec( commands :=
                             [ "LoadPackage( \"CAP\" );",
                               "LoadPackage( \"IO_ForHomalg\" );",
+                              "LoadPackage( \"FreydCategoriesForCAP\" );",
+                              "LoadPackage( \"RingsForHomalg\" );",
                               "HOMALG_IO.show_banners := false;",
                               "HOMALG_IO.suppress_PID := true;",
                               "HOMALG_IO.use_common_stream := true;",

--- a/FreydCategoriesForCAP/makedoc.g
+++ b/FreydCategoriesForCAP/makedoc.g
@@ -11,6 +11,7 @@ AutoDoc( "FreydCategoriesForCAP" : scaffold := true, autodoc :=
                               "LoadPackage( \"IO_ForHomalg\" );",
                               "LoadPackage( \"FreydCategoriesForCAP\" );",
                               "LoadPackage( \"RingsForHomalg\" );",
+                              "LoadPackage( \"GaussForHomalg\" );",
                               "HOMALG_IO.show_banners := false;",
                               "HOMALG_IO.suppress_PID := true;",
                               "HOMALG_IO.use_common_stream := true;",

--- a/FreydCategoriesForCAP/read.g
+++ b/FreydCategoriesForCAP/read.g
@@ -16,3 +16,5 @@ ReadPackage( "FreydCategoriesForCAP", "gap/HomStructureForAlgebroids.gi" );
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CokernelImageClosure.gi" );
+
+ReadPackage( "FreydCategoriesForCAP", "gap/AdelmanCategory.gi" );


### PR DESCRIPTION
I implemented the Adelman category as a category constructor
that takes as an input an additive category and creates
its corresponding Adelman category. One can think of the
Adelman category as the free abelian category
associated to an additive category.