### PR TITLE
Fix MorphismBetweenDirectSums in opposite category

### DIFF
--- a/CAP/examples/testfiles/OppositeCategory.gi
+++ b/CAP/examples/testfiles/OppositeCategory.gi
@@ -1,0 +1,29 @@
+#! @Chapter Examples and Tests
+
+#! @Section Opposite category
+LoadPackage( "LinearAlgebraForCAP" );
+
+#! @Example
+QQ := HomalgFieldOfRationals();;
+vec := MatrixCategory( QQ );;
+V1 := Opposite( TensorUnit( vec ) );;
+V2 := DirectSum( V1, V1 );;
+V3 := DirectSum( V1, V2 );;
+V4 := DirectSum( V1, V3 );;
+V5 := DirectSum( V1, V4 );;
+alpha13 := InjectionOfCofactorOfDirectSum( [ V1, V2 ], 1 );;
+alpha14 := InjectionOfCofactorOfDirectSum( [ V1, V2, V1 ], 3 );;
+alpha15 := InjectionOfCofactorOfDirectSum( [ V2, V1, V2 ], 2 );;
+alpha23 := InjectionOfCofactorOfDirectSum( [ V2, V1 ], 1 );;
+alpha24 := InjectionOfCofactorOfDirectSum( [ V1, V2, V1 ], 2 );;
+alpha25 := InjectionOfCofactorOfDirectSum( [ V2, V2, V1 ], 1 );;
+mat := [
+    [ alpha13, alpha14, alpha15 ],
+    [ alpha23, alpha24, alpha25 ]
+];;
+mor := MorphismBetweenDirectSums( mat );;
+IsWellDefined( mor );
+#! true
+IsWellDefined( Opposite( mor ) );
+#! true
+#! @EndExample

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2896,8 +2896,7 @@ MorphismBetweenDirectSums := rec(
   io_type := [ [ "S", "mat", "T" ], [ "S", "T" ] ],
   cache_name := "MorphismBetweenDirectSums",
   return_type := "morphism",
-  dual_operation := "MorphismBetweenDirectSums",
-  dual_arguments_reversed := true
+  dual_operation := "MorphismBetweenDirectSums"
 ),
   ) );
 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -209,24 +209,13 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
   
   function( opposite_category, category )
     local recnames, current_recname, category_weight_list, dual_name, current_entry, func,
-          current_add, create_func, create_func_with_category_input;
+          current_add, create_func, create_func_with_category_input, morphism_between_direct_sums_func;
     
     recnames := RecNames( CAP_INTERNAL_METHOD_NAME_RECORD );
     
     category_weight_list := category!.derivations_weight_list;
     
-    create_func := function( dual_name, arg... )
-        local list_operation;
-        
-        if IsBound( arg[1] ) and arg[1] = true then
-            
-            list_operation := Reversed;
-            
-        else
-            
-            list_operation := IdFunc;
-            
-        fi;
+    create_func := function( dual_name, list_operation )
         
         return function( arg )
             local op_arg, result;
@@ -288,13 +277,21 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
             
             func := create_func_with_category_input( dual_name );
             
+        elif current_recname = "MorphismBetweenDirectSums" then
+            
+            morphism_between_direct_sums_func := function( list )
+                return [ list[3], TransposedMat( list[2] ), list[1] ];
+            end;
+            
+            func := create_func( dual_name, morphism_between_direct_sums_func );
+            
         elif current_entry.dual_arguments_reversed then
             
-            func := create_func( dual_name, true );
+            func := create_func( dual_name, Reversed );
             
         else
             
-            func := create_func( dual_name );
+            func := create_func( dual_name, IdFunc );
             
         fi;
         

--- a/CAP/makedoc.g
+++ b/CAP/makedoc.g
@@ -8,6 +8,7 @@ AutoDoc( "CAP" : scaffold := true, autodoc :=
                               "LoadPackage( \"IO_ForHomalg\" );",
                               "LoadPackage( \"GaussForHomalg\" );",
                               "LoadPackage( \"ModulePresentationsForCAP\" );",
+                              "LoadPackage( \"LinearAlgebraForCAP\" );",
                               "LoadPackage( \"RingsForHomalg\" );",
                               "LoadPackage( \"HomologicalAlgebraForCAP\" );",
                               "LoadPackage( \"DeductiveSystemForCAP\" );",


### PR DESCRIPTION
`MorphismBetweenDirectSums` in the opposite category
needs a special treatment: the arguments have to be reversed
and the given matrix has to be transposed.