### PR TITLE
Preliminary support for cartesian closed and cocartesian coclosed categories

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2018.08.03", ## Mohamed's version
+  "2018.09.02", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -59,6 +59,8 @@ InstallValue( CAP_INTERNAL_CATEGORICAL_PROPERTIES_LIST,
     [ "IsSymmetricMonoidalCategory" ],
     [ "IsSymmetricClosedMonoidalCategory" ],
     [ "IsRigidSymmetricClosedMonoidalCategory" ],
+    [ "IsCartesianClosedCategory" ],
+    [ "IsCoCartesianCoclosedCategory" ],
     [ "IsStrictMonoidalCategory" ],
     [ "IsAbelianCategoryWithEnoughProjectives", "IsAbelianCategoryWithEnoughInjectives" ]
   ]

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -31,6 +31,10 @@ InstallTrueMethod( IsSymmetricMonoidalCategory, IsSymmetricClosedMonoidalCategor
 
 InstallTrueMethod( IsSymmetricClosedMonoidalCategory, IsRigidSymmetricClosedMonoidalCategory );
 
+InstallTrueMethod( IsSymmetricClosedMonoidalCategory, IsCartesianClosedCategory );
+
+InstallTrueMethod( IsSymmetricClosedMonoidalCategory, IsCoCartesianCoclosedCategory );
+
 ######################################
 ##
 ## Technical stuff

--- a/CAP/gap/MonoidalCategoriesDerivedMethods.gi
+++ b/CAP/gap/MonoidalCategoriesDerivedMethods.gi
@@ -1225,6 +1225,86 @@ AddDerivationToCAP( InverseMorphismFromCoimageToImageWithGivenObjects,
 end : CategoryFilter := IsAbelianCategory,
       Description := "InverseMorphismFromCoimageToImageWithGivenObjects as the inverse of MorphismFromCoimageToImage" );
 
+##
+AddDerivationToCAP( TensorProductOnObjects,
+                    
+  function( arg )
+    
+    return CallFuncList( DirectProduct, arg );
+    
+end : Description := "TensorProductOnObjects is DirectProduct",
+      CategoryFilter := IsCartesianClosedCategory );
+
+##
+AddDerivationToCAP( TensorProductOnMorphismsWithGivenTensorProducts,
+                    
+  function( s, alpha, beta, r )
+    
+    return DirectProductFunctorialWithGivenDirectProducts( s, [ alpha, beta ], r );
+    
+end : Description := "TensorProductOnMorphisms is DirectProductFunctorial",
+      CategoryFilter := IsCartesianClosedCategory );
+
+##
+AddDerivationToCAP( TensorUnit,
+                    
+  function( arg )
+    
+    return CallFuncList( TerminalObject, arg );
+    
+end : Description := "TensorUnit is TerminalObject",
+      CategoryFilter := IsCartesianClosedCategory );
+
+##
+AddDerivationToCAP( AssociatorLeftToRightWithGivenTensorProducts,
+                    
+  function( s, a, b, c, r )
+    
+    return AssociatorLeftToRightOfDirectProductsWithGivenDirectProducts( s, a, b, c, r );
+    
+end : Description := "AssociatorLeftToRight is AssociatorLeftToRightOfDirectProducts",
+      CategoryFilter := IsCartesianClosedCategory );
+
+##
+AddDerivationToCAP( AssociatorRightToLeftWithGivenTensorProducts,
+                    
+  function( s, a, b, c, r )
+    
+    return AssociatorRightToLeftOfDirectProductsWithGivenDirectProducts( s, a, b, c, r );
+    
+end : Description := "AssociatorRightToLeft is AssociatorRightToLeftOfDirectProducts",
+      CategoryFilter := IsCartesianClosedCategory );
+
+##
+AddDerivationToCAP( TensorProductOnObjects,
+                    
+  function( arg )
+    
+    return CallFuncList( Coproduct, arg );
+    
+end : Description := "TensorProductOnObjects is Coproduct",
+      CategoryFilter := IsCoCartesianCoclosedCategory );
+
+##
+AddDerivationToCAP( TensorProductOnMorphismsWithGivenTensorProducts,
+                    
+  function( s, alpha, beta, r )
+    
+    return CoproductFunctorialWithGivenCoproducts( s, [ alpha, beta ], r );
+    
+end : Description := "TensorProductOnMorphisms is CoproductFunctorial",
+      CategoryFilter := IsCoCartesianCoclosedCategory );
+
+##
+AddDerivationToCAP( TensorUnit,
+                    
+  function( arg )
+    
+    return CallFuncList( InitialObject, arg );
+    
+end : Description := "TensorUnit is InitialObject",
+      CategoryFilter := IsCoCartesianCoclosedCategory );
+
 ####################################
 ## Final derived methods
 ####################################


### PR DESCRIPTION
This will probably be outsourced to a package `Toposes` in the future, but I had to do this now since I am starting to use this code in two different independent packages `FinSetsForCAP` and `Locales`.
