### PR TITLE
Make LiftAlongMonomorphism/ ColiftAlongEpimorphism consistent

### DIFF
--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1046,8 +1046,7 @@ DeclareOperation( "LiftAlongMonomorphism",
 #! The arguments are a category $C$ and a function $F$.
 #! This operations adds the given function $F$
 #! to the category for the basic operation <C>LiftAlongMonomorphism</C>.
-#! The function $F$ maps a pair $(\iota, \tau)$ to a lift $u$ if it
-#! exists, and to <C>fail</C> otherwise.
+#! The function $F$ maps a pair $(\iota, \tau)$ to a lift $u$.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddLiftAlongMonomorphism",
@@ -1077,8 +1076,7 @@ DeclareOperation( "ColiftAlongEpimorphism",
 #! The arguments are a category $C$ and a function $F$.
 #! This operations adds the given function $F$
 #! to the category for the basic operation <C>ColiftAlongEpimorphism</C>.
-#! The function $F$ maps a pair $(\epsilon, \tau)$ to a lift $u$ if it
-#! exists, and to <C>fail</C> otherwise.
+#! The function $F$ maps a pair $(\epsilon, \tau)$ to a lift $u$.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddColiftAlongEpimorphism",

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -14,16 +14,6 @@ LiftAlongMonomorphism := rec(
   io_type := [ [ "iota", "tau" ], [ "tau_source", "iota_source" ] ],
   cache_name := "LiftAlongMonomorphism",
   return_type := "morphism",
-  
-  post_function := function( alpha, beta, lift )
-    
-    if lift = fail then
-        
-        Error( "Lift along monomorphism doesn't exist" );
-        
-    fi;
-    
-  end,
   dual_operation := "ColiftAlongEpimorphism" ),
 
 ColiftAlongEpimorphism := rec(
@@ -32,15 +22,6 @@ ColiftAlongEpimorphism := rec(
   io_type := [ [ "epsilon", "tau" ], [ "epsilon_range", "tau_range" ] ],
   cache_name := "ColiftAlongEpimorphism",
   return_type := "morphism",
-  post_function := function( alpha, beta, colift )
-    
-    if colift = fail then
-        
-        Error( "Colift along epimorphism doesn't exist" );
-        
-    fi;
-    
-  end,
   dual_operation := "LiftAlongMonomorphism" ),
 
 Lift := rec(


### PR DESCRIPTION
Get rid of the requirement that the user-given-function F
in both
`LiftAlongMonomorphism`
and
`ColiftAlongEpimorphism`
has to return `fail` if such a lift does not exist.

Reason: the specification of both functions
does not specify the function to return `fail`
if such a lift does not exist.