### PR TITLE
Fix wrong usage of "primitive"

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -280,9 +280,9 @@ DeclareGlobalFunction( "CapCategorySwitchLogicOff" );
 
 #! @Description
 #! The argument is a category $C$ and a string $s$,
-#! which should be the name of a primitive operation, e.g., PreCompose.
+#! which should be the name of a basic operation, e.g., PreCompose.
 #! If applying this method is possible in $C$, the method returns <C>true</C>, <C>false</C> otherwise.
-#! If the string is not the name of a primitive operation, an error is raised.
+#! If the string is not the name of a basic operation, an error is raised.
 #! @Returns <C>true</C> or <C>false</C>
 #! @Arguments C,s
 DeclareOperation( "CanCompute",

--- a/CAP/gap/Derivations.gd
+++ b/CAP/gap/Derivations.gd
@@ -178,7 +178,7 @@ DeclareOperation( "MakeDerivationGraph", [ IsDenseList ] );
 
 
 #! @Description Adds a list of operation names <A>operations</A> to a given derivation graph <A>graph</A>.
-#!  This is used in extensions of CAP which want to have their own primitive operations,
+#!  This is used in extensions of CAP which want to have their own basic operations,
 #!  but do not want to pollute the CAP kernel any more. Please use it with caution. If
 #!  a weight list/category was created before it will not be aware of the operations.
 #! @Arguments graph, operations


### PR DESCRIPTION
I think in the given cases the use of "primitive" is wrong. I think the remaining places where "primitive" is used are fine, but maybe you can double-check.