### PR TITLE
bump version to 2018.07.10

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -13,7 +13,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2018.02.27", ## Sepp's version
   ## this line prevents merge conflicts
-  "2018.04.27", ## Fabian's version
+  "2018.07.10", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},


### PR DESCRIPTION
Now that https://github.com/homalg-project/CAP_project/pull/142 is merged, bump the version so other packages can explicitly depend on the changes.