### PR TITLE
Add canonical identification of images and coimages

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -11,7 +11,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2019.06.05", ## Sebas' version
   ## this line prevents merge conflicts
-  "2019.06.07", ## Sepp's version
+  "2019.09.17", ## Sepp's version
   ## this line prevents merge conflicts
   "2019.08.10", ## Fabian's version
   ## this line prevents merge conflicts

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -303,6 +303,12 @@ InstallMethod( AddInverse,
                [ IsCapCategory, IsList, IsInt ],
                AddInverseImmutable );
 
+CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD(
+  rec(
+    Inverse := [ [ "InverseImmutable", 1 ] ]
+  )
+ );
+
 #######################################
 ##
 ## Caching

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -477,6 +477,18 @@ end : CategoryFilter := IsAbelianCategory, ##FIXME: PreAbelian?
       Description := "CoimageProjection as the cokernel projection of the kernel embedding" );
 
 ##
+AddWithGivenDerivationPairToCAP( CoimageProjection,
+  
+  function( mor )
+    local iso;
+    
+    iso := CanonicalIdentificationFromImageObjectToCoimage( mor );
+    
+    return PreCompose( CoastrictionToImage( mor ), iso );
+    
+end : Description := "CoimageProjection as the coastriction to image" );
+
+##
 AddWithGivenDerivationPairToCAP( CoastrictionToImage,
                       
   function( morphism )
@@ -519,6 +531,27 @@ AddWithGivenDerivationPairToCAP( AstrictionToCoimage,
 end : Description := "AstrictionToCoimage using that coimage projection can be seen as a cokernel" );
 
 ##
+AddWithGivenDerivationPairToCAP( AstrictionToCoimage,
+          
+  function( morphism )
+    local image_emb;
+    
+    image_emb := ImageEmbedding( morphism );
+    
+    return PreCompose( image_emb, CanonicalIdentificationFromCoimageToImageObject( morphism ) );
+    
+  end,
+  
+  function( morphism, coimage )
+    local image_emb;
+    
+    image_emb := ImageEmbedding( morphism );
+    
+    return PreCompose( image_emb, CanonicalIdentificationFromCoimageToImageObject( morphism ) );
+    
+end : Description := "AstrictionToCoimage as the image embedding" );
+
+##
 AddWithGivenDerivationPairToCAP( UniversalMorphismFromImage,
                       
   function( morphism, test_factorization )
@@ -559,6 +592,18 @@ AddWithGivenDerivationPairToCAP( UniversalMorphismIntoCoimage,
     return ColiftAlongEpimorphism( test_factorization[1], coimage_projection );
     
 end : Description := "UniversalMorphismIntoCoimage using CoimageProjection and ColiftAlongEpimorphism" );
+
+##
+AddWithGivenDerivationPairToCAP( UniversalMorphismIntoCoimage,
+  
+  function( morphism, test_factorization )
+    local induced_mor;
+    
+    induced_mor := UniversalMorphismFromImage( morphism, test_factorization );
+    
+    return PreCompose( Inverse( induced_mor ), CanonicalIdentificationFromImageObjectToCoimage( morphism ) );
+    
+  end : Description := "UniversalMorphismIntoCoimage using UniversalMorphismFromImage and CanonicalIdentificationFromImageObjectToCoimage" );
 
 ##
 AddWithGivenDerivationPairToCAP( UniversalMorphismIntoEqualizer,
@@ -2374,6 +2419,24 @@ AddDerivationToCAP( Coimage,
 end : Description := "Coimage as the source of IsomorphismFromCoimageToCokernelOfKernel" );
 
 ##
+AddDerivationToCAP( Coimage,
+        
+  function( morphism )
+    
+    return Range( CanonicalIdentificationFromImageObjectToCoimage( morphism ) );
+    
+end : Description := "Coimage as the range of CanonicalIdentificationFromImageObjectToCoimage" );
+
+##
+AddDerivationToCAP( Coimage,
+        
+  function( morphism )
+    
+    return Source( CanonicalIdentificationFromCoimageToImageObject( morphism ) );
+    
+end : Description := "Coimage as the source of CanonicalIdentificationFromCoimageToImageObject" );
+
+##
 AddDerivationToCAP( FiberProduct,
       
   function( diagram )
@@ -2869,6 +2932,15 @@ AddDerivationToCAP( InverseMorphismFromCoimageToImageWithGivenObjects,
     
 end : CategoryFilter := IsAbelianCategory,
       Description := "InverseMorphismFromCoimageToImageWithGivenObjects as the inverse of MorphismFromCoimageToImage" );
+
+##
+AddDerivationToCAP( CanonicalIdentificationFromCoimageToImageObject,
+                    
+  function( morphism )
+    
+    return Inverse( CanonicalIdentificationFromImageObjectToCoimage( morphism ) );
+    
+end : Description := "CanonicalIdentificationFromCoimageToImageObject as the inverse of CanonicalIdentificationFromImageObjectToCoimage" );
 
 ## Final methods for Coimage
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -538,7 +538,7 @@ AddWithGivenDerivationPairToCAP( AstrictionToCoimage,
     
     image_emb := ImageEmbedding( morphism );
     
-    return PreCompose( image_emb, CanonicalIdentificationFromCoimageToImageObject( morphism ) );
+    return PreCompose( CanonicalIdentificationFromCoimageToImageObject( morphism ), image_emb );
     
   end,
   
@@ -547,7 +547,7 @@ AddWithGivenDerivationPairToCAP( AstrictionToCoimage,
     
     image_emb := ImageEmbedding( morphism );
     
-    return PreCompose( image_emb, CanonicalIdentificationFromCoimageToImageObject( morphism ) );
+    return PreCompose( CanonicalIdentificationFromCoimageToImageObject( morphism ), image_emb );
     
 end : Description := "AstrictionToCoimage as the image embedding" );
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2927,6 +2927,22 @@ IsomorphismFromCokernelOfKernelToCoimage := rec(
   dual_operation := "IsomorphismFromImageObjectToKernelOfCokernel",
   no_with_given := true ),
 
+CanonicalIdentificationFromImageObjectToCoimage := rec(
+  installation_name := "CanonicalIdentificationFromImageObjectToCoimage",
+  filter_list := [ "morphism" ],
+  io_type := [ [ "alpha" ], [ "I", "C" ] ],
+  return_type := "morphism",
+  dual_operation := "CanonicalIdentificationFromCoimageToImageObject",
+  no_with_given := true ),
+
+CanonicalIdentificationFromCoimageToImageObject := rec(
+  installation_name := "CanonicalIdentificationFromCoimageToImageObject",
+  filter_list := [ "morphism" ],
+  io_type := [ [ "alpha" ], [ "C", "I" ] ],
+  return_type := "morphism",
+  dual_operation := "CanonicalIdentificationFromImageObjectToCoimage",
+  no_with_given := true ),
+
 IsomorphismFromDirectSumToDirectProduct := rec(
   installation_name := "IsomorphismFromDirectSumToDirectProductOp",
   filter_list := [ "list_of_objects", "object" ],

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4648,7 +4648,7 @@ DeclareAttribute( "InverseMorphismFromCoimageToImage",
 #! The output is the inverse of the canonical morphism (in an abelian category)
 #! $I \rightarrow C$.
 #! @Returns a morphism in $\mathrm{Hom}(I,C)$
-#! @Arguments alpha
+#! @Arguments C, alpha, I
 DeclareOperation( "InverseMorphismFromCoimageToImageWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ] );
 

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4965,11 +4965,29 @@ DeclareOperation( "AddUniversalMorphismIntoCoimageWithGivenCoimage",
                   [ IsCapCategory, IsList ] );
 
 
-##
+#! Whenever the <C>CoastrictionToImage</C> is an epi,
+#! or the <C>AstrictionToCoimage</C> is a mono,
+#! there is a canonical morphism from the image to the coimage.
+#! If this canonical morphism is an isomorphism, we call it
+#! the <Emph>canonical identification</Emph> (between image and coimage).
+
+
+#! @Description
+#! The argument is a morphism $\alpha: A \rightarrow B$.
+#! The output is the canonical identification
+#! $c: \mathrm{im}( \alpha ) \rightarrow \mathrm{coim}( \alpha )$.
+#! @Returns a morphism in $\mathrm{Hom}(\mathrm{im}( \alpha ), \mathrm{coim}( \alpha ) )$
+#! @Arguments alpha
 DeclareAttribute( "CanonicalIdentificationFromImageObjectToCoimage",
                   IsCapCategoryMorphism );
 
-##
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CanonicalIdentificationFromImageObjectToCoimage</C>.
+#! $F: \alpha \mapsto c$
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
                   [ IsCapCategory, IsFunction ] );
 
@@ -4982,11 +5000,22 @@ DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
 DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
                   [ IsCapCategory, IsList ] );
 
-##
+#! @Description
+#! The argument is a morphism $\alpha: A \rightarrow B$.
+#! The output is the canonical identification
+#! $c: \mathrm{coim}( \alpha ) \rightarrow \mathrm{im}( \alpha )$.
+#! @Returns a morphism in $\mathrm{Hom}(\mathrm{coim}( \alpha ), \mathrm{im}( \alpha ) )$
+#! @Arguments alpha
 DeclareAttribute( "CanonicalIdentificationFromCoimageToImageObject",
                   IsCapCategoryMorphism );
 
-##
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CanonicalIdentificationFromCoimageToImageObject</C>.
+#! $F: \alpha \mapsto c$
+#! @Returns nothing
+#! @Arguments C, F
 DeclareOperation( "AddCanonicalIdentificationFromCoimageToImageObject",
                   [ IsCapCategory, IsFunction ] );
 

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -4965,6 +4965,41 @@ DeclareOperation( "AddUniversalMorphismIntoCoimageWithGivenCoimage",
                   [ IsCapCategory, IsList ] );
 
 
+##
+DeclareAttribute( "CanonicalIdentificationFromImageObjectToCoimage",
+                  IsCapCategoryMorphism );
+
+##
+DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromImageObjectToCoimage",
+                  [ IsCapCategory, IsList ] );
+
+##
+DeclareAttribute( "CanonicalIdentificationFromCoimageToImageObject",
+                  IsCapCategoryMorphism );
+
+##
+DeclareOperation( "AddCanonicalIdentificationFromCoimageToImageObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromCoimageToImageObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromCoimageToImageObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCanonicalIdentificationFromCoimageToImageObject",
+                  [ IsCapCategory, IsList ] );
+
+
 #! @Chapter Universal Objects
 
 ####################################

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -1162,6 +1162,20 @@ InstallMethod( InverseMorphismFromCoimageToImage,
     
 end );
 
+CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD(
+  rec(
+    MorphismFromCoimageToImage :=
+      [ [ "MorphismFromCoimageToImageWithGivenObjects", 1 ],
+        [ "Coimage", 1 ],
+        [ "ImageObject", 1 ] ],
+    InverseMorphismFromCoimageToImage :=
+      [ [ "InverseMorphismFromCoimageToImageWithGivenObjects", 1 ],
+        [ "Coimage", 1 ],
+        [ "ImageObject", 1 ] ],
+  )
+ );
+
+
 ####################################
 ##
 ## Homology object

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -15,7 +15,7 @@ S := GradedRing( Q["x,y"] );
 Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
-#! 40 primitive operations were used to derive 173 operations for this category which
+#! 40 primitive operations were used to derive 174 operations for this category which
 #! * IsAbCategory
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
@@ -71,7 +71,7 @@ CohP1 := Sgrmod / C;
 #! The Serre quotient category of The category of graded left f.p. modules
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian
 InfoOfInstalledOperationsOfCategory( CohP1 );
-#! 21 primitive operations were used to derive 141 operations for this category which
+#! 21 primitive operations were used to derive 142 operations for this category which
 #! * IsAbCategory
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );


### PR DESCRIPTION
This will be used to automatically derive coimages from images in the case of elementary toposes.