### PR TITLE
Caching in MatrixCategory

### DIFF
--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
@@ -39,8 +39,8 @@ DeclareCategory( "IsVectorSpaceMorphism",
 DeclareOperation( "VectorSpaceMorphism",
                   [ IsVectorSpaceObject, IsHomalgMatrix, IsVectorSpaceObject ] );
 
-DeclareOperationWithCache( "VectorSpaceMorphism",
-                           [ IsVectorSpaceObject, IsList, IsVectorSpaceObject ] );
+DeclareOperation( "VectorSpaceMorphism",
+                  [ IsVectorSpaceObject, IsList, IsVectorSpaceObject ] );
 
 ####################################
 ##

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
@@ -14,8 +14,9 @@
 ##
 ####################################
 
-InstallMethodWithCache( VectorSpaceMorphism,
-                        [ IsVectorSpaceObject, IsList, IsVectorSpaceObject ],
+##
+InstallMethod( VectorSpaceMorphism,
+               [ IsVectorSpaceObject, IsList, IsVectorSpaceObject ],
                         
   function( source, element_list, range )
     local field, homalg_matrix;

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
@@ -33,10 +33,22 @@ DeclareCategory( "IsVectorSpaceObject",
 #! and a homalg field $F$.
 #! The output is an object in the category of
 #! matrices over $F$ of dimension $d$.
+#! This function delegates to <C>MatrixCategoryObject</C>.
 #! @Returns an object
 #! @Arguments d, F
-DeclareOperationWithCache( "VectorSpaceObject",
-                           [ IsInt, IsFieldForHomalg ] );
+DeclareOperation( "VectorSpaceObject",
+                  [ IsInt, IsFieldForHomalg ] );
+
+#! @Description
+#! The arguments are a homalg field $F$
+#! and a non-negative integer $d$.
+#! The output is an object in the category of
+#! matrices over $F$ of dimension $d$.
+#! @Returns an object
+#! @Arguments F, d
+KeyDependentOperation( "MatrixCategoryObject",
+                       IsFieldForHomalg, IsInt, ReturnTrue );
+
 
 ####################################
 ##

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
@@ -15,10 +15,20 @@
 ####################################
 
 ##
-InstallMethodWithCache( VectorSpaceObject,
-                        [ IsInt, IsFieldForHomalg ],
-               
+InstallMethod( VectorSpaceObject,
+               [ IsInt, IsFieldForHomalg ],
+                
   function( dimension, homalg_field )
+    
+    return MatrixCategoryObject( homalg_field, dimension );
+    
+end );
+
+##
+InstallMethod( MatrixCategoryObjectOp,
+               [ IsFieldForHomalg, IsInt ],
+               
+  function( homalg_field, dimension )
     local category, vector_space_object;
     
     if dimension < 0 then


### PR DESCRIPTION
I would like to discuss the caching in `MatrixCategory`.

Since this category is supposed to be a "work horse", it think caching (as provided by `ToolsForHomalg)` should be kept to a minimum. This is why I suggest to delete it from the current object and morphism constructors.

However, there is a cheap way to cache objects via `KeyDependentOperation`, which I suggest to incorporate into the current implementation.

