### PR TITLE
Introduce basic operations for homology objects

### DIFF
--- a/CAP/examples/testfiles/HomologyObject.gi
+++ b/CAP/examples/testfiles/HomologyObject.gi
@@ -1,0 +1,77 @@
+#! @Chapter Examples and Tests
+
+#! @Section Homology object
+
+LoadPackage( "LinearAlgebraForCAP" );
+
+#! @Example
+field := HomalgFieldOfRationals( );;
+A := VectorSpaceObject( 1, field );;
+B := VectorSpaceObject( 2, field );;
+C := VectorSpaceObject( 3, field );;
+
+alpha := VectorSpaceMorphism( A, HomalgMatrix( [ [ 1, 0, 0 ] ], 1, 3, field ), C );;
+beta := VectorSpaceMorphism( C, HomalgMatrix( [ [ 1, 0 ], [ 1, 1 ], [ 1, 2 ] ], 3, 2, field ), B );;
+IsZero( PreCompose( alpha, beta ) );
+#! false
+IsCongruentForMorphisms(
+    IdentityMorphism( HomologyObject( alpha, beta ) ),
+    HomologyObjectFunctorial( alpha, beta, IdentityMorphism( C ), alpha, beta )
+);
+#! true
+kernel_beta := KernelEmbedding( beta );;
+K := Source( kernel_beta );;
+IsIsomorphism(
+    HomologyObjectFunctorial( 
+        MorphismFromZeroObject( K ), 
+        MorphismIntoZeroObject( K ),
+        kernel_beta,
+        MorphismFromZeroObject( Source( beta ) ),
+        beta
+    )
+);
+#! true
+cokernel_alpha := CokernelProjection( alpha );;
+Co := Range( cokernel_alpha );;
+IsIsomorphism(
+    HomologyObjectFunctorial( 
+        alpha,
+        MorphismIntoZeroObject( Range( alpha ) ),
+        cokernel_alpha,
+        MorphismFromZeroObject( Co ),
+        MorphismIntoZeroObject( Co )
+    )
+);
+#! true
+alpha_op := Opposite( alpha );;
+beta_op := Opposite( beta );;
+IsCongruentForMorphisms(
+    IdentityMorphism( HomologyObject( beta_op, alpha_op ) ),
+    HomologyObjectFunctorial( beta_op, alpha_op, IdentityMorphism( Opposite( C ) ), beta_op, alpha_op )
+);
+#! true
+kernel_beta := KernelEmbedding( beta_op );;
+K := Source( kernel_beta );;
+IsIsomorphism(
+    HomologyObjectFunctorial( 
+        MorphismFromZeroObject( K ), 
+        MorphismIntoZeroObject( K ),
+        kernel_beta,
+        MorphismFromZeroObject( Source( beta_op ) ),
+        beta_op
+    )
+);
+#! true
+cokernel_alpha := CokernelProjection( alpha_op );;
+Co := Range( cokernel_alpha );;
+IsIsomorphism(
+    HomologyObjectFunctorial( 
+        alpha_op,
+        MorphismIntoZeroObject( Range( alpha_op ) ),
+        cokernel_alpha,
+        MorphismFromZeroObject( Co ),
+        MorphismIntoZeroObject( Co )
+    )
+);
+#! true
+#! @EndExample

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1472,6 +1472,48 @@ AddDerivationToCAP( MorphismBetweenDirectSums,
     
 end : Description := "MorphismBetweenDirectSums using universal morphisms of direct sums" );
 
+##
+AddDerivationToCAP( HomologyObjectFunctorialWithGivenHomologyObjects,
+                    
+  function( homology_source, mor_list, homology_range )
+    local alpha, beta, epsilon, gamma, delta, image_emb_source, image_emb_range, cok_functorial, functorial_mor;
+    
+    alpha := mor_list[1];
+    
+    beta := mor_list[2];
+    
+    epsilon := mor_list[3];
+    
+    gamma := mor_list[4];
+    
+    delta := mor_list[5];
+    
+    image_emb_source := ImageEmbedding(
+      PreCompose( KernelEmbedding( beta ), CokernelProjection( alpha ) )
+    );
+    
+    image_emb_range := ImageEmbedding(
+      PreCompose( KernelEmbedding( delta ), CokernelProjection( gamma ) )
+    );
+    
+    cok_functorial := CokernelFunctorial( alpha, epsilon, gamma );
+    
+    functorial_mor :=
+      LiftAlongMonomorphism(
+        image_emb_range, PreCompose( image_emb_source, cok_functorial )
+      );
+    
+    return PreCompose( [
+        IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject( alpha, beta ),
+        functorial_mor,
+        IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject( gamma, delta )
+      ]
+    );
+    
+end : CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
+      Description := "HomologyObjectFunctorialWithGivenHomologyObjects using functoriality of (co)kernels and images in abelian categories" );
+
+
 ###########################
 ##
 ## Methods returning a morphism with source or range constructed within the method!
@@ -2142,6 +2184,15 @@ AddDerivationToCAP( Colift,
     
 end : Description := "Colift by SolveLinearSystemInAbCategory" );
 
+##
+AddDerivationToCAP( IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject,
+  function( alpha, beta )
+    
+    return Inverse( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject( alpha, beta ) );
+    
+end : Description := "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject as the inverse of IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject" );
+
+
 ###########################
 ##
 ## Methods returning an object
@@ -2379,6 +2430,15 @@ AddDerivationToCAP( Coequalizer,
     return Range( ProjectionOntoCoequalizer( diagram ) );
     
 end : Description := "Coequalizer as the range of ProjectionOntoCoequalizer" );
+
+##
+AddDerivationToCAP( HomologyObject,
+                    
+  function( alpha, beta )
+    
+    return Source( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject( alpha, beta ) );
+    
+end : Description := "HomologyObject as the source of IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject" );
 
 ###########################
 ##
@@ -3008,6 +3068,28 @@ AddFinalDerivation( IsomorphismFromDirectSumToCoproduct,
     return IdentityMorphism( DirectSum( diagram ) );
     
 end : Description := "IsomorphismFromDirectSumToCoproduct as the identity of the direct sum" );
+
+## Final methods for homology object
+
+##
+AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject,
+                    [ [ ImageObject, 1 ],
+                      [ PreCompose, 1 ],
+                      [ KernelEmbedding, 1 ],
+                      [ CokernelProjection, 1 ] ],
+                    [ HomologyObject,
+                      HomologyObjectFunctorialWithGivenHomologyObjects ],
+                      
+  function( alpha, beta )
+    local homology_object;
+    
+    homology_object := ImageObject( PreCompose( KernelEmbedding( beta ), CokernelProjection( alpha ) ) );
+    
+    return IdentityMorphism( homology_object );
+    
+end : CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
+      Description := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject as the identity of the homology object constructed as an image object" );
+
 
 ## Final method for IsEqualForObjects
 ##

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3186,6 +3186,89 @@ RandomMorphismWithFixedSourceAndRangeByList := rec(
   return_type := "morphism_or_fail"
 ),
 
+HomologyObject := rec(
+  installation_name := "HomologyObject",
+  filter_list := [ "morphism", "morphism" ],
+  io_type := [ [ "alpha", "beta" ], [ "H" ] ],
+  return_type := "object",
+  pre_function := function( alpha, beta )
+      if not IsEqualForObjects( Range( alpha ), Source( beta ) ) then
+            
+            return [ false, "the range of the first morphism has to be equal to the source of the second morphism" ];
+            
+      fi;
+      
+      return [ true ];
+      
+  end,
+  dual_operation := "HomologyObject",
+  dual_arguments_reversed := true
+),
+
+HomologyObjectFunctorialWithGivenHomologyObjects := rec(
+  installation_name := "HomologyObjectFunctorialWithGivenHomologyObjects",
+  filter_list := [ "object", IsList, "object" ],
+  io_type := [ [ "H_1", "L", "H_2" ], [ "H_1", "H_2" ] ],
+  return_type := "morphism",
+  pre_function := function( H_1, L, H2 )
+      local alpha, beta, epsilon, gamma, delta;
+      
+      alpha := L[1];
+      
+      beta := L[2];
+      
+      epsilon := L[3];
+      
+      gamma := L[4];
+      
+      delta := L[5];
+      
+      if not IsEqualForObjects( Range( alpha ), Source( beta ) ) then
+            
+            return [ false, "the range of the first morphism has to be equal to the source of the second morphism" ];
+            
+      fi;
+      
+      if not IsEqualForObjects( Range( gamma ), Source( delta ) ) then
+            
+            return [ false, "the range of the fourth morphism has to be equal to the source of the fifth morphism" ];
+            
+      fi;
+      
+      if not IsEqualForObjects( Source( epsilon ), Source( beta ) ) then
+            
+            return [ false, "the source of the third morphism has to be equal to the source of the second morphism" ];
+            
+      fi;
+      
+      if not IsEqualForObjects( Range( epsilon ), Range( gamma ) ) then
+            
+            return [ false, "the range of the third morphism has to be equal to the range of the fourth morphism" ];
+            
+      fi;
+      
+      return [ true ];
+      
+  end,
+  dual_operation := "HomologyObjectFunctorialWithGivenHomologyObjects",
+  dual_preprocessor_func := function( arg )
+      local list;
+      list := CAP_INTERNAL_OPPOSITE_RECURSIVE( arg );
+      return [ list[3], Reversed( list[2] ), list[1] ];
+  end
+),
+
+IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject := rec(
+  installation_name := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+  filter_list := [ "morphism", "morphism" ],
+  io_type := [ [ "alpha", "beta" ], [ "A", "B" ] ],
+  return_type := "morphism" ),
+
+IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject := rec(
+  installation_name := "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+  filter_list := [ "morphism", "morphism" ],
+  io_type := [ [ "alpha", "beta" ], [ "A", "B" ] ],
+  return_type := "morphism" ),
 ) );
 
 InstallValue( CAP_INTERNAL_METHOD_NAME_RECORD_LIMITS, [

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4969,6 +4969,164 @@ DeclareOperation( "AddUniversalMorphismIntoCoimageWithGivenCoimage",
 
 ####################################
 ##
+#! @Section Homology objects
+##
+####################################
+
+#! In an abelian category, we can define the operation
+#! that takes as an input a pair of morphisms $\alpha: A \rightarrow B$, $\beta: B \rightarrow C$
+#! and outputs the subquotient of $B$ given by
+#! * $H := \mathrm{KernelObject}( \beta )/ (\mathrm{KernelObject}( \beta ) \cap \mathrm{ImageObject( \alpha )}$).
+#! This object is called a <Emph>homology object</Emph> of the pair $\alpha, \beta$.
+#! Note that we do not need the precomposition of $\alpha$ and $\beta$ to be zero
+#! in order to make sense of this notion.
+
+#! Moreover, given a second pair $\gamma: D \rightarrow E$, $\delta: E \rightarrow F$ of morphisms,
+#! and a morphism $\epsilon: B \rightarrow E$ such that
+#! there exists $\omega_1: A \rightarrow D$, $\omega_2: C \rightarrow F$
+#! with $\epsilon \circ \alpha \sim_{A,E} \gamma \circ \omega_1$
+#! and $\omega_2 \circ \beta \sim_{B,F} \delta \circ \epsilon$
+#! there is a functorial way to obtain from these data a morphism between the two corresponding homology objects.
+
+## Main Operations and Attributes
+#! @Description
+#! The arguments are two morphisms $\alpha: A \rightarrow B, \beta: B \rightarrow C$.
+#! The output is the homology object $H$ of this pair.
+#! @Returns an object
+#! @Arguments alpha, beta
+DeclareOperation( "HomologyObject",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The argument are five morphisms $\alpha: A \rightarrow B$, $\beta: B \rightarrow C$,
+#! $\epsilon: B \rightarrow E$,
+#! $\gamma: D \rightarrow E, \delta: E \rightarrow F$
+#! such that
+#! there exists $\omega_1: A \rightarrow D$, $\omega_2: C \rightarrow F$
+#! with $\epsilon \circ \alpha \sim_{A,E} \gamma \circ \omega_1$
+#! and $\omega_2 \circ \beta \sim_{B,F} \delta \circ \epsilon$.
+#! The output is the functorial morphism induced by $\epsilon$ between the corresponding homology objects $H_1$ and $H_2$,
+#! where $H_1$ denotes the homology object of the pair $\alpha, \beta$,
+#! and $H_2$ denotes the homology object of the pair $\gamma, \delta$.
+#! @Returns a morphism in $\mathrm{Hom}( H_1, H_2 )$
+#! @Arguments alpha, beta, epsilon, gamma, delta
+DeclareOperation( "HomologyObjectFunctorial",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+#! @Description
+#! @Description
+#! The arguments are an object $H_1$, a list $L$ consisting of five morphisms $\alpha: A \rightarrow B$, $\beta: B \rightarrow C$,
+#! $\epsilon: B \rightarrow E$,
+#! $\gamma: D \rightarrow E, \delta: E \rightarrow F$,
+#! and an object $H_2$, such that
+#! $H_1 = \mathrm{HomologyObject}( \alpha, \beta )$
+#! and $H_2 = \mathrm{HomologyObject}( \gamma, \delta )$,
+#! and such that there exists $\omega_1: A \rightarrow D$, $\omega_2: C \rightarrow F$
+#! with $\epsilon \circ \alpha \sim_{A,E} \gamma \circ \omega_1$
+#! and $\omega_2 \circ \beta \sim_{B,F} \delta \circ \epsilon$.
+#! The output is the functorial morphism induced by $\epsilon$ between the corresponding homology objects $H_1$ and $H_2$,
+#! where $H_1$ denotes the homology object of the pair $\alpha, \beta$,
+#! and $H_2$ denotes the homology object of the pair $\gamma, \delta$.
+#! @Returns a morphism in $\mathrm{Hom}( H_1, H_2 )$
+#! @Arguments H_1, L, H_2
+DeclareOperation( "HomologyObjectFunctorialWithGivenHomologyObjects",
+                  [ IsCapCategoryObject, IsList, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are two morphisms $\alpha: A \rightarrow B, \beta: B \rightarrow C$.
+#! The output is the natural isomorphism from the homology object $H$ of $\alpha$ and $\beta$
+#! to the construction of the homology object as
+#! $\mathrm{ImageObject}( \mathrm{PreCompose}( \mathrm{KernelEmbedding}( \beta ), \mathrm{CokernelProjection}( \alpha ) ) )$,
+#! denoted by $I$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{HomologyObject}( \alpha, \beta ), I )$
+#! @Arguments alpha, beta
+DeclareOperation( "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are two morphisms $\alpha: A \rightarrow B, \beta: B \rightarrow C$.
+#! The output is the natural isomorphism from the construction of the homology object as
+#! $\mathrm{ImageObject}( \mathrm{PreCompose}( \mathrm{KernelEmbedding}( \beta ), \mathrm{CokernelProjection}( \alpha ) ) )$,
+#! denoted by $I$,
+#! to the homology object $H$ of $\alpha$ and $\beta$.
+#! @Returns a morphism in $\mathrm{Hom}( I, \mathrm{HomologyObject}( \alpha, \beta ) )$
+#! @Arguments alpha, beta
+DeclareOperation( "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+## Add Operations
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>HomologyObject</C>.
+#! $F: (\alpha, \beta) \mapsto \mathrm{HomologyObject}(\alpha, \beta)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddHomologyObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddHomologyObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddHomologyObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddHomologyObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>AddHomologyObjectFunctorialWithGivenHomologyObjects</C>.
+#! $F: (H_1, \alpha, \beta, \epsilon, \gamma, \delta, H_2) \mapsto (H_1 \rightarrow H_2)$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddHomologyObjectFunctorialWithGivenHomologyObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddHomologyObjectFunctorialWithGivenHomologyObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddHomologyObjectFunctorialWithGivenHomologyObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddHomologyObjectFunctorialWithGivenHomologyObjects",
+                  [ IsCapCategory, IsList ] );
+
+
+DeclareOperation( "AddIsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+                  [ IsCapCategory, IsList ] );
+
+
+DeclareOperation( "AddIsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+                  [ IsCapCategory, IsList ] );
+
+
+
+
+#! @Chapter Universal Objects
+
+####################################
+##
 #! @Section Convenience Methods
 ##
 ####################################

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -1164,6 +1164,30 @@ end );
 
 ####################################
 ##
+## Homology object
+##
+####################################
+
+####################################
+## Convenience methods
+####################################
+
+##
+InstallMethod( HomologyObjectFunctorial,
+              [ IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryMorphism ],
+              
+  function( alpha, beta, epsilon, gamma, delta )
+    
+    return HomologyObjectFunctorialWithGivenHomologyObjects(
+      HomologyObject( alpha, beta ),
+      [ alpha, beta, epsilon, gamma, delta ],
+      HomologyObject( gamma, delta )
+    );
+    
+end );
+
+####################################
+##
 ## Scheme for Universal Object
 ##
 ####################################

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -15,7 +15,7 @@ S := GradedRing( Q["x,y"] );
 Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
-#! 40 primitive operations were used to derive 169 operations for this category which
+#! 40 primitive operations were used to derive 173 operations for this category which
 #! * IsAbCategory
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
@@ -71,7 +71,7 @@ CohP1 := Sgrmod / C;
 #! The Serre quotient category of The category of graded left f.p. modules
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian
 InfoOfInstalledOperationsOfCategory( CohP1 );
-#! 21 primitive operations were used to derive 137 operations for this category which
+#! 21 primitive operations were used to derive 141 operations for this category which
 #! * IsAbCategory
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );


### PR DESCRIPTION
In an abelian category, it is possible to construct homology objects of a given pair of composable arrows (that do not necessarily compose to zero). I introduce a basic operation for this operation.