### PR TITLE
FreydCategoriesForCAP: Deduce (some) map from a matrix and source/range.

### DIFF
--- a/FreydCategoriesForCAP/examples/GradedRowsAndColumns.g
+++ b/FreydCategoriesForCAP/examples/GradedRowsAndColumns.g
@@ -756,7 +756,6 @@ IsWellDefined( tens_mor );
 #! true
 #! @EndExample
 
-
 #####################################################################
 #! @Section FreydCategory for graded rows
 #####################################################################
@@ -920,3 +919,65 @@ Display( CokernelColift( z, CokernelProjection( z ) ) );
 #! 1
 #! (over a graded ring)
 #! @EndExample
+
+
+########################################################################
+#! @Section Examples to test Tools methods in graded rows/cols
+########################################################################
+
+#! @Example
+S := GradedRing( Q * "x,y" );
+#! Q[x,y]
+#! (weights: yet unset)
+SetWeightsOfIndeterminates( S, [ 1, 1 ] );
+mat_1 := HomalgMatrix( "[ x, 0, 0, y ]", 2, 2, S );
+#! <A 2 x 2 matrix over a graded ring>
+mat_2 := HomalgMatrix( "[ x, 0, 0, 0 ]", 2, 2, S );
+#! <A 2 x 2 matrix over a graded ring>
+a := GradedRow( [ [ [ 1 ], 1 ], [ [ 2 ], 1 ] ], S );
+#! <A graded row of rank 2>
+b := GradedColumn( [ [ [ 1 ], 1 ], [ [ 2 ], 1 ] ], S );
+#! <A graded column of rank 2>
+map := DeduceMapFromMatrixAndRangeForGradedRows( mat_1, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+some_map := DeduceSomeMapFromMatrixAndRangeForGradedRows( mat_1, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+IsEqualForMorphisms( map, some_map );
+#! true
+map := DeduceMapFromMatrixAndSourceForGradedRows( mat_1, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+some_map := DeduceSomeMapFromMatrixAndSourceForGradedRows( mat_1, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+IsEqualForMorphisms( map, some_map );
+#! true
+some_map := DeduceSomeMapFromMatrixAndRangeForGradedRows( mat_2, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+IsWellDefined( some_map );
+#! true
+some_map := DeduceSomeMapFromMatrixAndSourceForGradedRows( mat_2, a );
+#! <A morphism in the category of graded rows over Q[x,y] (with weights [ 1, 1 ])>
+IsWellDefined( some_map );
+#! true
+map := DeduceMapFromMatrixAndRangeForGradedCols( mat_1, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+some_map := DeduceSomeMapFromMatrixAndRangeForGradedCols( mat_1, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+IsEqualForMorphisms( map, some_map );
+#! true
+map := DeduceMapFromMatrixAndSourceForGradedCols( mat_1, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+some_map := DeduceSomeMapFromMatrixAndSourceForGradedCols( mat_1, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+IsEqualForMorphisms( map, some_map );
+#! true
+some_map := DeduceSomeMapFromMatrixAndRangeForGradedCols( mat_2, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+IsWellDefined( some_map );
+#! true
+some_map := DeduceSomeMapFromMatrixAndSourceForGradedCols( mat_2, b );
+#! <A morphism in the category of graded columns over Q[x,y] (with weights [ 1, 1 ])>
+IsWellDefined( some_map );
+#! true
+#! @EndExample
+
+

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/Tools.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/Tools.gd
@@ -19,38 +19,77 @@
 #! @Description
 #! The argument is a homalg_matrix <A>m</A> and a graded row <A>R</A>. We then consider the module map 
 #! induced from <A>m</A> with range <A>R</A>. This operation then deduces the source of this map and returns
-#! the map in the category of graded rows.
+#! the map in the category of graded rows if the degrees of the source are uniquely determined.
 #! @Returns a morphism
 #! @Arguments m, R
 DeclareOperation( "DeduceMapFromMatrixAndRangeForGradedRows",
                   [ IsHomalgMatrix, IsGradedRow ] );
 
 #! @Description
+#! The argument is a homalg_matrix <A>m</A> and a graded row <A>R</A>.
+#! This operation deduces the source of some map with matrix <A>m</A> and range <A>R</A> and returns
+#! the map in the category of graded rows.
+#! @Returns a morphism
+#! @Arguments m, R
+DeclareOperation( "DeduceSomeMapFromMatrixAndRangeForGradedRows",
+                  [ IsHomalgMatrix, IsGradedRow ] );
+
+
+#! @Description
 #! The argument is a homalg_matrix <A>m</A> and a graded row <A>S</A>. We then consider the module map 
 #! induced from <A>m</A> with source <A>S</A>. This operation then deduces the range of this map and returns
-#! the map in the category of graded rows.
+#! the map in the category of graded rows if the degrees of the range are uniquely determined.
 #! @Returns a morphism
 #! @Arguments m, S
 DeclareOperation( "DeduceMapFromMatrixAndSourceForGradedRows",
                   [ IsHomalgMatrix, IsGradedRow ] );
 
 #! @Description
+#! The argument is a homalg_matrix <A>m</A> and a graded row <A>S</A>.
+#! This operation deduces the range of some map with matrix <A>m</A> and source <A>S</A> and returns
+#! the map in the category of graded rows.
+#! @Returns a morphism
+#! @Arguments m, S
+DeclareOperation( "DeduceSomeMapFromMatrixAndSourceForGradedRows",
+                  [ IsHomalgMatrix, IsGradedRow ] );
+
+#! @Description
 #! The argument is a homalg_matrix <A>m</A> and a graded column <A>R</A>. We then consider the module map 
 #! induced from <A>m</A> with range <A>R</A>. This operation then deduces the source of this map and returns
-#! the map in the category of graded columns.
+#! the map in the category of graded columns if the degrees of the source are uniquely determined.
 #! @Returns a morphism
 #! @Arguments m, R
 DeclareOperation( "DeduceMapFromMatrixAndRangeForGradedCols",
                   [ IsHomalgMatrix, IsGradedColumn ] );
 
 #! @Description
+#! The argument is a homalg_matrix <A>m</A> and a graded column <A>R</A>.
+#! This operation deduces the source of some map with matrix <A>m</A> and range <A>R</A> and returns
+#! the map in the category of graded columns.
+#! @Returns a morphism
+#! @Arguments m, R
+DeclareOperation( "DeduceSomeMapFromMatrixAndRangeForGradedCols",
+                  [ IsHomalgMatrix, IsGradedColumn ] );
+
+
+#! @Description
 #! The argument is a homalg_matrix <A>m</A> and a graded column <A>S</A>. We then consider the module map 
 #! induced from <A>m</A> with source <A>S</A>. This operation then deduces the range of this map and returns
-#! the map in the category of graded columns.
+#! the map in the category of graded columns if the degrees of the range are uniquely determined.
 #! @Returns a morphism
 #! @Arguments m, S
 DeclareOperation( "DeduceMapFromMatrixAndSourceForGradedCols",
                   [ IsHomalgMatrix, IsGradedColumn ] );
+
+#! @Description
+#! The argument is a homalg_matrix <A>m</A> and a graded column <A>S</A>.
+#! This operation deduces the range of some map with matrix <A>m</A> and source <A>S</A> and returns
+#! the map in the category of graded columns.
+#! @Returns a morphism
+#! @Arguments m, S
+DeclareOperation( "DeduceSomeMapFromMatrixAndSourceForGradedCols",
+                  [ IsHomalgMatrix, IsGradedColumn ] );
+
 
 #! @Description
 #! Given a graded row or column <A>S</A>, the degrees are stored in compact form. For example, the degrees [ 1, 1, 1, 1 ] #! is stored internally as [ 1, 4 ]. The second argument is thus the multipicity with which three degree 1 
@@ -59,3 +98,15 @@ DeclareOperation( "DeduceMapFromMatrixAndSourceForGradedCols",
 #! @Arguments S
 DeclareOperation( "UnzipDegreeList",
                   [ IsGradedRowOrColumn ] );
+
+
+## Global functions
+
+DeclareGlobalFunction( "DEDUCE_MAP_FROM_MATRIX_AND_RANGE_FOR_GRADED_ROWS" );
+
+DeclareGlobalFunction( "DEDUCE_MAP_FROM_MATRIX_AND_SOURCE_FOR_GRADED_ROWS" );
+
+DeclareGlobalFunction( "DEDUCE_MAP_FROM_MATRIX_AND_RANGE_FOR_GRADED_COLS" );
+
+DeclareGlobalFunction( "DEDUCE_MAP_FROM_MATRIX_AND_SOURCE_FOR_GRADED_COLS" );
+


### PR DESCRIPTION
In the current **Deduce** methods which try to create a map from a matrix and source or range, a map will be returned only if it is uniquely determined. One can still with small edits profit from the code and return one map whenever these maps are not uniquely determined.

In this PR I add 4 methods

`Deduce[Some]MapFromMatrixAnd(Source/Range)ForGraded(Rows/Cols)( matrix, object )`

The output of these methods is exactly as the output of

`DeduceMapFromMatrixAnd(Source/Range)ForGraded(Rows/Cols)( matrix, object )`

if the output is uniquely determined, and otherwise one of the infinite number of possibilities will be choosed. The moto behind choosing one is the following: _Whenever I can choose a degree, I choose the degree of the unit of the ring._

@HereAround I am open to any thoughts or comments.

```
S := GradedRing( HomalgFieldOfRationalsInSingular()*"x,y,z" );
mat_1 := HomalgMatrix( "[ x, y, 1, y, x, 1 ]", 2, 3, S );
mat_2 := HomalgMatrix( "[ x, 0, 0, 0, 0, 0 ]", 2, 3, S );
a := GradedRow( [ [ [2], 2 ] ], S );
b := GradedRow( [ [ [ 1 ], 2 ], [ [2], 1 ] ], S );
map := DeduceMapFromMatrixAndSourceForGradedRows(mat_1,a);
some_map := DeduceSomeMapFromMatrixAndSourceForGradedRows(mat_1,a);
IsEqualForMorphisms( map, some_map );
# true
map := DeduceMapFromMatrixAndRangeForGradedRows(mat_1,b);
some_map := DeduceSomeMapFromMatrixAndRangeForGradedRows(mat_1,b);
IsEqualForMorphisms( map, some_map );
# true
map := DeduceMapFromMatrixAndSourceForGradedRows(mat_2,a);
Error, The range_object cannot be determined uniquely....
some_map := DeduceSomeMapFromMatrixAndSourceForGradedRows(mat_2,a);;
IsWellDefined( some_map );
# true
map := DeduceMapFromMatrixAndRangeForGradedRows(mat_2,b);
Error, The source_object cannot be determined uniquely....
some_map := DeduceSomeMapFromMatrixAndRangeForGradedRows(mat_2,b);
IsWellDefined( map );
# true
```
