### PR TITLE
use Display instead of Print

### DIFF
--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -12,6 +12,8 @@ PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
 Version := Maximum( [
   "2017.01.11", ## Sepp's version
+  ## this line prevents merge conflicts
+  "2019.09.01", ## Mohamed's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
@@ -340,7 +340,7 @@ InstallMethod( Display,
     
     if IsEmpty( morphism_list ) then
         
-        Print( "0" );
+        Display( "0" );
         
     else
         


### PR DESCRIPTION
Display correctly prints a trailing newline, otherwise

Perform( list_of_zero_morphisms, Display );

will print 00...00 without newlines