### PR TITLE
Bump version to 2018.08.31

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -14,6 +14,8 @@ Version := Maximum( [
   "2018.02.27", ## Sepp's version
   ## this line prevents merge conflicts
   "2018.08.15", ## Fabian's version
+  ## this line prevents merge conflicts
+  "2018.08.31", ## Mario's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},


### PR DESCRIPTION
Now that #180 is merged, bump the version so FinSetsForCAP
can depend on those changes.