### PR TITLE
Improve documentation

### DIFF
--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -138,8 +138,16 @@ The record can have the following components, used as described:
                             Please note that if you have a method selection argument for your function, you need to give the argument_list
                             to explicitly state which argument is the method selection argument.
 
-* return_type (optional): The return type can be object, morphism, or twocell. If it is one of those, the correct add function (see above) is
-                          used for the result of the computation. Otherwise, no add function is used after all.
+* return_type (optional): The return type can be one of the following:
+                          * <C>object</C>,
+                          * <C>morphism</C> or <C>morphism_or_fail</C>,
+                          * <C>twocell</C>,
+                          * <C>bool</C>,
+                          * <C>other_object</C>,
+                          * <C>other_morphism</C>.
+                          <P/>
+                          If it is one of the first three options, the correct <C>Add</C> function (see above) is
+                          used for the result of the computation. Otherwise, no <C>Add</C> function is used after all.
 
 * is_with_given: Boolean, marks wether the function which is to be installed a with given function or not.
 

--- a/CAP/doc/Intros.autodoc
+++ b/CAP/doc/Intros.autodoc
@@ -1,17 +1,21 @@
 @Chapter CAP Categories
 
-@Chapter Category of Categories
+@Chapter Objects
 
 @Chapter Morphisms
 
-@Chapter Objects
-
 @Chapter Category 2-Cells
+
+@Chapter Category of Categories
 
 @Chapter Universal Objects
 
 @Chapter Tensor Product and Internal Hom
 
+@Chapter Add Functions
+
 @Chapter Managing Derived Methods
 
-@Chapter Add Functions
+@Chapter Technical Details
+
+@Chapter Examples and Tests

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -258,6 +258,7 @@ DeclareAttribute( "RangeCategoryOfHomomorphismStructure",
 #############################################
 ##
 #! @Section Logic switcher
+#! @SectionLabel Logic_switcher
 ##
 #############################################
 
@@ -318,6 +319,7 @@ DeclareProperty( "IsWellDefined",
 ####################################
 ##
 #! @Section Caching
+#! @SectionLabel Caching
 ##
 ####################################
 
@@ -333,14 +335,26 @@ DeclareOperation( "SetCachingToCrisp",
 DeclareOperation( "DeactivateCaching",
                   [ IsCapCategory, IsString ] );
 
+#! @Description
+#!  Sets the caching of <A>category</A> to <A>type</A>.
+#! @Arguments category, type
 DeclareGlobalFunction( "SetCachingOfCategory" );
+
+#! @BeginGroup
+#! @Description
+#!  Sets the caching of <A>category</A> to <C>weak</C>, <C>crips</C> or <C>none</C>, respectively.
+#! @Arguments category
 DeclareGlobalFunction( "SetCachingOfCategoryWeak" );
+#! @Arguments category
 DeclareGlobalFunction( "SetCachingOfCategoryCrisp" );
+#! @Arguments category
 DeclareGlobalFunction( "DeactivateCachingOfCategory" );
+#! @EndGroup
 
 ####################################
 ##
 #! @Section Sanity checks
+#! @SectionLabel Sanity_checks
 ##
 ####################################
 
@@ -379,6 +393,7 @@ DeclareGlobalFunction( "EnableBasicOperationTypeCheck" );
 #############################################
 ##
 #! @Section Enable automatic calls of <C>Add</C>
+#! @SectionLabel Automatic_adds
 ##
 #############################################
 
@@ -398,3 +413,23 @@ DeclareGlobalFunction( "EnableAddForCategoricalOperations" );
 DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
 #! @EndGroup
 
+
+#############################################
+##
+#! @Section Performance tweaks
+##
+#############################################
+
+#!  CAP has several settings which can improve the performance.
+#!  In the following some of these are listed.
+#!    * <C>DeactivateCachingOfCategory</C>: see <Ref Sect="Section_Caching" />.
+#!        This can either improve or degrade the performance depending on the concrete example.
+#!    * <C>CapCategorySwitchLogicOff</C>: see <Ref Sect="Section_Logic_switcher" />.
+#!        This can either improve or degrade the performance depending on the concrete example.
+#!    * <C>DisableSanityChecks</C>: see <Ref Sect="Section_Sanity_checks" />.
+#!    * <C>DisableAddForCategoricalOperations</C>: see <Ref Sect="Section_Automatic_adds" />.
+#!    * <C>DeactivateToDoList</C>: see the package <C>ToolsForHomalg</C>.
+#!    * use <C>ObjectifyObjectForCAPWithAttributes</C> (<Ref Sect="Section_Adding_Objects_to_a_Category" />)
+#!        instead of <C>AddObject</C> and
+#!        <C>ObjectifyMorphismForCAPWithAttributes</C> (<Ref Sect="Section_Adding_Morphisms_to_a_Category" />)
+#!        instead of <C>AddMorphism</C>.

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -75,7 +75,7 @@ DeclareCategory( "IsCapCategory",
 #! of a CAP category lies in this GAP category.
 #! @Arguments object
 DeclareCategory( "IsCapCategoryCell",
-                 IsObject );
+                 IsAttributeStoringRep );
 
 #! @Description
 #! The GAP category of CAP category objects.

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -342,7 +342,7 @@ DeclareGlobalFunction( "SetCachingOfCategory" );
 
 #! @BeginGroup
 #! @Description
-#!  Sets the caching of <A>category</A> to <C>weak</C>, <C>crips</C> or <C>none</C>, respectively.
+#!  Sets the caching of <A>category</A> to <C>weak</C>, <C>crisp</C> or <C>none</C>, respectively.
 #! @Arguments category
 DeclareGlobalFunction( "SetCachingOfCategoryWeak" );
 #! @Arguments category

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -413,6 +413,7 @@ DeclareOperation( "AddIsAutomorphism",
 ###################################
 ##
 #! @Section Adding Morphisms to a Category
+#! @SectionLabel Adding_Morphisms_to_a_Category
 ##
 ###################################
 

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -425,6 +425,9 @@ DeclareOperation( "Add",
 
 #! @Description
 #!  Adds <A>morphism</A> as a morphism to <A>category</A>.
+#!  If <A>morphism</A> already lies in the filter <C>IsCapCategoryMorphism</C>,
+#!  the operation <Ref Oper="Add" Label="for IsCapCategory, IsCapCategoryMorphism" />
+#!  can be used instead.
 #! @Arguments category, morphism
 DeclareOperation( "AddMorphism",
                   [ IsCapCategory, IsAttributeStoringRep ] );

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -417,9 +417,15 @@ DeclareOperation( "AddIsAutomorphism",
 ##
 ###################################
 
+#! @Description
+#!  Adds <A>morphism</A> as a morphism to <A>category</A>.
+#! @Arguments category, morphism
 DeclareOperation( "Add",
                   [ IsCapCategory, IsCapCategoryMorphism ] );
 
+#! @Description
+#!  Adds <A>morphism</A> as a morphism to <A>category</A>.
+#! @Arguments category, morphism
 DeclareOperation( "AddMorphism",
                   [ IsCapCategory, IsAttributeStoringRep ] );
 

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -421,7 +421,7 @@ DeclareOperation( "Add",
                   [ IsCapCategory, IsCapCategoryMorphism ] );
 
 DeclareOperation( "AddMorphism",
-                  [ IsCapCategory, IsObject ] );
+                  [ IsCapCategory, IsAttributeStoringRep ] );
 
 #! @Arguments category, filter
 #! @Description

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -132,7 +132,7 @@ InstallMethod( AddMorphism,
 end );
 
 InstallMethod( AddMorphism,
-               [ IsCapCategory, IsObject ],
+               [ IsCapCategory, IsAttributeStoringRep ],
                
   function( category, morphism )
     

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -293,6 +293,9 @@ DeclareOperation( "Add",
 
 #! @Description
 #!  Adds <A>object</A> as an object to <A>category</A>.
+#!  If <A>object</A> already lies in the filter <C>IsCapCategoryObject</C>,
+#!  the operation <Ref Oper="Add" Label="for IsCapCategory, IsCapCategoryObject" />
+#!  can be used instead.
 #! @Arguments category, object
 DeclareOperation( "AddObject",
                   [ IsCapCategory, IsAttributeStoringRep ] );

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -285,9 +285,15 @@ DeclareOperation( "AddIsEqualForCacheForObjects",
 ##
 ###################################
 
+#! @Description
+#!  Adds <A>object</A> as an object to <A>category</A>.
+#! @Arguments category, object
 DeclareOperation( "Add",
                   [ IsCapCategory, IsCapCategoryObject ] );
 
+#! @Description
+#!  Adds <A>object</A> as an object to <A>category</A>.
+#! @Arguments category, object
 DeclareOperation( "AddObject",
                   [ IsCapCategory, IsAttributeStoringRep ] );
 

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -289,7 +289,7 @@ DeclareOperation( "Add",
                   [ IsCapCategory, IsCapCategoryObject ] );
 
 DeclareOperation( "AddObject",
-                  [ IsCapCategory, IsObject ] );
+                  [ IsCapCategory, IsAttributeStoringRep ] );
 
 #! @Arguments category, filter
 #! @Description

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -281,6 +281,7 @@ DeclareOperation( "AddIsEqualForCacheForObjects",
 ###################################
 ##
 #! @Section Adding Objects to a Category
+#! @SectionLabel Adding_Objects_to_a_Category
 ##
 ###################################
 

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -184,7 +184,7 @@ InstallMethod( AddObject,
 end );
 
 InstallMethod( AddObject,
-               [ IsCapCategory, IsObject ],
+               [ IsCapCategory, IsAttributeStoringRep ],
                
   function( category, object )
     

--- a/CAP/gap/MonoidalCategories.gi
+++ b/CAP/gap/MonoidalCategories.gi
@@ -5,7 +5,7 @@
 ##  Copyright 2015, Sebastian Gutsche, TU Kaiserslautern
 ##                  Sebastian Posur,   RWTH Aachen
 ##
-#! @Chapter Monoidal Categories
+#! @Chapter Tensor Product and Internal Hom
 #!
 ##
 #############################################################################

--- a/CAP/gap/PrepareFunctions.gd
+++ b/CAP/gap/PrepareFunctions.gd
@@ -5,7 +5,7 @@
 ##  Copyright 2017, Sebastian Gutsche, Siegen University
 ##                  Sebastian Posur,   Siegen University
 ##
-#! @Chapter Prepare functions
+#! @Chapter Add Functions
 ##
 #############################################################################
 

--- a/CAP/makedoc.g
+++ b/CAP/makedoc.g
@@ -8,7 +8,7 @@ AutoDoc( "CAP" :
           ),
          autodoc :=
          rec( files := [ "doc/Intros.autodoc" ],
-         scan_dirs := [ "gap", "examples/testfiles", "doc" ] ),
+         scan_dirs := [ "doc", "gap", "examples/testfiles" ] ),
          maketest := rec( commands :=
                             [ "LoadPackage( \"CAP\" );",
                               "LoadPackage( \"IO_ForHomalg\" );",


### PR DESCRIPTION
~Note: this PR depends on #269. I will open it for review once #269 is merged.~

To make the technical requirements more precise, I have changed  `IsCapCategoryCell` to imply `IsAttributeStoringRep`. If a GAP object does not lie in `IsAttributeStoringRep`, it cannot be added
to a category anyway.