### PR TITLE
DO NOT MERGE: avoid using InstallMethodWithCache if cache is deactivated

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2019.01.29", ## Mohamed's version
+  "2019.02.27", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -206,7 +206,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
         
         replaced_filter_list := CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS( filter_list, category );
         
-        if caching = true then
+        if caching = true and not category!.default_cache_type = "none" then
             install_method := InstallMethodWithCache;
             PushOptions( rec( Cache := GET_METHOD_CACHE( category, cache_name, nr_arguments )  ) );
             popper := true;


### PR DESCRIPTION
This is NOT a PR but rather a question.

@markuslh and I noticed, that if we `DeactivateCachingOfCategory`, even immediately after `CreateCapCategory`, then some methods are still installed using `InstallMethodWithCache`. We now believe that this is necessary to allow caching to be reactivated a posteriori using `SetCaching`.

Now our questions:
* Is our current understanding correct?
* Is there no significant overhead if those methods (e.g. `DirectProductOp`) are still installed using `InstallMethodWithCache`?
