### PR TITLE
Sanity check for computed_value in ApplyFunctor

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -374,6 +374,7 @@ BindGlobal( "EnableBasicOperationTypeCheck", EnablePartialBasicOperationTypeChec
 #!  are added to the category by their constructors.
 #! @Arguments C
 DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
+#! @Arguments C
 DeclareGlobalFunction( "EnableAddForCategoricalOperations" );
 #! @EndGroup
 

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -371,11 +371,10 @@ DeclareGlobalFunction( "EnableFullSanityChecks" );
 #! @EndGroup
 
 ## Undocumented, but kept for compatibility
-BindGlobal( "DisableBasicOperationTypeCheck", DisableInputSanityChecks );
-BindGlobal( "EnablePartialBasicOperationTypeCheck", EnablePartialInputSanityChecks );
-BindGlobal( "EnableFullBasicOperationTypeCheck", EnableFullInputSanityChecks );
-
-BindGlobal( "EnableBasicOperationTypeCheck", EnablePartialBasicOperationTypeCheck );
+DeclareGlobalFunction( "DisableBasicOperationTypeCheck" );
+DeclareGlobalFunction( "EnablePartialBasicOperationTypeCheck" );
+DeclareGlobalFunction( "EnableFullBasicOperationTypeCheck" );
+DeclareGlobalFunction( "EnableBasicOperationTypeCheck" );
 
 #############################################
 ##

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -340,24 +340,41 @@ DeclareGlobalFunction( "DeactivateCachingOfCategory" );
 
 ####################################
 ##
-#! @Section Type check
+#! @Section Sanity checks
 ##
 ####################################
 
 #! @BeginGroup
 #! @Description
-#!  Most operations have prefunctions, that perform additional checks on
-#!  the arguments. The checks can either be partial (enabled by default),
-#!  full, or disabled. With the following commands you can either
-#!  enable the full checks, just the basic checks, or, for performance,
-#!  disable the checks alltogether.
+#!  Most operations can perform optional sanity checks on their arguments and results.
+#!  The checks can either be partial (set by default), full, or disabled.
+#!  With the following commands you can either enable the full checks, the partial checks or, for performance, disable the checks altogether.
+#!  You can do this for input checks, output checks or for both at once.
 #! @Arguments category
-DeclareGlobalFunction( "DisableBasicOperationTypeCheck" );
-DeclareGlobalFunction( "EnablePartialBasicOperationTypeCheck" );
-DeclareGlobalFunction( "EnableFullBasicOperationTypeCheck" );
+DeclareGlobalFunction( "DisableInputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "DisableOutputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnablePartialInputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnablePartialOutputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnableFullInputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnableFullOutputSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "DisableSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnablePartialSanityChecks" );
+#! @Arguments category
+DeclareGlobalFunction( "EnableFullSanityChecks" );
 #! @EndGroup
 
 ## Undocumented, but kept for compatibility
+BindGlobal( "DisableBasicOperationTypeCheck", DisableInputSanityChecks );
+BindGlobal( "EnablePartialBasicOperationTypeCheck", EnablePartialInputSanityChecks );
+BindGlobal( "EnableFullBasicOperationTypeCheck", EnableFullInputSanityChecks );
+
 BindGlobal( "EnableBasicOperationTypeCheck", EnablePartialBasicOperationTypeCheck );
 
 #############################################

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -594,6 +594,60 @@ InstallGlobalFunction( "EnableFullSanityChecks" ,
     
 end );
 
+
+InstallGlobalFunction( "DisableBasicOperationTypeCheck",
+  function( category )
+    
+    Print(
+      Concatenation(
+      "WARNING: DisableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "Please use DisableInputSanityChecks( category ) instead.\n"
+      )
+    );
+    
+    DisableInputSanityChecks( category );
+    
+end );
+InstallGlobalFunction( "EnablePartialBasicOperationTypeCheck",
+  function( category )
+    
+    Print(
+      Concatenation(
+      "WARNING: EnablePartialBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "Please use EnablePartialInputSanityChecks( category ) instead.\n"
+      )
+    );
+    
+    EnablePartialInputSanityChecks( category );
+    
+end );
+InstallGlobalFunction( "EnableFullBasicOperationTypeCheck",
+  function( category )
+    
+    Print(
+      Concatenation(
+      "WARNING: EnableFullBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "Please use EnableFullInputSanityChecks( category ) instead.\n"
+      )
+    );
+    
+    EnableFullInputSanityChecks( category );
+    
+end );
+InstallGlobalFunction( "EnableBasicOperationTypeCheck",
+  function( category )
+    
+    Print(
+      Concatenation(
+      "WARNING: EnableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "Please use EnablePartialInputSanityChecks( category ) instead.\n"
+      )
+    );
+    
+    EnablePartialInputSanityChecks( category );
+    
+end );
+
 #######################################
 ##
 ## Logic

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -237,7 +237,8 @@ InstallGlobalFunction( "CREATE_CAP_CATEGORY_OBJECT",
     
     obj_rec!.default_cache_type := "weak";
     
-    obj_rec!.prefunction_check := 1;
+    obj_rec!.input_sanity_check_level := 1;
+    obj_rec!.output_sanity_check_level := 1;
     
     obj_rec!.predicate_logic := true;
     
@@ -531,31 +532,65 @@ end );
 
 ####################################
 ##
-## Type check
+## Sanity checks
 ##
 ####################################
-
-InstallGlobalFunction( DisableBasicOperationTypeCheck,
-  
+InstallGlobalFunction( "DisableInputSanityChecks",
   function( category )
     
-    category!.prefunction_check := 0;
+    category!.input_sanity_check_level := 0;
+    
+end );
+InstallGlobalFunction( "DisableOutputSanityChecks", 
+  function( category )
+    
+    category!.output_sanity_check_level := 0;
+    
+end );
+InstallGlobalFunction( "EnablePartialInputSanityChecks" ,
+  function( category )
+  
+    category!.input_sanity_check_level := 1;
+    
+end );
+InstallGlobalFunction( "EnablePartialOutputSanityChecks" ,
+  function( category )
+    
+    category!.output_sanity_check_level := 1;
+    
+end );
+InstallGlobalFunction( "EnableFullInputSanityChecks" ,
+  function( category )
+  
+    category!.input_sanity_check_level := 2;
+     
+end );
+InstallGlobalFunction( "EnableFullOutputSanityChecks" ,
+  function( category )
+    
+    category!.output_sanity_check_level := 2;
     
 end );
 
-InstallGlobalFunction( EnablePartialBasicOperationTypeCheck,
-  
+InstallGlobalFunction( "DisableSanityChecks" ,
   function( category )
-  
-    category!.prefunction_check := 1;
+    
+    DisableInputSanityChecks( category );
+    DisableOutputSanityChecks( category );
+     
+end );
+InstallGlobalFunction( "EnablePartialSanityChecks" ,
+  function( category )
+    
+    EnablePartialInputSanityChecks( category );
+    EnablePartialOutputSanityChecks( category );
     
 end );
-
-InstallGlobalFunction( EnableFullBasicOperationTypeCheck,
-  
+InstallGlobalFunction( "EnableFullSanityChecks" ,
   function( category )
-  
-    category!.prefunction_check := 2;
+    
+    EnableFullInputSanityChecks( category );
+    EnableFullOutputSanityChecks( category );
     
 end );
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -600,7 +600,7 @@ InstallGlobalFunction( "DisableBasicOperationTypeCheck",
     
     Print(
       Concatenation(
-      "WARNING: DisableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "WARNING: DisableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2020.02.27. ",
       "Please use DisableInputSanityChecks( category ) instead.\n"
       )
     );
@@ -613,7 +613,7 @@ InstallGlobalFunction( "EnablePartialBasicOperationTypeCheck",
     
     Print(
       Concatenation(
-      "WARNING: EnablePartialBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "WARNING: EnablePartialBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2020.02.27. ",
       "Please use EnablePartialInputSanityChecks( category ) instead.\n"
       )
     );
@@ -626,7 +626,7 @@ InstallGlobalFunction( "EnableFullBasicOperationTypeCheck",
     
     Print(
       Concatenation(
-      "WARNING: EnableFullBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "WARNING: EnableFullBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2020.02.27. ",
       "Please use EnableFullInputSanityChecks( category ) instead.\n"
       )
     );
@@ -639,7 +639,7 @@ InstallGlobalFunction( "EnableBasicOperationTypeCheck",
     
     Print(
       Concatenation(
-      "WARNING: EnableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2019.09.20. ",
+      "WARNING: EnableBasicOperationTypeCheck( category ) is deprecated and will not be supported after 2020.02.27. ",
       "Please use EnablePartialInputSanityChecks( category ) instead.\n"
       )
     );

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -433,12 +433,17 @@ InstallGlobalFunction( ApplyFunctor,
         computed_value := CallFuncList( FunctorObjectOperation( functor ), arguments );
 
         if range_category!.output_sanity_check_level > 0 then
+            if not IsCapCategoryObject( computed_value ) then
+                Error( Concatenation("the result of the object function of the functor \"", Name(functor), "\" does not lie in the IsCapCategoryObject filter." ) );
+            fi;
             if HasCapCategory( computed_value ) then
                 if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
                     Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
             else
-                Error( Concatenation("the result of the object function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                if not range_category!.add_primitive_output then
+                    Error( Concatenation("the result of the object function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                fi;
             fi;
         fi;
         
@@ -461,13 +466,19 @@ InstallGlobalFunction( ApplyFunctor,
         range_value := CallFuncList( ApplyFunctor, Concatenation( [ functor ], range_list ) );
         
         computed_value := CallFuncList( FunctorMorphismOperation( functor ), Concatenation( [ source_value ], arguments, [ range_value ] ) );
+
         if range_category!.output_sanity_check_level > 0 then
+            if not IsCapCategoryMorphism( computed_value ) then
+                Error( Concatenation("the result of the morphism function of the functor \"", Name(functor), "\" does not lie in the IsCapCategoryMorphism filter." ) );
+            fi;
             if HasCapCategory( computed_value ) then
                 if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
                     Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
             else
-                Error( Concatenation("the result of the morphism function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                if not range_category!.add_primitive_output then
+                    Error( Concatenation("the result of the morphism function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                fi;
             fi;
         fi;
 

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -437,6 +437,8 @@ InstallGlobalFunction( ApplyFunctor,
                 if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
                     Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
+            else
+                Error( Concatenation("The result of the object function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
             fi;
         fi;
         
@@ -464,6 +466,8 @@ InstallGlobalFunction( ApplyFunctor,
                 if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
                     Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
+            else
+                Error( Concatenation("The result of the morphism function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
             fi;
         fi;
 

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -405,7 +405,7 @@ InstallGlobalFunction( ApplyFunctor,
                
   function( arg )
     local functor, arguments, is_object, cache, cache_return, computed_value,
-          source_list, source_value, range_list, range_value, i, tmp, category;
+          source_list, source_value, range_list, range_value, i, tmp, range_category;
     
     functor := arg[ 1 ];
     
@@ -426,12 +426,17 @@ InstallGlobalFunction( ApplyFunctor,
          arguments[ 1 ] := Opposite( arguments[ 1 ] );
     fi;
     
+    range_category := AsCapCategory( Range( functor ) );
+    
     if IsCapCategoryObject( arguments[ 1 ] ) then
         
         computed_value := CallFuncList( FunctorObjectOperation( functor ), arguments );
-        if HasCapCategory( computed_value ) then
-            if not IsIdenticalObj( CapCategory( computed_value ), AsCapCategory( Range( functor ) ) ) then
-                Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+
+        if range_category!.output_sanity_check_level > 0 then
+            if HasCapCategory( computed_value ) then
+                if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
+                    Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+                fi;
             fi;
         fi;
         
@@ -454,9 +459,11 @@ InstallGlobalFunction( ApplyFunctor,
         range_value := CallFuncList( ApplyFunctor, Concatenation( [ functor ], range_list ) );
         
         computed_value := CallFuncList( FunctorMorphismOperation( functor ), Concatenation( [ source_value ], arguments, [ range_value ] ) );
-        if HasCapCategory( computed_value ) then
-            if not IsIdenticalObj( CapCategory( computed_value ), AsCapCategory( Range( functor ) ) ) then
-                Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+        if range_category!.output_sanity_check_level > 0 then
+            if HasCapCategory( computed_value ) then
+                if not IsIdenticalObj( CapCategory( computed_value ), range_category ) then
+                    Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+                fi;
             fi;
         fi;
 
@@ -466,11 +473,9 @@ InstallGlobalFunction( ApplyFunctor,
         
     fi;
     
-    category := AsCapCategory( Range( functor ) );
-    
-    if category!.add_primitive_output then
+    if range_category!.add_primitive_output then
         
-        Add( category, computed_value );
+        Add( range_category, computed_value );
         
     fi;
     

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -438,7 +438,7 @@ InstallGlobalFunction( ApplyFunctor,
                     Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
             else
-                Error( Concatenation("The result of the object function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                Error( Concatenation("the result of the object function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
             fi;
         fi;
         
@@ -467,7 +467,7 @@ InstallGlobalFunction( ApplyFunctor,
                     Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
                 fi;
             else
-                Error( Concatenation("The result of the morphism function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
+                Error( Concatenation("the result of the morphism function of the functor \"", Name(functor), "\" does not have a CAP category" ) );
             fi;
         fi;
 

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -429,6 +429,11 @@ InstallGlobalFunction( ApplyFunctor,
     if IsCapCategoryObject( arguments[ 1 ] ) then
         
         computed_value := CallFuncList( FunctorObjectOperation( functor ), arguments );
+        if HasCapCategory( computed_value ) then
+            if not IsIdenticalObj( CapCategory( computed_value ), AsCapCategory( Range( functor ) ) ) then
+                Error( Concatenation( "the category of the result of the object function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+            fi;
+        fi;
         
     elif IsCapCategoryMorphism( arguments[ 1 ] ) then
         
@@ -449,7 +454,12 @@ InstallGlobalFunction( ApplyFunctor,
         range_value := CallFuncList( ApplyFunctor, Concatenation( [ functor ], range_list ) );
         
         computed_value := CallFuncList( FunctorMorphismOperation( functor ), Concatenation( [ source_value ], arguments, [ range_value ] ) );
-        
+        if HasCapCategory( computed_value ) then
+            if not IsIdenticalObj( CapCategory( computed_value ), AsCapCategory( Range( functor ) ) ) then
+                Error( Concatenation( "the category of the result of the morphism function of the functor \"", Name(functor), "\" does not coincide with the range of this functor" ) );
+            fi;
+        fi;
+
     else
         
         Error( "Second argument of ApplyFunctor must be a category cell" );

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -271,6 +271,11 @@ InstallMethod( \=,
                
   function( morphism_1, morphism_2 )
     
+    if CapCategory( morphism_1 )!.input_sanity_check_level > 0 or CapCategory( morphism_2 )!.input_sanity_check_level > 0  then
+        if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
+            Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
+        fi;
+    fi;
     if not IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) ) or not IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) ) then
         
         return false;

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -70,8 +70,16 @@ end );
 ##
 InstallMethod( \=,
                [ IsCapCategoryObject, IsCapCategoryObject ],
+  function( object_1, object_2 )
+
+    if CapCategory( object_1 )!.input_sanity_check_level > 0 or CapCategory( object_2 )!.input_sanity_check_level > 0  then
+        if not IsIdenticalObj( CapCategory( object_1 ), CapCategory( object_2 ) ) then
+            Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" do not belong to the same CAP category" ) );
+        fi;
+    fi;
                
-  IsEqualForObjects );
+  return IsEqualForObjects( object_1, object_2 );
+end );
 
 ##
 InstallGlobalFunction( INSTALL_TODO_LIST_FOR_EQUAL_OBJECTS,

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -255,7 +255,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     fi;
                 fi;
                 
-                if not is_pair_func and category!.prefunction_check > 0 then
+                if not is_pair_func and category!.input_sanity_check_level > 0 then
                     
                     pre_func_return := CallFuncList( pre_function, arg );
                     if pre_func_return[ 1 ] = false then
@@ -264,7 +264,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                             Name( category ), ":\033[0m\n\033[1m       ", pre_func_return[ 2 ], "\033[0m\n" ) );
                     fi;
                     
-                    if category!.prefunction_check > 1 then
+                    if category!.input_sanity_check_level > 1 then
                         pre_func_return := CallFuncList( pre_function_full, arg );
                         if pre_func_return[ 1 ] = false then
                             Error( Concatenation( "in function \033[1m", record.function_name, 


### PR DESCRIPTION
This adds a sanity check for `computed_value` in `ApplyFunctor`. Without these changes faulty object/morphism functions might lead to errors when

`Add( AsCapCategory( Range( functor ) ), computed_value );`

is executed later on, which would throw an error that might not be very helpful for users.


