### PR TITLE
Adding random methods to the matrix category of a homalg field.

### DIFF
--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -91,7 +91,7 @@ Dependencies := rec(
   GAP := ">= 4.6",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
                            [ "MatricesForHomalg", ">= 2018.02.04" ],
-                           [ "CAP", ">= 2018.09.17" ],
+                           [ "CAP", ">= 2019.04.04" ],
                            [ "ToolsForHomalg", ">=2015.09.18" ]
                            ],
   SuggestedOtherPackages := [ ],

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
@@ -11,6 +11,17 @@
 
 ####################################
 ##
+#! @Section GAP Categories
+##
+####################################
+
+#! @Description
+#! The GAP category of the CAP categories of matrices of a field $F$.
+#! @Arguments a CAP category
+DeclareCategory( "IsCapMatrixCategory", IsCapCategory );
+
+####################################
+##
 #! @Section Constructors
 ##
 ####################################

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -48,9 +48,11 @@ InstallMethod( MatrixCategory,
         DirectoriesPackageLibrary( "LinearAlgebraForCAP", "LogicForMatrixCategory" ),
         "PredicateImplicationsForMatrixCategory.tex" )
     );
-     
+    
+    SetFilterObj( category, IsCapMatrixCategory );
+    
     to_be_finalized := ValueOption( "FinalizeCategory" );
-   
+    
     if to_be_finalized = false then
       
        return category;
@@ -853,8 +855,269 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
     end );
     
+    ## Random methods
+    
+    ## dimension of the output is in L
+    ##
+    AddRandomObjectByList( category,
+      function( category, L )
+        local n;
+        
+        if Length( L ) = 0 then
+          
+          Error( "The list should not be empty" );
+        
+        fi;
+        
+        if not ForAll( L, IsInt ) then
+          
+          Error( "All entries in the list should be integers" );
+        
+        fi;
+        
+        n := Random( L );
+        
+        if n < 0 then
+          
+          return fail;
+        
+        fi;
+        
+        return VectorSpaceObject( n, homalg_field );
+        
+    end );
+    
+    ##
+    ## entries of the matrix are linear combinations of elements in L
+    ##
+    AddRandomMorphismWithFixedSourceAndRangeByList( category,
+      function( a, b, L )
+        local category, entries, matrix;
+        
+        category := CapCategory( a );
+        
+        if Length( L ) = 0 then
+          
+          Error( "The list should not be empty" );
+        
+        fi;
+        
+        if not ForAll( L, l -> l = l/homalg_field ) then
+          
+          Error( Concatenation( "All elements in the list should belong to ", String( homalg_field ) ) );
+        
+        fi;
+        
+        entries := List( [ 1 .. Dimension( a ) ], i -> List( [ 1 .. Dimension( b ) ],
+                     j -> RandomMat( 1, Length( L ) )[ 1 ] * L ) );
+        
+        matrix := HomalgMatrix( entries, Dimension( a ), Dimension( b ), homalg_field );
+        
+        return VectorSpaceMorphism( a, matrix, b );
+        
+  end );
+    
+    ##
+    ## alpha: a --> b, dim(b) = L[1] and entries of matrix are linear combinations of elements in L[2]
+    ##
+    AddRandomMorphismWithFixedSourceByList( category,
+      function( a, L )
+        local category, b, entries, matrix;
+        
+        category := CapCategory( a );
+        
+        if not ( IsInt( L[ 1 ] ) and L[ 1 ] >= 0 ) then
+          
+          Error( "The first entry should be an integer greater or equal to 0" );
+        
+        fi;
+        
+        if not IsList( L[ 2 ] ) then
+          
+          Error( "The second entry should be a list" );
+        
+        fi;
+        
+        if Length( L[ 2 ] ) = 0 then
+          
+          Error( "The second entry should not be an empty list" );
+        
+        fi;
+        
+        if not ForAll( L[ 2 ], l -> l = l/homalg_field ) then
+          
+          Error( Concatenation( "All elements in the second entry list should belong to ", String( homalg_field ) ) );
+        
+        fi;
+        
+        b := VectorSpaceObject( L[ 1 ], homalg_field );
+        
+        entries := List( [ 1 .. Dimension( a ) ], i -> List( [ 1 .. Dimension( b ) ],
+                     j -> RandomMat( 1, Length( L[ 2 ] ) )[ 1 ] * L[ 2 ] ) );
+        
+        matrix := HomalgMatrix( entries, Dimension( a ), Dimension( b ), homalg_field );
+        
+        return VectorSpaceMorphism( a, matrix, b );
+    
+    end );
+    
+    ##
+    ## alpha: a --> b, dim(a) = L[1] and entries of matrix are linear combinations of elements in L[2]
+    ##
+    AddRandomMorphismWithFixedRangeByList( category,
+      function( b, L )
+        local category, a, entries, matrix;
+        
+        category := CapCategory( b );
+        
+        
+        if not ( IsInt( L[ 1 ] ) and L[ 1 ] >= 0 ) then
+          
+          Error( "The first entry should be an integer greater or equal to 0" );
+        
+        fi;
+        
+        if not IsList( L[ 2 ] ) then
+          
+          Error( "The second entry should be a list" );
+        
+        fi;
+        
+        if Length( L[ 2 ] ) = 0 then
+          
+          Error( "The second entry should not be an empty list" );
+        
+        fi;
+        
+        if not ForAll( L[ 2 ], l -> l = l/homalg_field ) then
+          
+          Error( Concatenation( "All elements in the second entry list should belong to ", String( homalg_field ) ) );
+        
+        fi;
+        
+        a := VectorSpaceObject( L[ 1 ], homalg_field );
+        
+        entries := List( [ 1 .. Dimension( a ) ], i -> List( [ 1 .. Dimension( b ) ],
+                     j -> RandomMat( 1, Length( L[ 2 ] ) )[ 1 ] * L[ 2 ] ) );
+        
+        matrix := HomalgMatrix( entries, Dimension( a ), Dimension( b ), homalg_field );
+        
+        return VectorSpaceMorphism( a, matrix, b );
+        
+    end );
+    
+    ##
+    ## alpha: a --> b, dim(a) = L[1], dim(b) = L[2] and entries of matrix are linear combinations of elements in L[3]
+    ##
+    AddRandomMorphismByList( category,
+      function( category, L )
+        local a, b, entries, matrix;
+        
+        
+        if not ( IsInt( L[ 1 ] ) and L[ 1 ] >= 0 ) then
+          
+          Error( "The first entry should be an integer greater or equal to 0" );
+        
+        fi;
+        
+        if not ( IsInt( L[ 2 ] ) and L[ 2 ] >= 0 ) then
+          
+          Error( "The second entry should be an integer greater or equal to 0" );
+        
+        fi;
+        
+        if not IsList( L[ 3 ] ) then
+          
+          Error( "The third entry should be a list" );
+        
+        fi;
+        
+        if Length( L[ 3 ] ) = 0 then
+          
+          Error( "The third entry should not be an empty list" );
+        
+        fi;
+        
+        if not ForAll( L[ 3 ], l -> l = l/homalg_field  ) then
+          
+          Error( Concatenation( "All elements in the third entry list should belong to ", String( homalg_field ) ) );
+        
+        fi;
+        
+        a := VectorSpaceObject( L[ 1 ], homalg_field );
+        
+        b := VectorSpaceObject( L[ 2 ], homalg_field );
+        
+        entries := List( [ 1 .. Dimension( a ) ], i -> List( [ 1 .. Dimension( b ) ],
+                   j -> RandomMat( 1, Length( L[ 3 ] ) )[ 1 ] * L[ 3 ] ) );
+        
+        matrix := HomalgMatrix( entries, Dimension( a ), Dimension( b ), homalg_field );
+        
+        return VectorSpaceMorphism( a, matrix, b );
+        
+    end );
+    
+    ##
+    ## Interpretation: the output has dimension at most n.
+    ##
+    AddRandomObjectByInteger( category,
+        function( category, n )
+          
+          if n < 0 then
+            
+            return fail;
+          
+          fi;
+          
+          return RandomObjectByList( category, [ 0 .. n ] );
+      
+    end );
+    
+    ##
+    ## Interpretation: the range of the output has dimension n.
+    ##
+    AddRandomMorphismWithFixedSourceByInteger( category,
+      
+      function( a, n )
+        
+        if n < 0 then
+          
+          return fail;
+        
+        fi;
+        
+        return RandomMorphismWithFixedSourceByList( a, [ n, [ -50 .. 50 ] * One( homalg_field ) ] );
+    
+    end );
+    
+    ##
+    ## Interpretation: the source of the output has dimension n.
+    ##
+    AddRandomMorphismWithFixedRangeByInteger( category,
+      
+      function( b, n )
+        
+        if n < 0 then
+          
+          return fail;
+        
+        fi;
+        
+        return RandomMorphismWithFixedRangeByList( b, [ n, [ -50 .. 50 ] * One( homalg_field ) ] );
+    
+    end );
+    
+    ##
+    ## Interpretation: The entries of the matrix elements are
+    ## linear combinations of elements in [ -|n| .. |n| ] * One( homalg_field )
+    ##
+    AddRandomMorphismWithFixedSourceAndRangeByInteger( category,
+      
+      function( a, b, n )
+        
+        return RandomMorphismWithFixedSourceAndRangeByList( a, b, [ -AbsInt( n ) .. AbsInt( n ) ] * One( homalg_field ) );
+    
+    end );
+  
 end );
-
-
-
 

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
@@ -42,6 +42,68 @@ DeclareOperation( "VectorSpaceMorphism",
 DeclareOperationWithCache( "VectorSpaceMorphism",
                            [ IsVectorSpaceObject, IsList, IsVectorSpaceObject ] );
 
+if false then
+
+  #! @Description
+  #! The arguments are a vector space object <A>a</A> and an integer <A>n</A>.
+  #! The output is a vector space morphism from <A>a</A> into a vector space <A>b</A> with dimension <A>n</A> 
+  #! if <A>n</A> is non-negative and <C>fail</C> otherwise.
+  #! @Returns a vector space morphism
+  #! @Arguments a, n
+  DeclareOperation( RandomMorphismWithFixedSourceByInteger, [ IsVectorSpaceObject, IsInt ] );
+  
+  #! @Description
+  #! The arguments are a vector space <A>a</A> and a list <A>L</A> of length $2$. The first entry in $L$ should be an integer and
+  #! the second entry is a non-empty list of elements in the underlying homalg field.
+  #! The output is <C>fail</C> if <A>L[1]</A> is negative integer or a vector space morphism from <A>a</A> into a vector space <A>b</A> whose dimension
+  #! is <A>L[1]</A> and whose matrix entries are linear combinations of elements in <A>L[2]</A>. 
+  #! @Returns a vector space morphism
+  #! @Arguments a, L
+  DeclareOperation( RandomMorphismWithFixedSourceByList, [ IsVectorSpaceObject, IsList ] );
+  
+  #! @Description
+  #! The arguments are a vector space object <A>b</A> and an integer <A>n</A>.
+  #! The output is a vector space morphism into <A>b</A> from a vector space <A>a</A> with dimension <A>n</A>
+  #! if <A>n</A> is non-negative and <C>fail</C> otherwise.
+  #! @Returns a vector space morphism
+  #! @Arguments b, n
+  DeclareOperation( RandomMorphismWithFixedRangeByInteger, [ IsVectorSpaceObject, IsInt ] );
+  
+  #! @Description
+  #! The arguments are a vector space <A>b</A> and a list <A>L</A> of length $2$. The first entry in $L$ should be an integer and
+  #! the second entry is a non-empty list of elemets in the underlying homalg field.
+  #! The output is <C>fail</C> if <A>L[1]</A> is a negative integer, and otherwise a vector space morphism into <A>b</A> from a 
+  #! vector space <A>a</A> whose dimension is <A>L[1]</A> and whose matrix entries are linear combinations of elements in <A>L[2]</A>. 
+  #! @Returns a vector space morphism
+  #! @Arguments b, L
+  DeclareOperation( RandomMorphismWithFixedRangeByList, [ IsVectorSpaceObject, IsList ] );
+  
+  #! @Description
+  #! The arguments are two vector spaces <A>a, b</A> and an integer <A>n</A>.
+  #! The output is a vector space morphism from <A>a</A> to <A>b</A> whose matrix entries are linear combinations of elements
+  #! in  $[|n|..|n|]*1_F$, where $F$ is the underlying homalg field.
+  #! @Returns a vector space morphism
+  #! @Arguments a, b, n
+  DeclareOperation( RandomMorphismWithFixedSourceAndRangeByInteger, [ IsVectorSpaceObject, IsVectorSpaceObject, IsInt ] );
+  
+  #! @Description
+  #! The arguments are vector spaces <A>a, b</A> and a non-empty list <A>L</A> of elements in the underlying homalg field.
+  #! The output is a vector space morphism from <A>a</A> to <A>b</A> whose matrix entries are linear combinations of elements in <A>L</A>.
+  #! @Returns a vector space morphism
+  #! @Arguments a, b, L
+  DeclareOperation( RandomMorphismWithFixedSourceAndRangeByList, [ IsVectorSpaceObject, IsVectorSpaceObject, IsList ] );
+  
+  #! @Description
+  #! The arguments are a Cap matrix category <A>C</A> and a list <A>L</A> of length $3$.
+  #! The first two entries in <A>L</A> are two non-negative integers and the third entry is a non-empty list of elements in the 
+  #! underlying homalg field. The output is a random morphism whose source has dimension <A>L[1]</A> and range has dimension
+  #! <A>L[2]</A> and whose matrix entries are linear combinations of elements in <A>L[3]</A>.
+  #! @Returns a vector space morphism
+  #! @Arguments C, L
+  DeclareOperation( RandomMorphismByList, [ IsCapMatrixCategory, IsList ] );
+
+fi;
+
 ####################################
 ##
 #! @Section Attributes

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
@@ -38,6 +38,25 @@ DeclareCategory( "IsVectorSpaceObject",
 DeclareOperationWithCache( "VectorSpaceObject",
                            [ IsInt, IsFieldForHomalg ] );
 
+if false then
+
+  #! @Description
+  #! The arguments are a category <A>C</A> and an integer <A>n</A>. The output is a vector space of dimension at most <A>n</A>
+  #! if <A>n</A> is non-negative and <C>fail</C> otherwise.
+  #! @Returns a vector space
+  #! @Arguments C, n
+  DeclareOperation( RandomObjectByInteger, [ IsCapMatrixCategory, IsInt ] );
+  
+  #! @Description
+  #! The arguments are a category <A>C</A> and a nonempty list <A>L</A> of integers. The output is a vector space whose
+  #! dimension is a random element in <A>L</A>. Hence the output may be <C>fail</C> if <A>L</A> contains negative integers.
+  #! @Returns a vector space
+  #! @Arguments C, L
+  DeclareOperation( RandomObjectByList, [ IsCapMatrixCategory, IsList ] );
+
+fi;
+
+
 ####################################
 ##
 #! @Section Attributes


### PR DESCRIPTION
`RandomObject( cat, n )` should return a vector space of dimension at most `n,` or `fail` if `n <0`.
`RandomMorphismWithFixedSource( M, n )` should return a linear map whose source is `M` and the whose range dimension is n.
`RandomMorphismWithFixedRange(M,n) `should return a linear map whose range is `M `and whose source dimension is n.
`RandomMorphismWithFixedSourceAndRange( M, N, n )` should return a morphism between `M` and `N` and whose matrix-entries are elements or inverse of elements in `[ -|n| .. |n| ] * One( field )`.
`RandomMorphism(cat,n)` will be derived using `RandomObject & RandomMorphismWithFixedSource`.

This PR is part 2 of https://github.com/homalg-project/CAP_project/pull/239