### PR TITLE
Do not trigger method reordering for installation of logical implications

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -9,7 +9,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts
-  "2019.06.02", ## Sebas' version
+  "2019.06.03", ## Sebas' version
   ## this line prevents merge conflicts
   "2019.02.26", ## Sepp's version
   ## this line prevents merge conflicts

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -156,16 +156,14 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
                        
   function( category )
     local name, cell_filter, filter_name, filter;
-    
-    SuspendMethodReordering();
 
     name := Name( category );
     
-    filter_name := NewFilter( Concatenation( name, "InternalCategoryFilter" ) );
+    filter := NewFilter( Concatenation( name, "InternalCategoryFilter" ) );
     
-    SetCategoryFilter( category, filter_name );
+    SetCategoryFilter( category, filter );
     
-    SetFilterObj( category, filter_name );
+    SetFilterObj( category, filter );
     
     filter_name := Concatenation( name, "CellFilter" );
     
@@ -173,25 +171,17 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
     
     SetCellFilter( category, cell_filter );
     
-    filter_name := NewFilter( Concatenation( name, "ObjectFilter" ) );
+    filter := NewCategory( Concatenation( name, "ObjectFilter" ), cell_filter );
     
-    InstallTrueMethod( cell_filter, filter_name );
+    SetObjectFilter( category, filter );
     
-    SetObjectFilter( category, filter_name );
+    filter := NewCategory( Concatenation( name, "MorphismFilter" ), cell_filter );
     
-    filter_name := NewFilter( Concatenation( name, "MorphismFilter" ) );
+    SetMorphismFilter( category, filter );
     
-    InstallTrueMethod( cell_filter, filter_name );
+    filter := NewCategory( Concatenation( name, "TwoCellFilter" ), cell_filter );
     
-    SetMorphismFilter( category, filter_name );
-    
-    filter_name := NewFilter( Concatenation( name, "TwoCellFilter" ) );
-    
-    InstallTrueMethod( cell_filter, filter_name );
-    
-    SetTwoCellFilter( category, filter_name );
-    
-    ResetMethodReordering();
+    SetTwoCellFilter( category, filter );
     
 end );
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -157,6 +157,8 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
   function( category )
     local name, cell_filter, filter_name, filter;
     
+    SuspendMethodReordering();
+
     name := Name( category );
     
     filter_name := NewFilter( Concatenation( name, "InternalCategoryFilter" ) );
@@ -188,6 +190,8 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
     InstallTrueMethod( cell_filter, filter_name );
     
     SetTwoCellFilter( category, filter_name );
+    
+    ResetMethodReordering();
     
 end );
 

--- a/CAP/gap/LogicForCAP.gi
+++ b/CAP/gap/LogicForCAP.gi
@@ -469,7 +469,9 @@ InstallGlobalFunction( INSTALL_LOGICAL_IMPLICATIONS_HELPER,
                        
   function( category, current_filter )
     local i, theorem_list, current_theorem;
-    
+
+    SuspendMethodReordering();
+
     for i in category!.logical_implication_files.Propositions.( current_filter ) do
         
         theorem_list := READ_THEOREM_FILE( i );
@@ -493,6 +495,8 @@ InstallGlobalFunction( INSTALL_LOGICAL_IMPLICATIONS_HELPER,
         od;
         
     od;
+
+    ResetMethodReordering();
     
 end );
 

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -800,3 +800,14 @@ InstallGlobalFunction( CachingStatistic,
     od;
     
 end );
+
+## Hack for making CAP work with GAP versions smaller than 4.11
+## Fixme: Remove this once we are sure we do not want compatibility
+## to GAP < 4.11 anymore.
+if not IsBound( SuspendMethodReordering ) then
+   BindGlobal( "SuspendMethodReordering", function() end );
+fi;
+
+if not IsBound( ResetMethodReordering ) then
+   BindGlobal( "ResetMethodReordering", function() end );
+fi;


### PR DESCRIPTION
I decided not to use the official API functions `Suspend/ResumeMethodReordering` but instead set the controlling flag manually, to not retrigger any reordering before the category is finalized. Functions using the new flags should not be called before finalizing.

In case this is considered too bad of a hack, we can go back to using the official functions or provide a similar way of suspending/resuming method reordering in the GAP kernel.