### PR TITLE
Hom structures as a CAP-operation

### DIFF
--- a/CAP/examples/testfiles/FieldAsCategory.gi
+++ b/CAP/examples/testfiles/FieldAsCategory.gi
@@ -1,0 +1,234 @@
+LoadPackage( "LinearAlgebraForCAP" );
+
+##
+DeclareCategory( "IsFieldAsCategoryObject",
+                 IsCapCategoryObject );
+
+DeclareCategory( "IsFieldAsCategoryMorphism",
+                 IsCapCategoryMorphism );
+
+DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY" );
+
+DeclareCategory( "IsFieldAsCategory",
+                 IsCapCategory );
+
+## Constructors
+DeclareAttribute( "FieldAsCategory",
+                  IsFieldForHomalg );
+
+DeclareAttribute( "FieldAsCategoryUniqueObject",
+                  IsFieldAsCategory );
+
+DeclareOperation( "FieldAsCategoryMorphism",
+                  [ IsRingElement, IsFieldAsCategory ] );
+
+## Attributes
+DeclareAttribute( "UnderlyingFieldElement",
+                  IsFieldAsCategoryMorphism );
+
+DeclareAttribute( "UnderlyingFieldForHomalg",
+                  IsFieldAsCategory );
+
+## Constructors
+
+##
+InstallMethod( FieldAsCategory,
+               [ IsFieldForHomalg ],
+               
+  function( field )
+    local category;
+    
+    category := CreateCapCategory( Concatenation( "Field as category( ", RingName( field )," )"  ) );
+    
+    SetFilterObj( category, IsFieldAsCategory );
+    
+    SetIsAbCategory( category, true );
+    
+    SetUnderlyingFieldForHomalg( category, field );
+    
+    SetRangeCategoryOfHomomorphismStructure( category, MatrixCategory( field ) );
+    
+    AddObjectRepresentation( category, IsFieldAsCategoryObject );
+    
+    AddMorphismRepresentation( category, IsFieldAsCategoryMorphism );
+
+    DisableAddForCategoricalOperations( category );
+    
+    INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY( category );
+    
+    Finalize( category );
+    
+    return category;
+    
+end );
+
+##
+InstallMethod( FieldAsCategoryUniqueObject,
+               [ IsFieldAsCategory ],
+               
+  function( category )
+    local unique_object;
+    
+    unique_object := rec( );
+    
+    ObjectifyObjectForCAPWithAttributes( unique_object, 
+                                         category
+    );
+    
+    Add( category, unique_object );
+    
+    return unique_object;
+    
+end );
+
+##
+InstallMethod( FieldAsCategoryMorphism,
+               [ IsRingElement, IsFieldAsCategory ],
+               
+  function( element, category )
+    local morphism, unique_object;
+    
+    morphism := rec( );
+    
+    unique_object := FieldAsCategoryUniqueObject( category );
+    
+    ObjectifyMorphismForCAPWithAttributes( morphism, category,
+                                           Source, unique_object,
+                                           Range, unique_object,
+                                           UnderlyingFieldElement, element
+    );
+    
+    Add( category, morphism );
+    
+    return morphism;
+    
+end );
+
+##
+InstallMethod( ViewObj,
+               [ IsFieldAsCategoryMorphism ],
+
+  function( alpha )
+
+    Print( String( UnderlyingFieldElement( alpha ) ) );
+
+end );
+
+## Basic operations
+
+InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY,
+  
+  function( category )
+    local field, vec, tunit;
+    
+    field := UnderlyingFieldForHomalg( category );
+    
+    ##
+    AddIsEqualForCacheForObjects( category,
+      IsIdenticalObj );
+    
+    ##
+    AddIsEqualForCacheForMorphisms( category,
+      IsIdenticalObj );
+    
+    ##
+    AddIsEqualForObjects( category,
+      function( a, b )
+      
+        return true;
+      
+    end );
+    
+    ##
+    AddIsEqualForMorphisms( category,
+      function( alpha, beta )
+        
+        return UnderlyingFieldElement( alpha ) = UnderlyingFieldElement( beta );
+        
+    end );
+    
+    ##
+    AddPreCompose( category,
+      function( alpha, beta )
+            
+        return FieldAsCategoryMorphism( 
+            UnderlyingFieldElement( alpha ) * UnderlyingFieldElement( beta ),
+            category
+        );
+            
+    end );
+    
+    ##
+    AddIdentityMorphism( category,
+      function( a )
+        
+        return FieldAsCategoryMorphism(
+            One( field ),
+            category
+        );
+        
+    end );
+    
+    ##
+    AddAdditionForMorphisms( category,
+      function( alpha, beta )
+            
+        return FieldAsCategoryMorphism( 
+            UnderlyingFieldElement( alpha ) + UnderlyingFieldElement( beta ),
+            category
+        );
+            
+    end );
+    
+    vec := RangeCategoryOfHomomorphismStructure( category );
+    
+    tunit := TensorUnit( vec );
+    
+    ## Homomorphism structure
+    AddHomomorphismStructureOnObjects( category,
+      function( a, b )
+        
+        return tunit;
+        
+    end );
+    
+    AddHomomorphismStructureOnMorphismsWithGivenObjects( category,
+      function( source, alpha, beta, range )
+        
+        return VectorSpaceMorphism( 
+            tunit,
+            HomalgMatrix( [ [ UnderlyingFieldElement( alpha ) * UnderlyingFieldElement( beta ) ] ], 1, 1, field ),
+            tunit
+        );
+        
+    end );
+    
+    AddDistinguishedObjectOfHomomorphismStructure( category,
+      function()
+        
+        return tunit;
+        
+    end );
+    
+    AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
+      function( alpha )
+        
+        return VectorSpaceMorphism(
+            tunit,
+            HomalgMatrix( [ [ UnderlyingFieldElement( alpha ) ] ], 1, 1, field ),
+            tunit
+        );
+        
+    end );
+    
+    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( category,
+      function( a, b, mor )
+        
+        return FieldAsCategoryMorphism(
+            EntriesOfHomalgMatrix( UnderlyingMatrix( mor ) )[1],
+            category
+        );
+        
+    end );
+    
+end );

--- a/CAP/examples/testfiles/FieldAsCategory.gi
+++ b/CAP/examples/testfiles/FieldAsCategory.gi
@@ -210,7 +210,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY,
         
     end );
     
-    AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
+    AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
       function( alpha )
         
         return VectorSpaceMorphism(
@@ -221,7 +221,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY,
         
     end );
     
-    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( category,
+    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism( category,
       function( a, b, mor )
         
         return FieldAsCategoryMorphism(

--- a/CAP/examples/testfiles/HomStructureTest.gi
+++ b/CAP/examples/testfiles/HomStructureTest.gi
@@ -1,0 +1,39 @@
+#! @Chapter Examples and Tests
+
+#! @Section Homomorphism structure
+
+#! @Example
+ReadPackage( "CAP", "examples/testfiles/FieldAsCategory.gi" );;
+Q := HomalgFieldOfRationals();;
+Qoid := FieldAsCategory( Q );;
+a := FieldAsCategoryMorphism( 1/2, Qoid );;
+b := FieldAsCategoryMorphism( -2/3, Qoid );;
+u := FieldAsCategoryUniqueObject( Qoid );;
+IsCongruentForMorphisms( a,
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+        u,u,
+        InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( 
+            a
+        )
+    )
+);
+#! true
+c := FieldAsCategoryMorphism( 3, Qoid );;
+d := FieldAsCategoryMorphism( 0, Qoid );;
+left_coeffs := [ [ a, b ], [ c, d ] ];;
+right_coeffs := [ [ PreCompose( a, b ), PreCompose( b, c ) ], [ c, PreCompose( a, a ) ] ];;
+right_side := [ a, b ];;
+solution := 
+    SolveLinearSystemInAbCategory(
+    left_coeffs,
+    right_coeffs,
+    right_side
+);;
+ForAll( [ 1, 2 ], i ->
+    IsCongruentForMorphisms(
+        Sum( List( [ 1, 2 ], j -> PreCompose( [ left_coeffs[i][j], solution[j], right_coeffs[i][j] ] ) ) ),
+        right_side[i]
+    )
+);
+#! true
+#! @EndExample

--- a/CAP/examples/testfiles/HomStructureTest.gi
+++ b/CAP/examples/testfiles/HomStructureTest.gi
@@ -10,9 +10,9 @@ a := FieldAsCategoryMorphism( 1/2, Qoid );;
 b := FieldAsCategoryMorphism( -2/3, Qoid );;
 u := FieldAsCategoryUniqueObject( Qoid );;
 IsCongruentForMorphisms( a,
-    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism(
         u,u,
-        InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( 
+        InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( 
             a
         )
     )

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -244,6 +244,10 @@ DeclareAttribute( "TwoCellFilter",
 DeclareAttribute( "CommutativeRingOfLinearCategory",
                   IsCapCategory );
 
+##
+DeclareAttribute( "RangeCategoryOfHomomorphismStructure",
+                  IsCapCategory );
+
 #############################################
 ##
 #! @Section Logic switcher

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1353,8 +1353,27 @@ DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStr
                   [ IsCapCategory, IsList ] );
 
 ##
-DeclareOperation( "SolveLinearSystemInAbCategory",
+DeclareOperation( "SolveLinearSystemInAbCategoryOp",
                    [ IsList, IsList, IsList, IsCapCategory ] );
+
+#! @Description
+#! The arguments are three lists $\alpha$, $\beta$, and $\gamma$.
+#! The first list $\alpha$ (the left coefficients) is a list of list of morphisms $\alpha_{ij}: A_i \rightarrow B_j$,
+#! where $i = 1 \dots m$ and $j = 1 \dots n$ for integers $m,n \geq 1$.
+#! The second list $\beta$ (the right coefficients) is a list of list of morphisms $\beta_{ij}: C_j \rightarrow D_i$,
+#! where $i = 1 \dots m$ and $j = 1 \dots n$.
+#! The third list $\gamma$ (the right side) is a list of morphisms $\gamma_i: A_i \rightarrow D_i$,
+#! where $i = 1, \dots, m$.
+#! The output is either
+#! a list of morphisms $X_j: B_j \rightarrow C_j$ for $j=1\dots n$ solving the linear system
+#! defined by $\alpha$, $\beta$, $\gamma$, i.e.,
+#! $\sum_{j = 1}^n \alpha_{ij}\cdot X_j \cdot \beta_{ij} = \gamma_i$
+#! for all $i = 1 \dots m$,
+#! or $\texttt{fail}$ if no such solution exists.
+#! @Returns a list of morphisms $[X_1, \dots, X_n]$
+#! @Arguments alpha, beta, gamma
+DeclareOperation( "SolveLinearSystemInAbCategory",
+                   [ IsList, IsList, IsList ] );
 
 DeclareOperation( "AddSolveLinearSystemInAbCategory",
                   [ IsCapCategory, IsFunction ] );

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1371,26 +1371,26 @@ DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
 #! $\nu( \alpha ): 1 \rightarrow H(a,a')$ in $D$ of the homomorphism structure.
 #! @Returns a morphism in $\mathrm{Hom}_{D}(1, H(a,a'))$
 #! @Arguments alpha
-DeclareAttribute( "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+DeclareAttribute( "InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   IsCapCategoryMorphism );
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operations adds the given function $F$ 
-#! to the category for the basic operation <C>InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure</C>.
+#! to the category for the basic operation <C>InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure</C>.
 #! $F: (\alpha: a \rightarrow a') \mapsto (\nu(\alpha):1 \rightarrow H(a,a'))$.
 #! @Returns nothing
 #! @Arguments C, F
-DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+DeclareOperation( "AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsFunction ] );
 
-DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+DeclareOperation( "AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsFunction, IsInt ] );
 
-DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+DeclareOperation( "AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsList, IsInt ] );
 
-DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+DeclareOperation( "AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsList ] );
 
 #! @Description
@@ -1401,26 +1401,26 @@ DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToH
 #! $\nu^{-1}(\iota): a \rightarrow a'$ in $C$ of the homomorphism structure.
 #! @Returns a morphism in $\mathrm{Hom}_{C}(a,a')$
 #! @Arguments a,a',iota
-DeclareOperation( "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+DeclareOperation( "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
                    [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operations adds the given function $F$ 
-#! to the category for the basic operation <C>InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism</C>.
+#! to the category for the basic operation <C>InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism</C>.
 #! $F: (a,a',\iota: 1 \rightarrow H(a,a')) \mapsto (\nu^{-1}(\iota): a \rightarrow a')$.
 #! @Returns nothing
 #! @Arguments C, F
-DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
                   [ IsCapCategory, IsFunction ] );
 
-DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
                   [ IsCapCategory, IsFunction, IsInt ] );
 
-DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
                   [ IsCapCategory, IsList, IsInt ] );
 
-DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
                   [ IsCapCategory, IsList ] );
 
 ##

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1261,3 +1261,109 @@ DeclareOperation( "AddIsEqualForCacheForMorphisms",
 DeclareOperation( "TransportHom",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism ] );
 
+###################################
+##
+#! @Section Homomorphism structures
+##
+###################################
+
+##
+DeclareOperation( "HomomorphismStructureOnObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+DeclareOperation( "AddHomomorphismStructureOnObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddHomomorphismStructureOnObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddHomomorphismStructureOnObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddHomomorphismStructureOnObjects",
+                  [ IsCapCategory, IsList ] );
+
+## the convenience method
+##
+DeclareOperation( "HomomorphismStructureOnMorphisms",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+##
+DeclareOperation( "HomomorphismStructureOnMorphismsWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+##
+DeclareAttribute( "DistinguishedObjectOfHomomorphismStructure",
+                  IsCapCategory );
+
+DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
+                  [ IsCapCategory, IsList ] );
+
+##
+DeclareAttribute( "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+                  IsCapCategoryMorphism );
+
+DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+                  [ IsCapCategory, IsList ] );
+
+##
+DeclareOperation( "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+                  [ IsCapCategory, IsList ] );
+
+##
+DeclareOperation( "SolveLinearSystemInAbCategory",
+                   [ IsList, IsList, IsList, IsCapCategory ] );
+
+DeclareOperation( "AddSolveLinearSystemInAbCategory",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSolveLinearSystemInAbCategory",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSolveLinearSystemInAbCategory",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSolveLinearSystemInAbCategory",
+                  [ IsCapCategory, IsList ] );

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1267,10 +1267,28 @@ DeclareOperation( "TransportHom",
 ##
 ###################################
 
-##
+#! Homomorphism structures are way to "oversee" the homomorphisms between two given objects.
+#! Let $C$, $D$ be categories.
+#! A $D$-homomorphism structure for $C$ consists of the following data:
+#! * a functor $H: C^{\mathrm{op}} \times C \rightarrow D$ (when $C$ and $D$ are Ab-categories, $H$ is assumed to be bilinear).
+#! * an object $1 \in D$, called the distinguished object,
+#! * a bijection $\nu: \mathrm{Hom}_{C}(a,b) \simeq \mathrm{Hom}_{D}(1, H(a,b))$ natural in $a,b \in C$.
+
+#! @Description
+#! The arguments are two objects $a, b$ in $C$.
+#! The output is the value of the homomorphism structure on objects $H(a,b)$.
+#! @Returns an object in $D$
+#! @Arguments a,b
 DeclareOperation( "HomomorphismStructureOnObjects",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>HomomorphismStructureOnObjects</C>.
+#! $F: (a,b) \mapsto H(a,b)$.
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddHomomorphismStructureOnObjects",
                   [ IsCapCategory, IsFunction ] );
 
@@ -1283,15 +1301,31 @@ DeclareOperation( "AddHomomorphismStructureOnObjects",
 DeclareOperation( "AddHomomorphismStructureOnObjects",
                   [ IsCapCategory, IsList ] );
 
-## the convenience method
-##
+#! @Description
+#! The arguments are two morphisms $\alpha: a \rightarrow a', \beta: b \rightarrow b'$ in $C$.
+#! The output is the value of the homomorphism structure on morphisms $H(\alpha, \beta )$.
+#! @Returns a morphism in $\mathrm{Hom}_{D}(H(a',b), H(a,b'))$
+#! @Arguments alpha, beta
 DeclareOperation( "HomomorphismStructureOnMorphisms",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
 
-##
+#! @Description
+#! The arguments are an object $s = H(a',b)$ in $D$,
+#! two morphisms $\alpha: a \rightarrow a', \beta: b \rightarrow b'$ in $C$,
+#! and an object $r = H(a,b')$ in $D$.
+#! The output is the value of the homomorphism structure on morphisms $H(\alpha, \beta )$.
+#! @Returns a morphism in $\mathrm{Hom}_{D}(H(a',b), H(a,b'))$
+#! @Arguments s, alpha, beta, r
 DeclareOperation( "HomomorphismStructureOnMorphismsWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
 
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>HomomorphismStructureOnMorphismsWithGivenObjects</C>.
+#! $F: ( s, \alpha: a \rightarrow a', \beta: b \rightarrow b', r ) \mapsto H( \alpha, \beta )$.
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
                   [ IsCapCategory, IsFunction ] );
 
@@ -1304,10 +1338,21 @@ DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
 DeclareOperation( "AddHomomorphismStructureOnMorphismsWithGivenObjects",
                   [ IsCapCategory, IsList ] );
 
-##
+#! @Description
+#! The argument is a category $C$.
+#! The output is the distinguished object $1$ in $D$ of the homomorphism structure.
+#! @Returns an object in $D$
+#! @Arguments C
 DeclareAttribute( "DistinguishedObjectOfHomomorphismStructure",
                   IsCapCategory );
 
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>DistinguishedObjectOfHomomorphismStructure</C>.
+#! $F: ( ) \mapsto 1$.
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
                   [ IsCapCategory, IsFunction ] );
 
@@ -1320,10 +1365,22 @@ DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
 DeclareOperation( "AddDistinguishedObjectOfHomomorphismStructure",
                   [ IsCapCategory, IsList ] );
 
-##
+#! @Description
+#! The argument is a morphism  $\alpha: a \rightarrow a'$ in $C$.
+#! The output is the corresponding morphism
+#! $\nu( \alpha ): 1 \rightarrow H(a,a')$ in $D$ of the homomorphism structure.
+#! @Returns a morphism in $\mathrm{Hom}_{D}(1, H(a,a'))$
+#! @Arguments alpha
 DeclareAttribute( "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   IsCapCategoryMorphism );
 
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure</C>.
+#! $F: (\alpha: a \rightarrow a') \mapsto (\nu(\alpha):1 \rightarrow H(a,a'))$.
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsFunction ] );
 
@@ -1336,10 +1393,24 @@ DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToH
 DeclareOperation( "AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
                   [ IsCapCategory, IsList ] );
 
-##
+#! @Description
+#! The arguments are
+#! objects $a,a'$ in $C$
+#! and a morphism $\iota: 1 \rightarrow H(a,a')$ in $D$.
+#! The output is the corresponding morphism
+#! $\nu^{-1}(\iota): a \rightarrow a'$ in $C$ of the homomorphism structure.
+#! @Returns a morphism in $\mathrm{Hom}_{C}(a,a')$
+#! @Arguments a,a',iota
 DeclareOperation( "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
                    [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
 
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism</C>.
+#! $F: (a,a',\iota: 1 \rightarrow H(a,a')) \mapsto (\nu^{-1}(\iota): a \rightarrow a')$.
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
                   [ IsCapCategory, IsFunction ] );
 

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -409,6 +409,20 @@ InstallMethod( PostCompose,
     
 end );
 
+##
+InstallMethod( HomomorphismStructureOnMorphisms,
+               [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+               
+  function( alpha, beta )
+    
+    return HomomorphismStructureOnMorphismsWithGivenObjects(
+             HomomorphismStructureOnObjects( Range( alpha ), Source( beta ) ),
+             alpha, beta,
+             HomomorphismStructureOnObjects( Source( alpha ), Range( beta ) )
+           );
+    
+end );
+
 ######################################
 ##
 ## Morphism transport

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -423,6 +423,16 @@ InstallMethod( HomomorphismStructureOnMorphisms,
     
 end );
 
+##
+InstallMethod( SolveLinearSystemInAbCategory,
+               [ IsList, IsList, IsList ],
+               
+  function( left_coeffs, right_coeffs, right_side )
+    
+    return SolveLinearSystemInAbCategoryOp( left_coeffs, right_coeffs, right_side, CapCategory( right_side[1] ) );
+    
+end );
+
 ######################################
 ##
 ## Morphism transport

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2274,7 +2274,89 @@ AddDerivationToCAP( IsEqualForCacheForObjects,
     
 end );
 
+###########################
+##
+## Methods involving homomorphism structures
+##
+###########################
 
+##
+AddDerivationToCAP( SolveLinearSystemInAbCategory,
+                    [ [ InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure, 1 ],
+                      [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
+                      [ HomomorphismStructureOnObjects, 1 ],
+                      [ InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism, 1 ] ],
+  function( left_coefficients, right_coefficients, right_side )
+    local m, n, nu, H, lift, summands, list;
+    
+    m := Size( left_coefficients );
+    
+    n := Size( left_coefficients[1] );
+    
+    ## create lift diagram
+    
+    nu :=
+      UniversalMorphismIntoDirectSum(
+        List( [ 1 .. m ],
+        i -> InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( right_side[i] ) )
+    );
+    
+    list := 
+      List( [ 1 .. n ],
+      j -> List( [ 1 .. m ], i -> HomomorphismStructureOnMorphisms( left_coefficients[i][j], right_coefficients[i][j] ) ) 
+    );
+    
+    H := MorphismBetweenDirectSums( list );
+    
+    ## the actual computation of the solution
+    lift := Lift( nu, H );
+    
+    if lift = fail then
+        
+        return fail;
+        
+    fi;
+    
+    ## reinterpretation of the solution
+    summands := List( [ 1 .. n ], j -> HomomorphismStructureOnObjects( Range( left_coefficients[1][j] ), Source( right_coefficients[1][j] ) ) );
+    
+    return
+      List( [ 1 .. n ], j -> 
+        InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+          Range( left_coefficients[1][j] ),
+          Source( right_coefficients[1][j] ),
+          PreCompose( lift, ProjectionInFactorOfDirectSum( summands, j ) )
+        )
+      );
+  end :
+  ConditionsListComplete := true,
+  CategoryFilter := function( cat )
+    local B, conditions;
+    
+    if HasRangeCategoryOfHomomorphismStructure( cat ) then
+        
+        B := RangeCategoryOfHomomorphismStructure( cat );
+        
+        conditions := [
+          "UniversalMorphismIntoDirectSum",
+          "MorphismBetweenDirectSums",
+          "Lift",
+          "PreCompose"
+        ];
+        
+        if ForAll( conditions, c -> CanCompute( B, c ) ) then
+            
+            return true;
+            
+        fi;
+        
+    fi;
+    
+    return false;
+    
+  end,
+  Description := "SolveLinearSystemInAbCategory using the homomorphism structure" 
+);
 
 ## Final methods for FiberProduct
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2282,10 +2282,10 @@ end );
 
 ##
 AddDerivationToCAP( SolveLinearSystemInAbCategory,
-                    [ [ InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure, 1 ],
+                    [ [ InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure, 1 ],
                       [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
                       [ HomomorphismStructureOnObjects, 1 ],
-                      [ InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism, 1 ] ],
+                      [ InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism, 1 ] ],
   function( left_coefficients, right_coefficients, right_side )
     local m, n, nu, H, lift, summands, list;
     
@@ -2298,7 +2298,7 @@ AddDerivationToCAP( SolveLinearSystemInAbCategory,
     nu :=
       UniversalMorphismIntoDirectSum(
         List( [ 1 .. m ],
-        i -> InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( right_side[i] ) )
+        i -> InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( right_side[i] ) )
     );
     
     list := 
@@ -2322,7 +2322,7 @@ AddDerivationToCAP( SolveLinearSystemInAbCategory,
     
     return
       List( [ 1 .. n ], j -> 
-        InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+        InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism(
           Range( left_coefficients[1][j] ),
           Source( right_coefficients[1][j] ),
           PreCompose( lift, ProjectionInFactorOfDirectSum( summands, j ) )

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -685,3 +685,15 @@ InstallMethod( AddSubobjectClassifier,
     
 end );
 
+##
+InstallMethod( AddDistinguishedObjectOfHomomorphismStructure,
+               [ IsCapCategory, IsFunction, IsInt ],
+               
+  function( category, func, weight )
+    local wrapped_func;
+    
+    wrapped_func := function( cat ) return func(); end;
+    
+    AddDistinguishedObjectOfHomomorphismStructure( category, [ [ wrapped_func, [ ] ] ], weight );
+    
+end );

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2905,17 +2905,17 @@ DistinguishedObjectOfHomomorphismStructure := rec(
   return_type := "other_object" 
 ),
 
-InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure := rec(
-  installation_name := "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure := rec(
+  installation_name := "InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
   filter_list := [ "morphism" ],
-  cache_name := "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+  cache_name := "InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
   return_type := "other_morphism" 
 ),
 
-InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism := rec(
-  installation_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism := rec(
+  installation_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
   filter_list := [ "object", "object", "other_morphism" ],
-  cache_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+  cache_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism",
   return_type := "morphism" 
 ),
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2883,6 +2883,49 @@ MorphismBetweenDirectSums := rec(
   return_type := "morphism",
   dual_operation := "MorphismBetweenDirectSums"
 ),
+
+HomomorphismStructureOnObjects := rec(
+  installation_name := "HomomorphismStructureOnObjects",
+  filter_list := [ "object", "object" ],
+  return_type := "other_object",
+  cache_name := "HomomorphismStructureOnObjects",
+),
+
+HomomorphismStructureOnMorphismsWithGivenObjects := rec(
+  installation_name := "HomomorphismStructureOnMorphismsWithGivenObjects",
+  filter_list := [ IsCapCategoryObject, "morphism", "morphism", IsCapCategoryObject ],
+  return_type := "other_morphism",
+  cache_name := "HomomorphismStructureOnMorphismsWithGivenObjects",
+),
+
+DistinguishedObjectOfHomomorphismStructure := rec(
+  installation_name := "DistinguishedObjectOfHomomorphismStructure",
+  filter_list := [ "category" ],
+  cache_name := "DistinguishedObjectOfHomomorphismStructure",
+  return_type := "other_object" 
+),
+
+InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure := rec(
+  installation_name := "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+  filter_list := [ "morphism" ],
+  cache_name := "InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure",
+  return_type := "other_morphism" 
+),
+
+InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism := rec(
+  installation_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+  filter_list := [ "object", "object", IsCapCategoryMorphism ],
+  cache_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
+  return_type := "morphism" 
+),
+
+SolveLinearSystemInAbCategory := rec(
+  installation_name := "SolveLinearSystemInAbCategory",
+  filter_list := [ IsList, IsList, IsList, "category" ],
+  cache_name := "SolveLinearSystemInAbCategory",
+  return_type := "morphism_or_fail"
+),
+
   ) );
 
 BindGlobal( "CAP_INTERNAL_PREPARE_INHERITED_PRE_FUNCTION",

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2893,7 +2893,7 @@ HomomorphismStructureOnObjects := rec(
 
 HomomorphismStructureOnMorphismsWithGivenObjects := rec(
   installation_name := "HomomorphismStructureOnMorphismsWithGivenObjects",
-  filter_list := [ IsCapCategoryObject, "morphism", "morphism", IsCapCategoryObject ],
+  filter_list := [ "other_object", "morphism", "morphism", "other_object" ],
   return_type := "other_morphism",
   cache_name := "HomomorphismStructureOnMorphismsWithGivenObjects",
 ),
@@ -2914,13 +2914,15 @@ InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure :
 
 InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism := rec(
   installation_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
-  filter_list := [ "object", "object", IsCapCategoryMorphism ],
+  filter_list := [ "object", "object", "other_morphism" ],
   cache_name := "InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism",
   return_type := "morphism" 
 ),
 
 SolveLinearSystemInAbCategory := rec(
-  installation_name := "SolveLinearSystemInAbCategory",
+    ## TODO: Type-check of linear system
+  installation_name := "SolveLinearSystemInAbCategoryOp",
+  argument_list := [ 1, 2, 3 ],
   filter_list := [ IsList, IsList, IsList, "category" ],
   cache_name := "SolveLinearSystemInAbCategory",
   return_type := "morphism_or_fail"

--- a/LinearAlgebraForCAP/examples/Example.gi
+++ b/LinearAlgebraForCAP/examples/Example.gi
@@ -121,4 +121,8 @@ IsCongruentForMorphisms(
     )
 );
 #! true
+right_side := PreCompose( [ i1, DualOnMorphisms( u ), u ] );;
+x := SolveLinearSystemInAbCategory( [ [ i1 ] ], [ [ u ] ], [ right_side ] )[1];;
+IsCongruentForMorphisms( PreCompose( [ i1, x, u ] ), right_side );
+#! true
 #! @EndExample

--- a/LinearAlgebraForCAP/examples/Example.gi
+++ b/LinearAlgebraForCAP/examples/Example.gi
@@ -93,4 +93,32 @@ IsOne( PushoutFunctorial( [ u, u ], [ IdentityMorphism( Range( u ) ), IdentityMo
 #! true
 IsCongruentForMorphisms( (1/2) * alpha, alpha * (1/2) );
 #! true
+Dimension( HomomorphismStructureOnObjects( a, b ) ) = Dimension( a ) * Dimension( b );
+#! true
+IsCongruentForMorphisms(
+    PreCompose( [ u, DualOnMorphisms( i1 ), DualOnMorphisms( alpha ) ] ),
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( Source( u ), Source( alpha ),
+         PreCompose(
+             InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( DualOnMorphisms( i1 ) ),
+             HomomorphismStructureOnMorphisms( u, DualOnMorphisms( alpha ) )
+         )
+    )
+);
+#! true
+vec := CapCategory( alpha );;
+t := TensorUnit( vec );;
+z := ZeroObject( vec );;
+IsCongruentForMorphisms(
+    ZeroObjectFunctorial( vec ),
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( z, z, ZeroMorphism( t, z ) )
+);
+#! true
+IsCongruentForMorphisms(
+    ZeroObjectFunctorial( vec ),
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+        z, z,
+        InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( ZeroObjectFunctorial( vec ) )
+    )
+);
+#! true
 #! @EndExample

--- a/LinearAlgebraForCAP/examples/Example.gi
+++ b/LinearAlgebraForCAP/examples/Example.gi
@@ -97,9 +97,9 @@ Dimension( HomomorphismStructureOnObjects( a, b ) ) = Dimension( a ) * Dimension
 #! true
 IsCongruentForMorphisms(
     PreCompose( [ u, DualOnMorphisms( i1 ), DualOnMorphisms( alpha ) ] ),
-    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( Source( u ), Source( alpha ),
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism( Source( u ), Source( alpha ),
          PreCompose(
-             InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( DualOnMorphisms( i1 ) ),
+             InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( DualOnMorphisms( i1 ) ),
              HomomorphismStructureOnMorphisms( u, DualOnMorphisms( alpha ) )
          )
     )
@@ -110,14 +110,14 @@ t := TensorUnit( vec );;
 z := ZeroObject( vec );;
 IsCongruentForMorphisms(
     ZeroObjectFunctorial( vec ),
-    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( z, z, ZeroMorphism( t, z ) )
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism( z, z, ZeroMorphism( t, z ) )
 );
 #! true
 IsCongruentForMorphisms(
     ZeroObjectFunctorial( vec ),
-    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism(
+    InterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism(
         z, z,
-        InterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( ZeroObjectFunctorial( vec ) )
+        InterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( ZeroObjectFunctorial( vec ) )
     )
 );
 #! true

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -40,6 +40,8 @@ InstallMethod( MatrixCategory,
     
     SetCommutativeRingOfLinearCategory( category, homalg_field );
     
+    SetRangeCategoryOfHomomorphismStructure( category, category );
+    
     INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY( category );
     
     ## TODO: Logic for MatrixCategory

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -798,7 +798,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     end );
     
     ##
-    AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
+    AddInterpretMorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
       function( alpha )
         local matrix, m, new_matrix, c;
         
@@ -825,7 +825,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     end );
     
     ##
-    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( category,
+    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsMorphism( category,
       function( source, range, alpha )
         local matrix, m, n, new_matrix;
         

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -765,6 +765,94 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
     end );
     
+    ## Homomorphism structure
+    
+    ##
+    AddHomomorphismStructureOnObjects( category,
+      function( object_1, object_2 )
+        
+        return VectorSpaceObject( Dimension( object_1 ) * Dimension( object_2 ), homalg_field );
+        
+    end );
+    
+    ##
+    AddHomomorphismStructureOnMorphismsWithGivenObjects( category,
+      function( hom_source, alpha, beta, hom_range )
+        
+        return VectorSpaceMorphism( 
+          hom_source,
+          KroneckerMat( Involution( UnderlyingMatrix( alpha ) ), UnderlyingMatrix( beta ) ),
+          hom_range
+        );
+        
+    end );
+    
+    ##
+    AddDistinguishedObjectOfHomomorphismStructure( category,
+      function( )
+        
+        return VectorSpaceObject( 1, homalg_field );
+      
+    end );
+    
+    ##
+    AddInterpretHomomorphismAsMorphismFromDinstinguishedObjectToHomomorphismStructure( category,
+      function( alpha )
+        local matrix, m, new_matrix, c;
+        
+        matrix := UnderlyingMatrix( alpha );
+        
+        m := NrRows( matrix );
+        
+        if m > 0 then
+            
+            new_matrix := UnionOfColumns( List( [ 1 .. NrRows( matrix ) ], n -> CertainRows( matrix, [ n ] ) ) );
+            
+        else
+            
+            new_matrix := HomalgZeroMatrix( 1, NrColumns( matrix ), homalg_field );
+            
+        fi;
+            
+        return VectorSpaceMorphism(
+          VectorSpaceObject( 1, homalg_field ),
+          new_matrix,
+          VectorSpaceObject( NrColumns( new_matrix ), homalg_field )
+        );
+        
+    end );
+    
+    ##
+    AddInterpretMorphismFromDinstinguishedObjectToHomomorphismStructureAsHomomorphism( category,
+      function( source, range, alpha )
+        local matrix, m, n, new_matrix;
+        
+        matrix := UnderlyingMatrix( alpha );
+        
+        m := Dimension( source );
+        
+        n := Dimension( range );
+        
+        if m > 0 then
+            
+            new_matrix := UnionOfRows(
+              List( [ 0 .. m - 1 ], i -> CertainColumns( matrix, [ 1 + i*n .. n + i*n ] ) )
+            );
+        
+        else
+            
+            new_matrix := HomalgZeroMatrix( m, n, homalg_field );
+            
+        fi;
+        
+        return VectorSpaceMorphism(
+          source,
+          new_matrix,
+          range
+        );
+        
+    end );
+    
 end );
 
 


### PR DESCRIPTION
I introduce homomorphism structures as CAP-operations.
Moreover, I test them in two cases:
in the first case, both the source and the range category of 
the homomorphism structure coincide,
and in the second case, they differ.