### PR TITLE
Revert "Test FinSetsForCAP and FinGSetsForCAP in CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,22 +12,8 @@ jobs:
           sudo apt install -y texlive-latex-extra texlive-science curl
           cd ..
           git clone --depth 1 https://github.com/homalg-project/homalg_project
-          
           cd CAP_project
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
           sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g
           make ci-test
-          cd ..
-          
-          git clone --depth 1 https://github.com/homalg-project/FinSetsForCAP.git
-          cd FinSetsForCAP
-          make ci-test
-          cd ..
-          
-          git clone --depth 1 https://github.com/homalg-project/FinGSetsForCAP.git
-          cd FinGSetsForCAP
-          make ci-test
-          cd ..
-          
-          cd CAP_project
           bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
After some discussions we decided against this addition for the following reasons:
* the tests are not reproducible locally
* the tests might fail for reasons which are not related to CAP itself
* for external contributors its hard to interpret test failures

There are two possible solutions for testing external packages together with CAP:
* import the external packages into CAP_project (planned for `FinSetsForCAP` and `FinGSetsForCAP`)
* reference them via a submodule