### PR TITLE
Disable adds by default

### DIFF
--- a/CAP/examples/testfiles/FieldAsCategory.gi
+++ b/CAP/examples/testfiles/FieldAsCategory.gi
@@ -52,8 +52,6 @@ InstallMethod( FieldAsCategory,
     
     AddMorphismRepresentation( category, IsFieldAsCategoryMorphism );
 
-    DisableAddForCategoricalOperations( category );
-    
     INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY( category );
     
     Finalize( category );

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -378,19 +378,23 @@ DeclareGlobalFunction( "EnableBasicOperationTypeCheck" );
 
 #############################################
 ##
-#! @Section Disable add in functions
+#! @Section Enable automatic calls of <C>Add</C>
 ##
 #############################################
 
 #! @BeginGroup
 #! @Description
-#!  Enables/disables the call of add for the output
+#!  Enables/disables the automatic call of <C>Add</C> for the output
 #!  of primitively added functions for the category <A>C</A>.
-#!  This can be savely done if the all objects and morphisms
-#!  are added to the category by their constructors.
-#! @Arguments C
-DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
+#!  If the automatic call of <C>Add</C> is disabled (default),
+#!  the output of primitively added functions must belong to the correct category.
+#!  If the automatic call of <C>Add</C> is enabled,
+#!  the output of primitively added functions only has to be a GAP object
+#!  lying in <C>IsAttributeStoringRep</C> (with suitable attributes <C>Source</C> and <C>Range</C>
+#!  if the output should be a morphism or a twocell).
 #! @Arguments C
 DeclareGlobalFunction( "EnableAddForCategoricalOperations" );
+#! @Arguments C
+DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
 #! @EndGroup
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -245,7 +245,7 @@ InstallGlobalFunction( "CREATE_CAP_CATEGORY_OBJECT",
     
     obj_rec!.predicate_logic := true;
     
-    obj_rec!.add_primitive_output := true;
+    obj_rec!.add_primitive_output := false;
     
     return obj_rec;
     

--- a/CAP/gap/CategoriesCategory.gd
+++ b/CAP/gap/CategoriesCategory.gd
@@ -174,9 +174,10 @@ DeclareOperation( "CapFunctor",
 #!  $[ [A_1, b_1], \dots, [A_n,b_n] ]$,
 #!  then $f$ must take $n$ arguments, where the $i$-th
 #!  argument is an object in the category $A_i$ (the boolean $b_i$ is ignored).
-#!  The function should return a GAP object in <C>IsAttributeStoringRep</C> which
-#!  will be automatically added to the range of the functor,
-#!  except when this feature was deactivated via <C>DisableAddForCategoricalOperations</C>.
+#!  The function should return an object in the range of the functor, except when
+#!  the automatic call of <C>AddObject</C> was enabled via <C>EnableAddForCategoricalOperations</C>.
+#!  In this case the output only has to be a GAP object in <C>IsAttributeStoringRep</C>,
+#!  which will be automatically added as an object to the range of the functor.
 #! @Arguments F, f
 DeclareOperation( "AddObjectFunction",
                   [ IsCapFunctor, IsFunction ] );
@@ -210,10 +211,11 @@ DeclareAttribute( "FunctorObjectOperation",
 #!  The last argument of $f$ must be an object $r$ that is equal (via <C>IsEqualForObjects</C>)
 #!  to the range of the result of applying
 #!  $F$ to the input morphisms.
-#!  The function should return a GAP object in <C>IsAttributeStoringRep</C> (with attributes <C>Source</C>
-#!  and <C>Range</C> containing also GAP objects in <C>IsAttributeStoringRep</C>) which
-#!  will be automatically added to the range of the functor,
-#!  except when this feature was deactivated via <C>DisableAddForCategoricalOperations</C>.
+#!  The function should return a morphism in the range of the functor, except when
+#!  the automatic call of <C>AddMorphism</C> was enabled via <C>EnableAddForCategoricalOperations</C>.
+#!  In this case the output only has to be a GAP object in <C>IsAttributeStoringRep</C>
+#!  (with attributes <C>Source</C> and <C>Range</C> containing also GAP objects in <C>IsAttributeStoringRep</C>),
+#!  which will be automatically added as a morphism to the range of the functor.
 #! @Arguments F, f
 DeclareOperation( "AddMorphismFunction",
                   [ IsCapFunctor, IsFunction ] );

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -37,8 +37,6 @@ InstallMethod( AdditiveClosure,
     
     AddMorphismRepresentation( category, IsAdditiveClosureMorphism );
     
-    DisableAddForCategoricalOperations( category );
-    
     INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE( category );
     
     to_be_finalized := ValueOption( "FinalizeCategory" );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -31,8 +31,6 @@ InstallMethod( CategoryOfRows,
     
     AddMorphismRepresentation( category, IsCategoryOfRowsMorphism );
     
-    DisableAddForCategoricalOperations( category );
-    
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS( category );
     
     to_be_finalized := ValueOption( "FinalizeCategory" );

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -59,8 +59,6 @@ InstallMethod( CokernelImageClosure,
         
     fi;
     
-    DisableAddForCategoricalOperations( cokernel_image_closure );
-
     AddObjectRepresentation( cokernel_image_closure, IsCokernelImageClosureObject );
     
     AddMorphismRepresentation( cokernel_image_closure, IsCokernelImageClosureMorphism );

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -59,8 +59,6 @@ InstallMethod( FreydCategory,
         
     fi;
     
-    DisableAddForCategoricalOperations( freyd_category );
-    
     AddObjectRepresentation( freyd_category, IsFreydCategoryObject );
     
     AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism );

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
@@ -275,8 +275,6 @@ InstallMethod( GeneralizedMorphismCategoryByCospans,
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByCospan );
     
-    DisableAddForCategoricalOperations( generalized_morphism_category );
-    
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
     SetUnderlyingHonestCategory( generalized_morphism_category, category );

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
@@ -271,8 +271,6 @@ InstallMethod( GeneralizedMorphismCategoryBySpans,
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismBySpan );
     
-    DisableAddForCategoricalOperations( generalized_morphism_category );
-    
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
     SetUnderlyingHonestCategory( generalized_morphism_category, category );

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -293,8 +293,6 @@ InstallMethod( GeneralizedMorphismCategoryByThreeArrows,
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByThreeArrows );
     
-    DisableAddForCategoricalOperations( generalized_morphism_category );
-    
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
     SetUnderlyingHonestCategory( generalized_morphism_category, category );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
@@ -364,8 +364,6 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospans,
     
     AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByCospansMorphism );
     
-    DisableAddForCategoricalOperations( serre_category );
-    
     serre_category!.predicate_logic := category!.predicate_logic;
     
     SetFilterObj( serre_category, WasCreatedAsSerreQuotientCategoryByCospans );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
@@ -431,8 +431,6 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpans,
     
     AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryBySpansMorphism );
     
-    DisableAddForCategoricalOperations( serre_category );
-    
     serre_category!.predicate_logic := category!.predicate_logic;
     
     SetFilterObj( serre_category, WasCreatedAsSerreQuotientCategoryBySpans );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -385,8 +385,6 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrows,
     
     AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsMorphism );
     
-    DisableAddForCategoricalOperations( serre_category );
-    
     serre_category!.predicate_logic := category!.predicate_logic;
     
     SetFilterObj( serre_category, WasCreatedAsSerreQuotientCategoryByThreeArrows );

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -22,8 +22,6 @@ InstallMethod( MatrixCategory,
     
     category := CreateCapCategory( Concatenation( "Category of matrices over ", RingName( homalg_field ) ) );
     
-    DisableAddForCategoricalOperations( category );
-    
     AddObjectRepresentation( category, IsVectorSpaceObject );
     
     AddMorphismRepresentation( category, IsVectorSpaceMorphism );

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -85,8 +85,6 @@ InstallMethod( RightPresentations,
     
     category := CreateCapCategory( Concatenation( "Category of right presentations of ", RingName( ring ) ) );
     
-    DisableAddForCategoricalOperations( category );
-    
     AddObjectRepresentation( category, IsRightPresentation );
     
     AddMorphismRepresentation( category, IsRightPresentationMorphism );


### PR DESCRIPTION
~Note: This depends on PR #265. I will open this PR for review once #265 is merged.~

**Note 2**: if this PR is merged, the CAP Manual has to be updated accordingly.

This PR sets the default value for `add_primitive_output` to `false`.
Rationale for this change: Most users of CAP do not rely on the automatic calls of `Add` but also do not know about `DisableAddForCategoricalOperations` (of course, I do not have numbers to support this statement, but I think it is a reasonable guess). On the other hand, users relying on the automatic calls of `Add` are probably advanced users who either know about `EnableAddForCategoricalOperations` or know where to look if errors occur if `add_primitive_output` is set to `false`.

Thus, most users benefit from this change in two ways:
* faster code
* stricter output sanity checks (see #188 and #263)

In particular, stricter output sanity checks are very useful for users now to CAP and GAP.