### PR TITLE
Added images and descriptions to docu of FreydCategory

### DIFF
--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -405,6 +405,37 @@ DeclareOperation( "AddWeakCokernelColiftWithGivenWeakCokernelObject",
 ##
 ####################################
 
+#! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon C \rightarrow B)$, a weak bi-fiber product of $(\alpha, \beta)$ consists of three parts:
+#! * an object $P$,
+#! * morphisms $\pi_1: P \rightarrow A$, $\pi_2: P \rightarrow B$ such that $\alpha \circ \pi_1 \sim_{P,B} \beta \circ \pi_2$,
+#! * a dependent function $u$ mapping each tripel consisting of an object $T$, a morphism $\tau_1: T \rightarrow A$ and a morphism $\tau: T \to C$ such that $\alpha \circ \tau_1 \sim_{T,B} \beta \circ \tau_2$ to a morphism $u(\tau):T \rightarrow P$ such that $\pi_1 \circ u( \tau ) \sim_{A,T} \tau_1$ and $\pi_2 \circ u( \tau ) \sim_{C,T} \tau_2$.
+#! The quadrupel $( P, \pi_1, \pi_2, u )$ is called a <Emph>weak bi-fiber product</Emph> of $(\alpha,\beta)$.
+#! We denote the object $P$ of such a quadrupel by $\mathrm{WeakBiFiberProduct}(\alpha,\beta)$.
+#! We say that the morphism $u(\tau)$ is induced by the
+#! <Emph>universal property of the weak bi-fiber product</Emph>.
+#! $\\ $
+
+## FIXME functoriality of $\mathrm{WeakBiFiberProduct}$
+
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \node (C) at (\w,\w) {$C$};
+#! \node (P) at (0,\w) {$P$};
+#! \node (T) at (-\w,2*\w) {$T$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (C) to node[pos=0.45, right] {$\beta$} (B);
+#! \draw[-latex] (P) to node[pos=0.45, left] {$\pi_1$} (A);
+#! \draw[-latex] (P) to node[pos=0.45, above] {$\pi_2$} (C);
+#! \draw[-latex] (T) to [out = -90, in = 180] node[pos=0.45, left] {$\tau_1$} (A);
+#! \draw[-latex] (T) to [out = 0, in = 90] node[pos=0.45, above] {$\tau_2$} (C);
+#! \draw[-latex] (T) to node[pos=0.45, above right] {$u( \tau )$} (P);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
 
 ## Main Operations and Attributes
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -56,7 +56,7 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION"
 #! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
 #! \draw[-latex] (K) to node[pos=0.45, above] {$\iota$} (A);
 #! \draw[-latex] (T) to node[pos=0.45, above right] {$\tau$} (A);
-#! \draw[-latex] (T) to node[pos=0.45, left] {$u( \tau )$} (K);
+#! \draw[-latex] (T) to node[pos=0.45, left] {$\exists u( \tau )$} (K);
 #! \draw[-latex, dotted] (T) to [out = 0, in = 90] node[pos=0.45, above right] {$\alpha \circ \tau \sim_{T,B} 0$} (B);
 #! \draw[-latex, dotted] (K) to [out = -45, in = -135] node[pos=0.45, below] {$\alpha \circ \iota \sim_{K,B} 0$} (B);
 #! \end{tikzpicture}
@@ -244,7 +244,7 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 #! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
 #! \draw[-latex] (B) to node[pos=0.45, above] {$\epsilon$} (K);
 #! \draw[-latex] (B) to node[pos=0.45, above left] {$\tau$} (T);
-#! \draw[-latex] (K) to node[pos=0.45, left] {$u( \tau )$} (T);
+#! \draw[-latex] (K) to node[pos=0.45, left] {$\exists u( \tau )$} (T);
 #! \draw[-latex, dotted] (A) to [out = 90, in = 180] node[pos=0.45, above left] {$\tau \circ \alpha \sim_{A,T} 0$} (T);
 #! \draw[-latex, dotted] (A) to [out = -45, in = -135] node[pos=0.45, below] {$\epsilon \circ \alpha \sim_{A,K} 0$} (K);
 #! \end{tikzpicture}
@@ -432,7 +432,7 @@ DeclareOperation( "AddWeakCokernelColiftWithGivenWeakCokernelObject",
 #! \draw[-latex] (P) to node[pos=0.45, above] {$\pi_2$} (C);
 #! \draw[-latex] (T) to [out = -90, in = 180] node[pos=0.45, left] {$\tau_1$} (A);
 #! \draw[-latex] (T) to [out = 0, in = 90] node[pos=0.45, above] {$\tau_2$} (C);
-#! \draw[-latex] (T) to node[pos=0.45, above right] {$u( \tau )$} (P);
+#! \draw[-latex] (T) to node[pos=0.45, above right] {$\exists u( \tau )$} (P);
 #! \end{tikzpicture}
 #! \end{center}
 #! @EndLatexOnly
@@ -630,7 +630,7 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 #! \draw[-latex] (C) to node[pos=0.45, right] {$\beta$} (B);
 #! \draw[-latex] (P) to node[pos=0.45, left] {$\pi$} (A);
 #! \draw[-latex] (T) to [out = -90, in = 180] node[pos=0.45, left] {$\tau$} (A);
-#! \draw[-latex] (T) to node[pos=0.45, above right] {$u( \tau )$} (P);
+#! \draw[-latex] (T) to node[pos=0.45, above right] {$\exists u( \tau )$} (P);
 #! \draw[-latex, dotted] (P) to node[pos=0.45, above] {$\delta$} (C);
 #! \draw[-latex, dotted] (T) to [out = 0, in = 90] node[pos=0.45, above] {$\mu$} (C);
 #! \end{tikzpicture}
@@ -786,7 +786,7 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 #! \draw[-latex] (A) to node[pos=0.45, left] {$\beta$} (C);
 #! \draw[-latex] (B) to node[pos=0.45, right] {$\iota_1$} (P);
 #! \draw[-latex] (B) to [out = 0, in = -90] node[pos=0.45, right] {$\tau_1$} (T);
-#! \draw[-latex] (P) to node[pos=0.45, above left] {$u( \tau )$} (T);
+#! \draw[-latex] (P) to node[pos=0.45, above left] {$\exists u( \tau )$} (T);
 #! \draw[-latex] (C) to node[pos=0.45, above] {$\iota_2$} (P);
 #! \draw[-latex] (C) to [out = 90, in = 180] node[pos=0.45, above] {$\tau_2$} (T);
 #! \end{tikzpicture}
@@ -984,7 +984,7 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 #! \draw[-latex] (A) to node[pos=0.45, left] {$\beta$} (C);
 #! \draw[-latex] (B) to node[pos=0.45, right] {$\iota$} (P);
 #! \draw[-latex] (B) to [out = 0, in = -90] node[pos=0.45, right] {$\tau$} (T);
-#! \draw[-latex] (P) to node[pos=0.45, above left] {$u( \tau )$} (T);
+#! \draw[-latex] (P) to node[pos=0.45, above left] {$\exists u( \tau )$} (T);
 #! \draw[-latex, dotted] (C) to node[pos=0.45, above] {$\delta$} (P);
 #! \draw[-latex, dotted] (C) to [out = 90, in = 180] node[pos=0.45, above] {$\mu$} (T);
 #! \end{tikzpicture}

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -961,7 +961,7 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta: A \rightarrow C)$, a biased weak pushout  of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
-#! * a morphism $\iota: B \rightarrow P$ such that there exists a morphism $\delta: C \rightarrow P$ such that $\delta \circ \beta \sim_{P,A} \iota \circ \alpha$,
+#! * a morphism $\iota: B \rightarrow P$ such that there exists a morphism $\delta: C \rightarrow P$ such that $\delta \circ \beta \sim_{A,P} \iota \circ \alpha$,
 #! * a dependent function $u$ mapping each $\tau: B \rightarrow T$, which admits a morphism $\mu \colon C \rightarrow T$ with $\mu \circ \beta \sim_{T,B} \tau \circ \alpha$, to a morphism $u(\tau):P \rightarrow T$ such that $u(\tau) \circ \iota \sim_{T,A} \tau$.
 #! The triple $( P, \iota, u )$ is called a <Emph>biased weak pushout</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a triple by $\mathrm{BiasedWeakPushout}(\alpha,\beta)$.

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -764,7 +764,7 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon A \rightarrow C)$, a weak bi-pushout of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
 #! * morphisms $\iota_1: B \rightarrow P$, $\iota_2: C \rightarrow P$ such that $\iota_1 \circ \alpha \sim_{A,P} \iota_2 \circ \beta$,
-#! * a dependent function $u$ mapping each pair $\tau = (\tau_1, \tau_2)$ of morphisms $\tau_1: B \rightarrow T$, $\tau_2: C \rightarrow T$ with the property $\tau_1 \circ \alpha \sim_{T,A} \tau_2 \circ \beta$ to a morphism $u(\tau): P \rightarrow T$ such that $u( \tau ) \circ \iota_1 \sim_{B,T} \tau_1$ and $u( \tau ) \circ \iota_2 \sim_{C,T} \tau_2$.
+#! * a dependent function $u$ mapping each pair $\tau = (\tau_1, \tau_2)$ of morphisms $\tau_1: B \rightarrow T$, $\tau_2: C \rightarrow T$ with the property $\tau_1 \circ \alpha \sim_{A,T} \tau_2 \circ \beta$ to a morphism $u(\tau): P \rightarrow T$ such that $u( \tau ) \circ \iota_1 \sim_{B,T} \tau_1$ and $u( \tau ) \circ \iota_2 \sim_{C,T} \tau_2$.
 #! The quadrupel $( P, \iota_1, \iota_2, u )$ is called a <Emph>weak bi-pushout</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a quadrupel by $\mathrm{WeakBiPushout}(\alpha,\beta)$.
 #! We say that the morphism $u(\tau)$ is induced by the

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -219,20 +219,19 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 ##
 ####################################
 
-#! For a given morphism $\alpha: A \rightarrow B$, a cokernel of $\alpha$ consists of three parts:
+#! For a given morphism $\alpha: A \rightarrow B$, a weak cokernel of $\alpha$ consists of three parts:
 #! * an object $K$,
 #! * a morphism $\epsilon: B \rightarrow K$ such that $\epsilon \circ \alpha \sim_{A,K} 0$,
 #! * a dependent function $u$ mapping each $\tau: B \rightarrow T$ satisfying $\tau \circ \alpha \sim_{A, T} 0$ to a morphism $u(\tau):K \rightarrow T$ such that $u(\tau) \circ \epsilon \sim_{B,T} \tau$.
-#! The triple $( K, \epsilon, u )$ is called a <Emph>cokernel</Emph> of $\alpha$ if the morphisms $u( \tau )$ are uniquely determined up to
-#! congruence of morphisms.
-#! We denote the object $K$ of such a triple by $\mathrm{CokernelObject}(\alpha)$.
+#! The triple $( K, \epsilon, u )$ is called a <Emph>weak cokernel</Emph> of $\alpha$.
+#! We denote the object $K$ of such a triple by $\mathrm{WeakCokernelObject}(\alpha)$.
 #! We say that the morphism $u(\tau)$ is induced by the
-#! <Emph>universal property of the cokernel</Emph>.
+#! <Emph>universal property of the weak cokernel</Emph>.
 #! $\\ $
-#! $\mathrm{CokernelObject}$ is a functorial operation. This means:
+#! $\mathrm{WeakCokernelObject}$ is a functorial operation. This means:
 #! for $\mu: A \rightarrow A'$, $\nu: B \rightarrow B'$,
 #! $\alpha: A \rightarrow B$, $\alpha': A' \rightarrow B'$ such that $\nu \circ \alpha \sim_{A,B'} \alpha' \circ \mu$,
-#! we obtain a morphism $\mathrm{CokernelObject}( \alpha ) \rightarrow \mathrm{CokernelObject}( \alpha' )$.
+#! we obtain a morphism $\mathrm{WeakCokernelObject}( \alpha ) \rightarrow \mathrm{WeakCokernelObject}( \alpha' )$.
 
 #! @BeginLatexOnly
 #! \begin{center}

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -962,7 +962,7 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta: A \rightarrow C)$, a biased weak pushout  of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
 #! * a morphism $\iota: B \rightarrow P$ such that there exists a morphism $\delta: C \rightarrow P$ such that $\delta \circ \beta \sim_{A,P} \iota \circ \alpha$,
-#! * a dependent function $u$ mapping each $\tau: B \rightarrow T$, which admits a morphism $\mu \colon C \rightarrow T$ with $\mu \circ \beta \sim_{T,B} \tau \circ \alpha$, to a morphism $u(\tau):P \rightarrow T$ such that $u(\tau) \circ \iota \sim_{T,A} \tau$.
+#! * a dependent function $u$ mapping each $\tau: B \rightarrow T$, which admits a morphism $\mu \colon C \rightarrow T$ with $\mu \circ \beta \sim_{B,T} \tau \circ \alpha$, to a morphism $u(\tau):P \rightarrow T$ such that $u(\tau) \circ \iota \sim_{A,T} \tau$.
 #! The triple $( P, \iota, u )$ is called a <Emph>biased weak pushout</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a triple by $\mathrm{BiasedWeakPushout}(\alpha,\beta)$.
 #! We say that the morphism $u(\tau)$ is induced by the

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -763,7 +763,7 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon A \rightarrow C)$, a weak bi-pushout of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
-#! * morphisms $\iota_1: B \rightarrow P$, $\iota_2: C \rightarrow P$ such that $\iota_1 \circ \alpha \sim_{P,A} \iota_2 \circ \beta$,
+#! * morphisms $\iota_1: B \rightarrow P$, $\iota_2: C \rightarrow P$ such that $\iota_1 \circ \alpha \sim_{A,P} \iota_2 \circ \beta$,
 #! * a dependent function $u$ mapping each pair $\tau = (\tau_1, \tau_2)$ of morphisms $\tau_1: B \rightarrow T$, $\tau_2: C \rightarrow T$ with the property $\tau_1 \circ \alpha \sim_{T,A} \tau_2 \circ \beta$ to a morphism $u(\tau): P \rightarrow T$ such that $u( \tau ) \circ \iota_1 \sim_{B,T} \tau_1$ and $u( \tau ) \circ \iota_2 \sim_{C,T} \tau_2$.
 #! The quadrupel $( P, \iota_1, \iota_2, u )$ is called a <Emph>weak bi-pushout</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a quadrupel by $\mathrm{WeakBiPushout}(\alpha,\beta)$.

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -235,6 +235,23 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 #! $\alpha: A \rightarrow B$, $\alpha': A' \rightarrow B'$ such that $\nu \circ \alpha \sim_{A,B'} \alpha' \circ \mu$,
 #! we obtain a morphism $\mathrm{CokernelObject}( \alpha ) \rightarrow \mathrm{CokernelObject}( \alpha' )$.
 
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \node (K) at (2*\w,0) {$K$};
+#! \node (T) at (2*\w,\w) {$T$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (B) to node[pos=0.45, above] {$\epsilon$} (K);
+#! \draw[-latex] (B) to node[pos=0.45, above left] {$\tau$} (T);
+#! \draw[-latex] (K) to node[pos=0.45, left] {$u( \tau )$} (T);
+#! \draw[-latex, dotted] (A) to [out = 90, in = 180] node[pos=0.45, above left] {$\tau \circ \alpha \sim_{A,T} 0$} (T);
+#! \draw[-latex, dotted] (A) to [out = -45, in = -135] node[pos=0.45, below] {$\epsilon \circ \alpha \sim_{A,K} 0$} (K);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
 
 
 ## Main Operations and Attributes

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -244,7 +244,7 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 #! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
 #! \draw[-latex] (B) to node[pos=0.45, above] {$\epsilon$} (K);
 #! \draw[-latex] (B) to node[pos=0.45, above left] {$\tau$} (T);
-#! \draw[-latex] (K) to node[pos=0.45, left] {$\exists u( \tau )$} (T);
+#! \draw[-latex] (K) to node[pos=0.45, right] {$\exists u( \tau )$} (T);
 #! \draw[-latex, dotted] (A) to [out = 90, in = 180] node[pos=0.45, above left] {$\tau \circ \alpha \sim_{A,T} 0$} (T);
 #! \draw[-latex, dotted] (A) to [out = -45, in = -135] node[pos=0.45, below] {$\epsilon \circ \alpha \sim_{A,K} 0$} (K);
 #! \end{tikzpicture}

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -574,6 +574,38 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 ##
 ####################################
 
+#! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon C \rightarrow B)$, a biased weak fiber product of $(\alpha, \beta)$ consists of three parts:
+#! * an object $P$,
+#! * a morphism $\pi: P \rightarrow A$ such that there exists a morphism $\delta: P \rightarrow C$ such that $\beta \circ \delta \sim_{P,B} \alpha \circ \pi$,
+#! * a dependent function $u$ mapping each $\tau: T \rightarrow A$, which admits a morphism $\mu \colon T \rightarrow C$ with $\mu \circ \beta \sim_{T,B} \alpha \circ \tau$, to a morphism $u(\tau):T \rightarrow P$ such that $\pi \circ u(\tau) \sim_{T,A} \tau$.
+#! The triple $( P, \pi, u )$ is called a <Emph>biased weak fiber product</Emph> of $(\alpha,\beta)$.
+#! We denote the object $P$ of such a triple by $\mathrm{BiasedWeakFiberProduct}(\alpha,\beta)$.
+#! We say that the morphism $u(\tau)$ is induced by the
+#! <Emph>universal property of the biased weak fiber product</Emph>.
+#! $\\ $
+
+## FIXME functoriality of $\mathrm{BiasedWeakFiberProduct}$
+
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \node (C) at (\w,\w) {$C$};
+#! \node (P) at (0,\w) {$P$};
+#! \node (T) at (-\w,2*\w) {$T$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (C) to node[pos=0.45, right] {$\beta$} (B);
+#! \draw[-latex] (P) to node[pos=0.45, left] {$\pi$} (A);
+#! \draw[-latex] (T) to [out = -90, in = 180] node[pos=0.45, left] {$\tau$} (A);
+#! \draw[-latex] (T) to node[pos=0.45, above right] {$u( \tau )$} (P);
+#! \draw[-latex, dotted] (P) to node[pos=0.45, above] {$\delta$} (C);
+#! \draw[-latex, dotted] (T) to [out = 0, in = 90] node[pos=0.45, above] {$\mu$} (C);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
+
 
 ## Main Operations and Attributes
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -896,6 +896,37 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 ##
 ####################################
 
+#! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta: A \rightarrow C)$, a biased weak pushout  of $(\alpha, \beta)$ consists of three parts:
+#! * an object $P$,
+#! * a morphism $\iota: B \rightarrow P$ such that there exists a morphism $\delta: C \rightarrow P$ such that $\delta \circ \beta \sim_{P,A} \iota \circ \alpha$,
+#! * a dependent function $u$ mapping each $\tau: B \rightarrow T$, which admits a morphism $\mu \colon C \rightarrow T$ with $\mu \circ \beta \sim_{T,B} \tau \circ \alpha$, to a morphism $u(\tau):P \rightarrow T$ such that $u(\tau) \circ \iota \sim_{T,A} \tau$.
+#! The triple $( P, \iota, u )$ is called a <Emph>biased weak pushout</Emph> of $(\alpha,\beta)$.
+#! We denote the object $P$ of such a triple by $\mathrm{BiasedWeakPushout}(\alpha,\beta)$.
+#! We say that the morphism $u(\tau)$ is induced by the
+#! <Emph>universal property of the biased weak pushout</Emph>.
+#! $\\ $
+
+## FIXME functoriality of $\mathrm{BiasedWeakPushout}$
+
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \node (C) at (0,\w) {$C$};
+#! \node (P) at (\w,\w) {$P$};
+#! \node (T) at (2*\w,2*\w) {$T$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (A) to node[pos=0.45, left] {$\beta$} (C);
+#! \draw[-latex] (B) to node[pos=0.45, right] {$\iota$} (P);
+#! \draw[-latex] (B) to [out = 0, in = -90] node[pos=0.45, right] {$\tau$} (T);
+#! \draw[-latex] (P) to node[pos=0.45, above left] {$u( \tau )$} (T);
+#! \draw[-latex, dotted] (C) to node[pos=0.45, above] {$\delta$} (P);
+#! \draw[-latex, dotted] (C) to [out = 90, in = 180] node[pos=0.45, above] {$\mu$} (T);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
 
 DeclareOperation( "BiasedWeakPushout",
                    [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -577,7 +577,7 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon C \rightarrow B)$, a biased weak fiber product of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
 #! * a morphism $\pi: P \rightarrow A$ such that there exists a morphism $\delta: P \rightarrow C$ such that $\beta \circ \delta \sim_{P,B} \alpha \circ \pi$,
-#! * a dependent function $u$ mapping each $\tau: T \rightarrow A$, which admits a morphism $\mu \colon T \rightarrow C$ with $\mu \circ \beta \sim_{T,B} \alpha \circ \tau$, to a morphism $u(\tau):T \rightarrow P$ such that $\pi \circ u(\tau) \sim_{T,A} \tau$.
+#! * a dependent function $u$ mapping each $\tau: T \rightarrow A$, which admits a morphism $\mu \colon T \rightarrow C$ with $\beta \circ \mu \sim_{T,B} \alpha \circ \tau$, to a morphism $u(\tau):T \rightarrow P$ such that $\pi \circ u(\tau) \sim_{T,A} \tau$.
 #! The triple $( P, \pi, u )$ is called a <Emph>biased weak fiber product</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a triple by $\mathrm{BiasedWeakFiberProduct}(\alpha,\beta)$.
 #! We say that the morphism $u(\tau)$ is induced by the

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -48,7 +48,7 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION"
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (T) at (-\w,\w) {$T$};
 #! \node (K) at (-\w,0) {$K$};
 #! \node (A) at (0,0) {$A$};
@@ -236,7 +236,7 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (K) at (2*\w,0) {$K$};
@@ -420,7 +420,7 @@ DeclareOperation( "AddWeakCokernelColiftWithGivenWeakCokernelObject",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (\w,\w) {$C$};
@@ -620,7 +620,7 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (\w,\w) {$C$};
@@ -776,7 +776,7 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (0,\w) {$C$};
@@ -974,7 +974,7 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
+#! \def\w{2};
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (0,\w) {$C$};

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -46,6 +46,23 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION"
 #! $\alpha: A \rightarrow B$, $\alpha': A' \rightarrow B'$ such that $\nu \circ \alpha \sim_{A,B'} \alpha' \circ \mu$,
 #! we obtain a morphism $\mathrm{KernelObject}( \alpha ) \rightarrow \mathrm{KernelObject}( \alpha' )$.
 
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (T) at (-\w,\w) {$T$};
+#! \node (K) at (-\w,0) {$K$};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (K) to node[pos=0.45, above] {$\iota$} (A);
+#! \draw[-latex] (T) to node[pos=0.45, above right] {$\tau$} (A);
+#! \draw[-latex] (T) to node[pos=0.45, left] {$u( \tau )$} (K);
+#! \draw[-latex, dotted] (T) to [out = 0, in = 90] node[pos=0.45, above right] {$\alpha \circ \tau \sim_{T,B} 0$} (B);
+#! \draw[-latex, dotted] (K) to [out = -45, in = -135] node[pos=0.45, below] {$\alpha \circ \iota \sim_{K,B} 0$} (B);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
 
 ## Main Operations and Attributes
 #! @Description

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -31,20 +31,19 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION"
 ##
 ####################################
 
-#! For a given morphism $\alpha: A \rightarrow B$, a kernel of $\alpha$ consists of three parts:
+#! For a given morphism $\alpha: A \rightarrow B$, a weak kernel of $\alpha$ consists of three parts:
 #! * an object $K$, 
 #! * a morphism $\iota: K \rightarrow A$ such that $\alpha \circ \iota \sim_{K,B} 0$,
 #! * a dependent function $u$ mapping each morphism $\tau: T \rightarrow A$ satisfying $\alpha \circ \tau \sim_{T,B} 0$ to a morphism $u(\tau): T \rightarrow K$ such that $\iota \circ u( \tau ) \sim_{T,A} \tau$. 
-#! The triple $( K, \iota, u )$ is called a <Emph>kernel</Emph> of $\alpha$ if the morphisms $u( \tau )$ are uniquely determined up to
-#! congruence of morphisms.
-#! We denote the object $K$ of such a triple by $\mathrm{KernelObject}(\alpha)$.
+#! The triple $( K, \iota, u )$ is called a <Emph>weak kernel</Emph> of $\alpha$.
+#! We denote the object $K$ of such a triple by $\mathrm{WeakKernelObject}(\alpha)$.
 #! We say that the morphism $u(\tau)$ is induced by the
-#! <Emph>universal property of the kernel</Emph>.
+#! <Emph>universal property of the weak kernel</Emph>.
 #! $\\ $
-#! $\mathrm{KernelObject}$ is a functorial operation. This means:
+#! $\mathrm{WeakKernelObject}$ is a functorial operation. This means:
 #! for $\mu: A \rightarrow A'$, $\nu: B \rightarrow B'$,
 #! $\alpha: A \rightarrow B$, $\alpha': A' \rightarrow B'$ such that $\nu \circ \alpha \sim_{A,B'} \alpha' \circ \mu$,
-#! we obtain a morphism $\mathrm{KernelObject}( \alpha ) \rightarrow \mathrm{KernelObject}( \alpha' )$.
+#! we obtain a morphism $\mathrm{WeakKernelObject}( \alpha ) \rightarrow \mathrm{WeakKernelObject}( \alpha' )$.
 
 #! @BeginLatexOnly
 #! \begin{center}

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -761,6 +761,38 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 ##
 ####################################
 
+#! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon A \rightarrow C)$, a weak bi-pushout of $(\alpha, \beta)$ consists of three parts:
+#! * an object $P$,
+#! * morphisms $\iota_1: B \rightarrow P$, $\iota_2: C \rightarrow P$ such that $\iota_1 \circ \alpha \sim_{P,A} \iota_2 \circ \beta$,
+#! * a dependent function $u$ mapping each pair $\tau = (\tau_1, \tau_2)$ of morphisms $\tau_1: B \rightarrow T$, $\tau_2: C \rightarrow T$ with the property $\tau_1 \circ \alpha \sim_{T,A} \tau_2 \circ \beta$ to a morphism $u(\tau): P \rightarrow T$ such that $u( \tau ) \circ \iota_1 \sim_{B,T} \tau_1$ and $u( \tau ) \circ \iota_2 \sim_{C,T} \tau_2$.
+#! The quadrupel $( P, \iota_1, \iota_2, u )$ is called a <Emph>weak bi-pushout</Emph> of $(\alpha,\beta)$.
+#! We denote the object $P$ of such a quadrupel by $\mathrm{WeakBiPushout}(\alpha,\beta)$.
+#! We say that the morphism $u(\tau)$ is induced by the
+#! <Emph>universal property of the weak bi-pushout</Emph>.
+#! $\\ $
+
+## FIXME functoriality of $\mathrm{WeakBiPushout}$
+
+#! @BeginLatexOnly
+#! \begin{center}
+#! \begin{tikzpicture}
+#! \def\w{4};
+#! \node (A) at (0,0) {$A$};
+#! \node (B) at (\w,0) {$B$};
+#! \node (C) at (0,\w) {$C$};
+#! \node (P) at (\w,\w) {$P$};
+#! \node (T) at (2*\w,2*\w) {$T$};
+#! \draw[-latex] (A) to node[pos=0.45, above] {$\alpha$} (B);
+#! \draw[-latex] (A) to node[pos=0.45, left] {$\beta$} (C);
+#! \draw[-latex] (B) to node[pos=0.45, right] {$\iota_1$} (P);
+#! \draw[-latex] (B) to [out = 0, in = -90] node[pos=0.45, right] {$\tau_1$} (T);
+#! \draw[-latex] (P) to node[pos=0.45, above left] {$u( \tau )$} (T);
+#! \draw[-latex] (C) to node[pos=0.45, above] {$\iota_2$} (P);
+#! \draw[-latex] (C) to [out = 90, in = 180] node[pos=0.45, above] {$\tau_2$} (T);
+#! \end{tikzpicture}
+#! \end{center}
+#! @EndLatexOnly
+
 
 DeclareOperation( "WeakBiPushout",
                    [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -408,7 +408,7 @@ DeclareOperation( "AddWeakCokernelColiftWithGivenWeakCokernelObject",
 #! For a given pair of morphisms $(\alpha: A \rightarrow B, \beta \colon C \rightarrow B)$, a weak bi-fiber product of $(\alpha, \beta)$ consists of three parts:
 #! * an object $P$,
 #! * morphisms $\pi_1: P \rightarrow A$, $\pi_2: P \rightarrow B$ such that $\alpha \circ \pi_1 \sim_{P,B} \beta \circ \pi_2$,
-#! * a dependent function $u$ mapping each tripel consisting of an object $T$, a morphism $\tau_1: T \rightarrow A$ and a morphism $\tau: T \to C$ such that $\alpha \circ \tau_1 \sim_{T,B} \beta \circ \tau_2$ to a morphism $u(\tau):T \rightarrow P$ such that $\pi_1 \circ u( \tau ) \sim_{A,T} \tau_1$ and $\pi_2 \circ u( \tau ) \sim_{C,T} \tau_2$.
+#! * a dependent function $u$ mapping each pair $\tau = ( \tau_1, \tau_2 )$ of morphisms $\tau_1: T \rightarrow A$, $\tau_2: T \rightarrow C$ with the property $\alpha \circ \tau_1 \sim_{T,B} \beta \circ \tau_2$ to a morphism $u(\tau):T \rightarrow P$ such that $\pi_1 \circ u( \tau ) \sim_{A,T} \tau_1$ and $\pi_2 \circ u( \tau ) \sim_{C,T} \tau_2$.
 #! The quadrupel $( P, \pi_1, \pi_2, u )$ is called a <Emph>weak bi-fiber product</Emph> of $(\alpha,\beta)$.
 #! We denote the object $P$ of such a quadrupel by $\mathrm{WeakBiFiberProduct}(\alpha,\beta)$.
 #! We say that the morphism $u(\tau)$ is induced by the

--- a/FreydCategoriesForCAP/makedoc.g
+++ b/FreydCategoriesForCAP/makedoc.g
@@ -3,7 +3,13 @@
 #
 LoadPackage( "AutoDoc" );
 
-AutoDoc( "FreydCategoriesForCAP" : scaffold := true, autodoc :=
+AutoDoc( "FreydCategoriesForCAP" :
+         scaffold :=
+          rec(
+            gapdoc_latex_options := rec(
+            LateExtraPreamble := "\\usepackage{tikz}\n\\usetikzlibrary{arrows}" )
+          ),
+         autodoc :=
          rec( files := [ "doc/Intros.autodoc" ],
          scan_dirs := [ "gap", "gap/CategoryOfGradedRowsAndColumns", "examples", "doc" ] ),
          maketest := rec( commands :=


### PR DESCRIPTION
I updated the documentation of weak kernel and weak kernel and added images for these descriptions. Does this close the issue number 185?

Also, I added descriptions and images for the following:
- Weak bi-fiber product
- Biased weak fiber product
- weak bi-pushout
- biased weak pushout