### PR TITLE
change filters of TestPentagonIdentity

### DIFF
--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
@@ -154,13 +154,13 @@ DeclareOperation( "Component", [ IsSemisimpleCategoryObject, IsObject ] );
 #! This is a debug operation.
 #! The arguments are 4
 #! objects $v_1, v_2, v_3, v_4$
-#! in a semisimple category $\bigoplus_{i \in I} k\mathrm{-vec}$.
+#! in a category.
 #! The output is true if the pentagon identity holds
 #! for those 4 objects, false otherwise.
 #! @Returns a boolean
 #! @Arguments v_1, v_2, v_3, v_4
 DeclareOperation( "TestPentagonIdentity",
-              [ IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject ] );
+              [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
 #! This is a debug operation.

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
@@ -204,7 +204,7 @@ end );
 
 ##
 InstallMethod( TestPentagonIdentity,
-               [ IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject ],
+               [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ],
                
   function( object_a, object_b, object_c, object_d )
     local morphism_1, morphism_2;
@@ -223,7 +223,7 @@ InstallMethod( TestPentagonIdentity,
     morphism_2 := PreCompose( morphism_2,
       AssociatorLeftToRight( object_a, object_b, TensorProductOnObjects( object_c, object_d ) ) );
     
-    return morphism_1 = morphism_2;
+    return IsCongruentForMorphisms( morphism_1, morphism_2 );
     
 end );
 


### PR DESCRIPTION
from `[ IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject, IsSemisimpleCategoryObject ]`
to `[ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ]`

and use `IsCongruentForMorphisms` instead of `=`