### PR TITLE
generic IsEqualForMorphisms and IsCongruentForMorphisms

### DIFF
--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -223,6 +223,34 @@ end );
 ##
 ######################################
 
+# This method should usually not be selected when the two morphisms belong to the same category
+InstallMethod( IsEqualForMorphisms,
+                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+
+  function( morphism_1, morphism_2 )
+    
+    if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
+    else
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsEqualForMorphisms is installed" ) );
+    fi;
+    
+end );
+
+# This method should usually not be selected when the two morphisms belong to the same category
+InstallMethod( IsCongruentForMorphisms,
+                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+
+  function( morphism_1, morphism_2 )
+    
+    if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
+    else
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsCongruentForMorphisms is installed" ) );
+    fi;
+    
+end );
+
 ##
 InstallMethod( \=,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -232,7 +232,7 @@ InstallMethod( IsEqualForMorphisms,
     if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
         Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsEqualForMorphisms is installed" ) );
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsEqualForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
     fi;
     
 end );
@@ -246,7 +246,7 @@ InstallMethod( IsCongruentForMorphisms,
     if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
         Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsCongruentForMorphisms is installed" ) );
+        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsCongruentForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
     fi;
     
 end );

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -46,6 +46,20 @@ InstallValue( PROPAGATION_LIST_FOR_EQUAL_OBJECTS,
 ##
 ###################################
 
+# This method should usually not be selected when the two morphisms belong to the same category
+InstallMethod( IsEqualForObjects,
+                [ IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2 )
+    
+    if not IsIdenticalObj( CapCategory( object_1 ), CapCategory( object_2 ) ) then
+        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" do not belong to the same CAP category" ) );
+    else
+        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" belong to the same CAP category, but no specific method IsEqualForObjects is installed." ) );
+    fi;
+    
+end );
+
 ##
 InstallMethod( \=,
                [ IsCapCategoryObject, IsCapCategoryObject ],

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -55,7 +55,7 @@ InstallMethod( IsEqualForObjects,
     if not IsIdenticalObj( CapCategory( object_1 ), CapCategory( object_2 ) ) then
         Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" belong to the same CAP category, but no specific method IsEqualForObjects is installed." ) );
+        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" belong to the same CAP category, but no specific method IsEqualForObjects is installed. Maybe you forgot to finalize the category?" ) );
     fi;
     
 end );


### PR DESCRIPTION
These methods are meant to provide helpful error messages if called with morphisms belonging to different CAP categories or, which should normally not happen, no specific methods `IsEqualForMorphisms` and `IsCongruentForMorphisms` are installed.