### PR TITLE
Adding LiftAlongMonomorphism & ColiftAlongEpimorphism to

### DIFF
--- a/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gd
+++ b/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gd
@@ -117,3 +117,7 @@ DeclareGlobalFunction( "ADD_GRADED_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT" );
 
 DeclareGlobalFunction( "ADD_GRADED_UNITOR" );
 
+DeclareGlobalFunction( "ADD_GRADED_LIFT_ALONG_MONOMORPHISM" );
+
+DeclareGlobalFunction( "ADD_GRADED_COLIFT_ALONG_EPIMORPHISM" );
+

--- a/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
+++ b/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
@@ -198,6 +198,10 @@ InstallGlobalFunction( ADD_GRADED_FUNCTIONS_FOR_LEFT_PRESENTATION,
     ADD_GRADED_IS_IDENTICAL_FOR_MORPHISMS( category );
     
     ADD_GRADED_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT( category );
+
+    ADD_GRADED_LIFT_ALONG_MONOMORPHISM( category );
+
+    ADD_GRADED_COLIFT_ALONG_EPIMORPHISM( category );
     
     if HasIsCommutative( category!.ring_for_representation_category ) and IsCommutative( category!.ring_for_representation_category ) then
       
@@ -271,6 +275,10 @@ InstallGlobalFunction( ADD_GRADED_FUNCTIONS_FOR_RIGHT_PRESENTATION,
     ADD_GRADED_IS_IDENTICAL_FOR_MORPHISMS( category );
     
     ADD_GRADED_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT( category );
+
+    ADD_GRADED_LIFT_ALONG_MONOMORPHISM( category );
+
+    ADD_GRADED_COLIFT_ALONG_EPIMORPHISM( category );
     
     if HasIsCommutative( category!.ring_for_representation_category ) and IsCommutative( category!.ring_for_representation_category ) then
       
@@ -574,10 +582,20 @@ InstallGlobalFunction( ADD_GRADED_LIFT,
         lift := Lift( UnderlyingPresentationMorphism( alpha ), UnderlyingPresentationMorphism( beta ) );
         
         if lift = fail then
+        
             return fail;
+        
         fi;
         
-        return GradedPresentationMorphism( Source( alpha ), lift, Source( beta ) );
+        lift := GradedPresentationMorphism( Source( alpha ), lift, Source( beta ) );
+        
+        if not IsWellDefined( lift ) then
+          
+          Error( "An output of the Lift method is not well-defined!" );
+          
+        fi;
+        
+        return lift;
         
     end );
     
@@ -596,10 +614,20 @@ InstallGlobalFunction( ADD_GRADED_COLIFT,
         colift := Colift( UnderlyingPresentationMorphism( alpha ), UnderlyingPresentationMorphism( beta ) );
         
         if colift = fail then
-            return fail;
+        
+          return fail;
+        
         fi;
         
-        return GradedPresentationMorphism( Range( alpha ), colift, Range( beta ) );
+        colift := GradedPresentationMorphism( Range( alpha ), colift, Range( beta ) );
+        
+        if not IsWellDefined( colift ) then
+        
+          Error( "An output of the Colift method is not well-defined!" );
+        
+        fi;
+        
+        return colift;
         
     end );
     
@@ -922,6 +950,70 @@ InstallGlobalFunction( ADD_GRADED_IDENTITY,
         
         return GradedPresentationMorphism( object, morphism, object );
         
+    end );
+    
+end );
+
+##
+InstallGlobalFunction( ADD_GRADED_LIFT_ALONG_MONOMORPHISM,
+
+  function( category )
+    
+    AddLiftAlongMonomorphism( category,
+
+      function( iota, tau )
+        local lift;
+
+        lift := LiftAlongMonomorphism( UnderlyingPresentationMorphism( iota ), UnderlyingPresentationMorphism( tau ) );
+        
+        if lift = fail then
+
+            return fail;
+
+        fi;
+
+        lift := GradedPresentationMorphism( Source( tau ), lift, Source( iota ) );
+
+        if not IsWellDefined( lift ) then
+
+          Error( "An output of the LiftAlongMonomorphism is not well-defined!" );
+
+        fi;
+
+        return lift;
+
+    end );
+
+end );
+
+##
+InstallGlobalFunction( ADD_GRADED_COLIFT_ALONG_EPIMORPHISM,
+
+  function( category )
+
+    AddColiftAlongEpimorphism( category,
+
+      function( epsilon, tau )
+        local colift;
+
+        colift := ColiftAlongEpimorphism( UnderlyingPresentationMorphism( epsilon ), UnderlyingPresentationMorphism( tau ) );
+
+        if colift = fail then
+
+            return fail;
+
+        fi;
+
+        colift := GradedPresentationMorphism( Range( epsilon ), colift, Range( tau ) );
+
+        if not IsWellDefined( colift ) then
+
+          Error( "An output of the ColiftAlongEpimorphism is not well-defined!" );
+
+        fi;
+
+        return colift;
+
     end );
     
 end );

--- a/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
+++ b/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
@@ -972,15 +972,7 @@ InstallGlobalFunction( ADD_GRADED_LIFT_ALONG_MONOMORPHISM,
 
         fi;
 
-        lift := GradedPresentationMorphism( Source( tau ), lift, Source( iota ) );
-
-        if not IsWellDefined( lift ) then
-
-          Error( "An output of the LiftAlongMonomorphism is not well-defined!" );
-
-        fi;
-
-        return lift;
+        return GradedPresentationMorphism( Source( tau ), lift, Source( iota ) );
 
     end );
 
@@ -1004,15 +996,7 @@ InstallGlobalFunction( ADD_GRADED_COLIFT_ALONG_EPIMORPHISM,
 
         fi;
 
-        colift := GradedPresentationMorphism( Range( epsilon ), colift, Range( tau ) );
-
-        if not IsWellDefined( colift ) then
-
-          Error( "An output of the ColiftAlongEpimorphism is not well-defined!" );
-
-        fi;
-
-        return colift;
+        return GradedPresentationMorphism( Range( epsilon ), colift, Range( tau ) );
 
     end );
     


### PR DESCRIPTION
the category of graded presentations.

The outputs of Lift, LiftAlongMonomorphism, Colift and
ColiftAlongEpimorphism are checked whether they are well-defined or not
and an error will be raised whenever it is not well-defined.

This checking is supposed to be temporary until the pull-request
    https://github.com/homalg-project/homalg_project/pull/222
is merged to homalg_project.