### PR TITLE
Subobject classifier

### DIFF
--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2023,6 +2023,26 @@ AddDerivationToCAP( IsomorphismFromDirectSumToCoproduct,
     return Inverse( IsomorphismFromCoproductToDirectSum( diagram ) );
     
 end : Description := "IsomorphismFromDirectSumToCoproduct as the inverse of IsomorphismFromCoproductToDirectSum" );
+
+
+##
+AddDerivationToCAP( SubobjectOfClassifyingMorphism,
+                    [ [ TruthMorphismIntoSubobjectClassifierWithGivenObjects , 1 ],
+                      [ ProjectionInFactorOfFiberProduct , 1 ] ],
+  function( mor )
+
+      local category, truth;
+
+      category := CapCategory(mor);
+
+      truth := TruthMorphismIntoSubobjectClassifierWithGivenObjects(
+                  TerminalObject(category), SubobjectClassifier(category));
+
+      return ProjectionInFactorOfFiberProduct([ mor , truth ], 1);
+
+end : Description := "SubobjectOfClassifyingMorphism using the fiber product along the true morphism" );
+
+
 ###########################
 ##
 ## Methods returning an object

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -686,15 +686,3 @@ InstallMethod( AddSubobjectClassifier,
     
 end );
 
-##
-InstallMethod( AddTruthMorphismIntoSubobjectClassifier,
-               [ IsCapCategory, IsFunction, IsInt ],
-               
-  function( category, func, weight )
-    local wrapped_func;
-    
-    wrapped_func := function( cat ) return func(); end;
-    
-    AddTruthMorphismIntoSubobjectClassifier( category, [ [ wrapped_func, [ ] ] ], weight );
-    
-end );

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -672,3 +672,29 @@ InstallMethod( AddTerminalObject,
     AddTerminalObject( category, [ [ wrapped_func, [ ] ] ], weight );
     
 end );
+
+##
+InstallMethod( AddSubobjectClassifier,
+               [ IsCapCategory, IsFunction, IsInt ],
+               
+  function( category, func, weight )
+    local wrapped_func;
+    
+    wrapped_func := function( cat ) return func(); end;
+    
+    AddSubobjectClassifier( category, [ [ wrapped_func, [ ] ] ], weight );
+    
+end );
+
+##
+InstallMethod( AddTruthMorphismIntoSubobjectClassifier,
+               [ IsCapCategory, IsFunction, IsInt ],
+               
+  function( category, func, weight )
+    local wrapped_func;
+    
+    wrapped_func := function( cat ) return func(); end;
+    
+    AddTruthMorphismIntoSubobjectClassifier( category, [ [ wrapped_func, [ ] ] ], weight );
+    
+end );

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -621,7 +621,6 @@ UniversalMorphismFromInitialObjectWithGivenInitialObject := rec(
   return_type := "morphism",
   dual_operation := "UniversalMorphismIntoTerminalObjectWithGivenTerminalObject" ),
 
-
 SubobjectClassifier := rec(
   installation_name := "SubobjectClassifier",
   filter_list := [ "category" ],
@@ -631,22 +630,26 @@ SubobjectClassifier := rec(
 TruthMorphismIntoSubobjectClassifierWithGivenObjects := rec(
   installation_name := "TruthMorphismIntoSubobjectClassifierWithGivenObjects",
   filter_list := [ "object", "object" ],
+  io_type := [ [ "I", "S" ] , [ "I" , "S" ] ],
   universal_object_position := "Range",
   return_type := "morphism" ),
 
 ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier := rec(
   installation_name := "ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
   filter_list := [ "morphism" , "object" ],
+  io_type := [ [ "alpha", "S" ] , [ "alpha_range" , "S" ] ],
   return_type := "morphism" ),
 
 ClassifyingMorphismOfSubobject := rec(
   installation_name := "ClassifyingMorphismOfSubobject",
   filter_list := [ "morphism" ],
+  io_type := [ [ "alpha" ] , [ "alpha_range" , "S" ] ],  
   return_type := "morphism" ),
 
 SubobjectOfClassifyingMorphism := rec(
   installation_name := "SubobjectOfClassifyingMorphism",
   filter_list := [ "morphism" ],
+  io_type := [ [ "alpha" ] , [ "subobject" , "alpha_source" ] ]
   return_type := "morphism" ),
 
 DirectProduct := rec(

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -644,6 +644,11 @@ ClassifyingMorphismOfSubobject := rec(
   filter_list := [ "morphism" ],
   return_type := "morphism" ),
 
+SubobjectOfClassifyingMorphism := rec(
+  installation_name := "SubobjectOfClassifyingMorphism",
+  filter_list := [ "morphism" ],
+  return_type := "morphism" ),
+
 DirectProduct := rec(
   installation_name := "DirectProductOp",
   argument_list := [ 1 ],

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -621,6 +621,24 @@ UniversalMorphismFromInitialObjectWithGivenInitialObject := rec(
   return_type := "morphism",
   dual_operation := "UniversalMorphismIntoTerminalObjectWithGivenTerminalObject" ),
 
+
+SubobjectClassifier := rec(
+  installation_name := "SubobjectClassifier",
+  filter_list := [ "category" ],
+  cache_name := "SubobjectClassifier",
+  return_type := "object" ),
+
+TruthMorphismIntoSubobjectClassifier := rec(
+  installation_name := "TruthMorphismIntoSubobjectClassifier",
+  filter_list := [ "category" ],
+  universal_object_position := "Range",
+  return_type := "morphism" ),
+
+ClassifyingMorphismOfSubobject := rec(
+  installation_name := "ClassifyingMorphismOfSubobject",
+  filter_list := [ "morphism" ],
+  return_type := "morphism" ),
+
 DirectProduct := rec(
   installation_name := "DirectProductOp",
   argument_list := [ 1 ],

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -628,9 +628,9 @@ SubobjectClassifier := rec(
   cache_name := "SubobjectClassifier",
   return_type := "object" ),
 
-TruthMorphismIntoSubobjectClassifier := rec(
-  installation_name := "TruthMorphismIntoSubobjectClassifier",
-  filter_list := [ "category" ],
+TruthMorphismIntoSubobjectClassifierWithGivenObjects := rec(
+  installation_name := "TruthMorphismIntoSubobjectClassifierWithGivenObjects",
+  filter_list := [ "object", "object" ],
   universal_object_position := "Range",
   return_type := "morphism" ),
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -634,6 +634,11 @@ TruthMorphismIntoSubobjectClassifierWithGivenObjects := rec(
   universal_object_position := "Range",
   return_type := "morphism" ),
 
+ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier := rec(
+  installation_name := "ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
+  filter_list := [ "morphism" , "object" ],
+  return_type := "morphism" ),
+
 ClassifyingMorphismOfSubobject := rec(
   installation_name := "ClassifyingMorphismOfSubobject",
   filter_list := [ "morphism" ],

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4694,6 +4694,14 @@ DeclareOperation( "ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
                   [ IsCapCategoryMorphism , IsCapCategoryObject ] );
 
 
+#! @Description
+#! The argument is a classifying morphism $\chi : S \rightarrow \Omega$.
+#! The output is the subobject monomorphism of the classifying morphism, 
+#! $m : A \rightarrow S$.
+#! @Returns a monomorphism in $\mathrm{Hom}( A , S )$
+#! @Arguments chi
+DeclareOperation( "SubobjectOfClassifyingMorphism" , 
+                  [ IsCapCategoryMorphism ] );
 
 #! @Description
 #! The arguments are a category and a function $F$.
@@ -4776,6 +4784,27 @@ DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$ to the category
+#! for the basic operation <C>SubobjectOfClassifyingMorphism</C>.
+#! $F : m \mapsto \mathrm{SubobjectOfClassifyingMorphism}(m)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSubobjectOfClassifyingMorphism",
+                  [ IsCapCategory , IsFunction ] );
+
+DeclareOperation( "AddSubobjectOfClassifyingMorphism",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddSubobjectOfClassifyingMorphism",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSubobjectOfClassifyingMorphism",
                   [ IsCapCategory, IsList ] );
 
 

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4674,6 +4674,18 @@ DeclareOperation( "ClassifyingMorphismOfSubobject",
 
 
 #! @Description
+#! The arguments are a terminal object of the category and
+#! a subobject classifier.
+#! The output is the truth morphism to the subobject classifier
+#! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
+#! @Arguments T, W
+DeclareOperation( "TruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategoryObject , IsCapCategoryObject ]);
+
+
+
+#! @Description
 #! The arguments are a category and a function $F$.
 #! This operation adds the given function $F$
 #! to the category for the basic operation <C>SubobjectClassifier</C>.
@@ -4733,6 +4745,30 @@ DeclareOperation( "AddClassifyingMorphismOfSubobject",
 
 DeclareOperation( "AddClassifyingMorphismOfSubobject",
                   [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$ to the category
+#! for the basic operation 
+#! <C>TruthMorphismIntoSubobjectClassifierWithGivenObjects</C>.
+#! $F : (1, \Omega) \mapsto \mathrm{true}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategory , IsFunction ] );
+
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+
 
 
 #! @Chapter Universal Objects

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4642,14 +4642,26 @@ DeclareAttribute( "SubobjectClassifier",
 DeclareAttribute( "SubobjectClassifier",
                   IsCapCategoryCell );
 
+
+#! @Description
+#! The arguments are a terminal object of the category and
+#! a subobject classifier.
+#! The output is the truth morphism to the subobject classifier
+#! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
+#! @Arguments T, W
+DeclareOperation( "TruthMorphismIntoSubobjectClassifierWithGivenObjects",
+                  [ IsCapCategoryObject , IsCapCategoryObject ]);
+
+
 #! @Description
 #! The argument is a category $C$.
 #! The output is the truth morphism to the subobject classifier 
 #! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
 #! @Arguments C
-DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
-                  IsCapCategory );
+DeclareOperation( "TruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategory ] );
 
 #! @Description
 #! This is a convenience method.
@@ -4659,8 +4671,8 @@ DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
 #! of the category $C$ for which $c \in C$.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
 #! @Arguments c
-DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
-                  IsCapCategoryCell );
+DeclareOperation( "TruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategoryCell ] );
 
 
 #! @Description
@@ -4672,16 +4684,6 @@ DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
 DeclareOperation( "ClassifyingMorphismOfSubobject",
                   [ IsCapCategoryMorphism ] );
 
-
-#! @Description
-#! The arguments are a terminal object of the category and
-#! a subobject classifier.
-#! The output is the truth morphism to the subobject classifier
-#! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
-#! @Arguments T, W
-DeclareOperation( "TruthMorphismIntoSubobjectClassifierWithGivenObjects",
-                  [ IsCapCategoryObject , IsCapCategoryObject ]);
 
 
 
@@ -4703,26 +4705,6 @@ DeclareOperation( "AddSubobjectClassifier",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddSubobjectClassifier",
-                  [ IsCapCategory, IsList ] );
-
-#! @Description
-#! The arguments are a category $C$ and a function $F$.
-#! This operation adds the given function $F$ to the category
-#! for the basic operation <C>TruthMorphismIntoSubobjectClassifier</C>.
-#! $F : () \mapsto \mathrm{True}$.
-#! @Returns nothing
-#! @Arguments C, F
-DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
-                  [ IsCapCategory , IsFunction ] );
-
-DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
-                  [ IsCapCategory, IsFunction, IsInt ] );
-
-## don't document this function
-DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
-                  [ IsCapCategory, IsList, IsInt ] );
-
-DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
                   [ IsCapCategory, IsList ] );
 
 

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4608,6 +4608,133 @@ DeclareOperation( "AddUniversalMorphismIntoCoimageWithGivenCoimage",
 DeclareOperation( "AddUniversalMorphismIntoCoimageWithGivenCoimage",
                   [ IsCapCategory, IsList ] );
 
+
+####################################
+##
+#! @Section Subobject Classifier
+##
+####################################
+
+#! A subobject classifier object consists of three parts:
+#! * an object $\Omega$,
+#! * a function $\mathrm{true}$ providing a morphism $\mathrm{true}: 1 \rightarrow \Omega$,
+#! * a function $\chi$ mapping each monomorphism $i : A \rightarrow S$ to a morphism $\chi_i : S \to \Omega$.
+#! The triple $(\Omega,\mathrm{true},\chi)$ is called a <Emph>subobject classifier</Emph> if
+#! for each monomorphism $i : A \to S$, the morphism $\chi_i : S \to \Omega$ is the unique
+#! morphism such that $\chi_i \circ i = \mathrm{true} \circ \ast$ determine a pullback diagram.
+## Main Operations and Attributes
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is a subobject classifier object $\Omega$ of $C$.
+#! @Returns an object
+#! @Arguments C
+DeclareAttribute( "SubobjectClassifier",
+                  IsCapCategory );
+
+#! @Description
+#! This is a convenience method.
+#! The argument is a cell $c$.
+#! The output is a subobject classifier $\Omega$ of the
+#! category $C$ for which $c \in C$.
+#! @Returns an object
+#! @Arguments c
+DeclareAttribute( "SubobjectClassifier",
+                  IsCapCategoryCell );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is the truth morphism to the subobject classifier 
+#! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
+#! @Arguments C
+DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
+                  IsCapCategory );
+
+#! @Description
+#! This is a convenience method.
+#! The argument is a cell $c$.
+#! The output is the truth morphism to the subobject classifier 
+#! $\mathrm{true}: \mathrm{TerminalObject} \rightarrow \mathrm{SubobjectClassifier}$
+#! of the category $C$ for which $c \in C$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{TerminalObject} , \mathrm{SubobjectClassifier} )$
+#! @Arguments c
+DeclareAttribute( "TruthMorphismIntoSubobjectClassifier",
+                  IsCapCategoryCell );
+
+
+#! @Description
+#! The argument is a monomorphism $m : A \rightarrow S$.
+#! The output is its classifying morphism 
+#! $\chi_m : S \rightarrow \mathrm{SubobjectClassifier}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{Range}(m) , \mathrm{SubobjectClassifier} )$
+#! @Arguments m
+DeclareOperation( "ClassifyingMorphismOfSubobject",
+                  [ IsCapCategoryMorphism ] );
+
+
+#! @Description
+#! The arguments are a category and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SubobjectClassifier</C>.
+#! $F : () \mapsto \mathrm{SubobjectClassifier}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSubobjectClassifier",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSubobjectClassifier",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddSubobjectClassifier",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSubobjectClassifier",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$ to the category
+#! for the basic operation <C>TruthMorphismIntoSubobjectClassifier</C>.
+#! $F : () \mapsto \mathrm{True}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategory , IsFunction ] );
+
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddTruthMorphismIntoSubobjectClassifier",
+                  [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$ to the category
+#! for the basic operation <C>ClassifyingMorphismOfSubobject</C>.
+#! $F : m \mapsto \mathrm{ClassifyingMorphism}(m)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddClassifyingMorphismOfSubobject",
+                  [ IsCapCategory , IsFunction ] );
+
+DeclareOperation( "AddClassifyingMorphismOfSubobject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddClassifyingMorphismOfSubobject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddClassifyingMorphismOfSubobject",
+                  [ IsCapCategory, IsList ] );
+
+
 #! @Chapter Universal Objects
 
 ####################################

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4684,6 +4684,14 @@ DeclareOperation( "TruthMorphismIntoSubobjectClassifier",
 DeclareOperation( "ClassifyingMorphismOfSubobject",
                   [ IsCapCategoryMorphism ] );
 
+#! @Description
+#! The arguments are a monomorphism $m : A \rightarrow S$ and
+#! a subobject classifier $\Omega$. The output is the classifying morphism 
+#! of the monomorphism $\chi_m : S \rightarrow \mathrm{SubobjectClassifier}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{Range}(m) , \mathrm{SubobjectClassifier} )$
+#! @Arguments m, omega
+DeclareOperation( "ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
+                  [ IsCapCategoryMorphism , IsCapCategoryObject ] );
 
 
 
@@ -4726,6 +4734,26 @@ DeclareOperation( "AddClassifyingMorphismOfSubobject",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddClassifyingMorphismOfSubobject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$ to the category
+#! for the basic operation <C>ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier</C>.
+#! $F : (m, \Omega) \mapsto \mathrm{ClassifyingMorphism}(m)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
+                  [ IsCapCategory , IsFunction ] );
+
+DeclareOperation( "AddClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+## don't document this function
+DeclareOperation( "AddClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
                   [ IsCapCategory, IsList ] );
 
 

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -988,6 +988,19 @@ InstallMethod( InverseMorphismFromCoimageToImage,
 end );
 
 ####################################
+## Subobject Classifier
+####################################
+
+InstallMethod( SubobjectClassifier,
+               [ IsCapCategoryCell ],
+               
+  function( cell )
+    
+    return SubobjectClassifier( CapCategory( cell ) );
+    
+end );
+
+####################################
 ##
 ## Scheme for Universal Object
 ##

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -991,6 +991,7 @@ end );
 ## Subobject Classifier
 ####################################
 
+##
 InstallMethod( SubobjectClassifier,
                [ IsCapCategoryCell ],
                
@@ -999,6 +1000,28 @@ InstallMethod( SubobjectClassifier,
     return SubobjectClassifier( CapCategory( cell ) );
     
 end );
+
+##
+InstallMethod( TruthMorphismIntoSubobjectClassifier,
+               [ IsCapCategory ],
+  function( category )
+      
+      return TruthMorphismIntoSubobjectClassifierWithGivenObjects(
+               TerminalObject(category),
+               SubobjectClassifier(category)
+             );
+      
+end );
+
+##
+InstallMethod( TruthMorphismIntoSubobjectClassifier,
+               [ IsCapCategoryCell ],
+  function( cell )
+    
+    return TruthMorphismIntoSubobjectClassifier( CapCategory( cell ) );
+    
+end );
+
 
 ####################################
 ##


### PR DESCRIPTION
Provides methods for the subobject classifier of a category.

1. In `UniversalObjects.gd`, declares the subobject classifier, the "true" morphism from the terminal object and the classifying morphism for a monomorphism.
2. In `UniversalObjects.gi`, implements the method `SubobjectClassifier` for a cell fo the category.
3. In `InstallAdds.gi`, creates functions similar to those of the terminal, initial and zero objects for the subobject classifier.
4. In `MethodRecord.gi`, adds records for these attributes.

The code will probably contain many obvious errors, as my knowledge of GAP is very limited. I will continue to improve this pull request, but a review would be really appreciated.