### PR TITLE
conditional installation of IsWellDefinedFor*

### DIFF
--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -12,7 +12,7 @@ PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
 
 Version := Maximum( [
-  "2019.01.16", ## Mohamed's version
+  "2019.09.02", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.08.19", ## Sebas' version
   ## this line prevents merge conflicts

--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -558,6 +558,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_LEFT_ACTIONS_CATEGORY,
     
     v := UnderlyingActingObject( left_actions_category );
     
+    if CanCompute( UnderlyingCategory( left_actions_category ), "IsWellDefinedForMorphisms" ) then
+    
     ##
     AddIsWellDefinedForObjects( left_actions_category,
       function( object )
@@ -599,6 +601,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_LEFT_ACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
 end );
 
 ##
@@ -608,6 +612,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_RIGHT_ACTIONS_CATEGORY,
     local v;
     
     v := UnderlyingActingObject( right_actions_category );
+    
+    if CanCompute( UnderlyingCategory( right_actions_category ), "IsWellDefinedForMorphisms" ) then
     
     ##
     AddIsWellDefinedForObjects( right_actions_category,
@@ -649,5 +655,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_RIGHT_ACTIONS_CATEGORY,
                    );
         
     end );
+    
+    fi;
     
 end );

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -564,6 +564,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_LEFT_COACTIONS_CATEGORY,
     
     w := UnderlyingCoactingObject( left_coactions_category );
     
+    if CanCompute( UnderlyingCategory( left_coactions_category ), "IsWellDefinedForMorphisms" ) then
+    
     ##
     AddIsWellDefinedForObjects( left_coactions_category,
       function( object )
@@ -605,6 +607,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_LEFT_COACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
 end );
 
 ##
@@ -614,6 +618,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_RIGHT_COACTIONS_CATEGORY,
     local w;
     
     w := UnderlyingCoactingObject( right_coactions_category );
+    
+    if CanCompute( UnderlyingCategory( right_coactions_category ), "IsWellDefinedForMorphisms" ) then
     
     ##
     AddIsWellDefinedForObjects( right_coactions_category,
@@ -655,5 +661,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ONLY_RIGHT_COACTIONS_CATEGORY,
                    );
         
     end );
+    
+    fi;
     
 end );


### PR DESCRIPTION
only install IsWellDefinedForObjects and IsWellDefinedForMorphisms
if CanCompute( underlying_category, "IsWellDefinedForMorphisms" )