### PR TITLE
Detect more errors in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
       - image: gapsystem/gap-docker:latest
     working_directory: ~/.gap/pkg/CAP_project
@@ -18,3 +18,19 @@ jobs:
           sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g
           make ci-test
           bash <(curl -s https://codecov.io/bash)
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - test
+  nightly:
+    triggers:
+      - schedule:
+          # 0:00 UTC = 1:00 CET = 2:00 CEST
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
           git clone --depth 1 https://github.com/homalg-project/homalg_project.git
           cd CAP_project
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
+          echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g
           make ci-test
           bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           sudo apt dist-upgrade -y
           sudo apt install -y texlive-latex-extra texlive-science curl
           cd ..
-          git clone --depth 1 https://github.com/homalg-project/homalg_project
+          git clone --depth 1 https://github.com/homalg-project/homalg_project.git
           cd CAP_project
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
           sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g

--- a/CAP/makefile
+++ b/CAP/makefile
@@ -17,7 +17,7 @@ test:	doc
 test-with-coverage:	doc
 	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
 	echo "$$OUTPUT"; \
-	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/CAP/makefile
+++ b/CAP/makefile
@@ -15,7 +15,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
+++ b/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
@@ -48,7 +48,7 @@ Persons := [
   ),
 ],
 
-PackageWWWHome := "",
+PackageWWWHome := "http://TODO/",
 
 ArchiveURL     := Concatenation( ~.PackageWWWHome, "ComplexesAndFilteredObjectsForCAP-", ~.Version ),
 README_URL     := Concatenation( ~.PackageWWWHome, "README" ),

--- a/GeneralizedMorphismsForCAP/makefile
+++ b/GeneralizedMorphismsForCAP/makefile
@@ -17,7 +17,7 @@ test:	doc
 test-with-coverage:	doc
 	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
 	echo "$$OUTPUT"; \
-	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/GeneralizedMorphismsForCAP/makefile
+++ b/GeneralizedMorphismsForCAP/makefile
@@ -15,7 +15,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/LinearAlgebraForCAP/makefile
+++ b/LinearAlgebraForCAP/makefile
@@ -17,7 +17,7 @@ test:	doc
 test-with-coverage:	doc
 	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
 	echo "$$OUTPUT"; \
-	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/LinearAlgebraForCAP/makefile
+++ b/LinearAlgebraForCAP/makefile
@@ -15,7 +15,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/ModulePresentationsForCAP/makefile
+++ b/ModulePresentationsForCAP/makefile
@@ -17,7 +17,7 @@ test:	doc
 test-with-coverage:	doc
 	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
 	echo "$$OUTPUT"; \
-	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/ModulePresentationsForCAP/makefile
+++ b/ModulePresentationsForCAP/makefile
@@ -15,7 +15,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage


### PR DESCRIPTION
* If banners are disabled, any output except "Running list..." is a warning or an error. In contrast to the old approach this also catches syntax warnings and syntax errors.
* If packages fail to load, `SetInfoLevel(InfoPackageLoading, 3);` makes it easier to find the culprit.