### PR TITLE
Add interface for a categorical Simplify command

### DIFF
--- a/CAP/examples/testfiles/Simplify.gi
+++ b/CAP/examples/testfiles/Simplify.gi
@@ -1,0 +1,112 @@
+#! @Chapter Examples and Tests
+
+#! @Section Homomorphism structure
+
+#! @Example
+ReadPackage( "CAP", "examples/testfiles/StringsAsCategory.gi" );;
+C := StringsAsCategory();;
+obj1 := StringsAsCategoryObject( "qaeiou", C );;
+obj2 := StringsAsCategoryObject( "qxayeziouT", C );;
+mor := StringsAsCategoryMorphism( obj1, "xyzaTe", obj2 );;
+IsWellDefined( mor );
+#! true
+
+## Test SimplifyObject
+IsEqualForObjects( SimplifyObject( obj1, 0 ), obj1 );
+#! true
+IsEqualForObjects( SimplifyObject( obj1, 1 ), obj1 );
+#! false
+ForAny( [0,1,2,3,4], i -> IsEqualForObjects( SimplifyObject( obj1, i ), SimplifyObject( obj1, i + 1 ) ) );
+#! false
+ForAll( [5,6,7,8], i -> IsEqualForObjects( SimplifyObject( obj1, i ), SimplifyObject( obj1, i + 1 ) ) );
+#! true
+
+
+## Test SimplifyMorphism
+IsEqualForMorphisms( SimplifyMorphism( mor, 0 ), mor );
+#! true
+IsEqualForMorphisms( SimplifyMorphism( mor, 1 ), mor );
+#! false
+ForAny( [0,1], i -> IsEqualForMorphisms( SimplifyMorphism( mor, i ), SimplifyMorphism( mor, i + 1 ) ) );
+#! false
+ForAll( [2,3,4,5], i -> IsEqualForMorphisms( SimplifyMorphism( mor, i ), SimplifyMorphism( mor, i + 1 ) ) );
+#! true
+
+## Test SimplifySource
+IsEqualForMorphismsOnMor( SimplifySource( mor, 0 ), mor );
+#! true
+IsEqualForMorphismsOnMor( SimplifySource( mor, 1 ), mor );
+#! false
+ForAny( [0,1,2,3,4], i -> IsEqualForMorphismsOnMor( SimplifySource( mor, i ), SimplifySource( mor, i + 1 ) ) );
+#! false
+ForAll( [5,6,7,8,9], i -> IsEqualForMorphismsOnMor( SimplifySource( mor, i ), SimplifySource( mor, i + 1 ) ) );
+#! true
+IsCongruentForMorphisms(
+    PreCompose( SimplifySource_IsoFromInputObject( mor, infinity ), SimplifySource( mor, infinity ) ), mor
+);
+#! true
+IsCongruentForMorphisms(
+    PreCompose( SimplifySource_IsoToInputObject( mor, infinity ), mor ) , SimplifySource( mor, infinity )
+);
+#! true
+
+## Test SimplifyRange
+IsEqualForMorphismsOnMor( SimplifyRange( mor, 0 ), mor );
+#! true
+IsEqualForMorphismsOnMor( SimplifyRange( mor, 1 ), mor );
+#! false
+ForAny( [0,1,2,3,4], i -> IsEqualForMorphismsOnMor( SimplifyRange( mor, i ), SimplifyRange( mor, i + 1 ) ) );
+#! false
+ForAll( [5,6,7,8,9], i -> IsEqualForMorphismsOnMor( SimplifyRange( mor, i ), SimplifyRange( mor, i + 1 ) ) );
+#! true
+IsCongruentForMorphisms(
+    PreCompose( SimplifyRange( mor, infinity ), SimplifyRange_IsoToInputObject( mor, infinity ) ), mor
+);
+#! true
+IsCongruentForMorphisms(
+    PreCompose( mor, SimplifyRange_IsoFromInputObject( mor, infinity ) ), SimplifyRange( mor, infinity )
+);
+#! true
+
+## Test SimplifySourceAndRange
+IsEqualForMorphismsOnMor( SimplifySourceAndRange( mor, 0 ), mor );
+#! true
+IsEqualForMorphismsOnMor( SimplifySourceAndRange( mor, 1 ), mor );
+#! false
+ForAny( [0,1,2,3,4], i -> IsEqualForMorphismsOnMor( SimplifySourceAndRange( mor, i ), SimplifySourceAndRange( mor, i + 1 ) ) );
+#! false
+ForAll( [5,6,7,8,9], i -> IsEqualForMorphismsOnMor( SimplifySourceAndRange( mor, i ), SimplifySourceAndRange( mor, i + 1 ) ) );
+#! true
+IsCongruentForMorphisms(
+    mor,
+    PreCompose( [ SimplifySourceAndRange_IsoFromInputSource( mor, infinity ),
+                  SimplifySourceAndRange( mor, infinity ),
+                  SimplifySourceAndRange_IsoToInputRange( mor, infinity ) ] )
+);
+#! true
+IsCongruentForMorphisms(
+    SimplifySourceAndRange( mor, infinity ),
+    PreCompose( [ SimplifySourceAndRange_IsoToInputSource( mor, infinity ),
+                  mor,
+                  SimplifySourceAndRange_IsoFromInputRange( mor, infinity ) ] )
+);
+#! true
+
+## Test SimplifyEndo
+endo := StringsAsCategoryMorphism( obj1, "uoiea", obj1 );;
+IsWellDefined( endo );
+#! true
+IsEqualForMorphismsOnMor( SimplifyEndo( endo, 0 ), endo );
+#! true
+IsEqualForMorphismsOnMor( SimplifyEndo( endo, 1 ), endo );
+#! false
+ForAny( [0,1,2,3,4], i -> IsEqualForMorphismsOnMor( SimplifySourceAndRange( endo, i ), SimplifySourceAndRange( endo, i + 1 ) ) );
+#! false
+ForAll( [5,6,7,8,9], i -> IsEqualForMorphismsOnMor( SimplifySourceAndRange( endo, i ), SimplifySourceAndRange( endo, i + 1 ) ) );
+#! true
+iota := SimplifyEndo_IsoToInputObject( endo, infinity );;
+iota_inv := SimplifyEndo_IsoFromInputObject( endo, infinity );;
+IsCongruentForMorphisms( PreCompose( [ iota_inv, SimplifyEndo( endo, infinity ), iota ] ), endo );
+#! true
+#! @EndExample
+

--- a/CAP/examples/testfiles/StringsAsCategory.gi
+++ b/CAP/examples/testfiles/StringsAsCategory.gi
@@ -1,0 +1,543 @@
+LoadPackage( "CAP" );
+
+##
+DeclareCategory( "IsStringsAsCategoryObject",
+                 IsCapCategoryObject );
+
+DeclareCategory( "IsStringsAsCategoryMorphism",
+                 IsCapCategoryMorphism );
+
+DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_STRINGS_AS_CATEGORY" );
+
+DeclareGlobalFunction( "RemovedCharacters" );
+
+DeclareGlobalFunction( "DeleteVowels" );
+
+DeclareGlobalVariable( "STRINGS_AS_CATEGORY" );
+
+DeclareCategory( "IsStringsAsCategory",
+                 IsCapCategory );
+
+## Constructors
+DeclareOperation( "StringsAsCategory",
+                  [] );
+
+DeclareOperation( "StringsAsCategoryObject",
+                  [ IsString, IsCapCategory ] );
+
+DeclareOperation( "StringsAsCategoryMorphism",
+                  [ IsStringsAsCategoryObject, IsString, IsStringsAsCategoryObject ] );
+
+## Attributes
+
+DeclareAttribute( "UnderlyingString",
+                  IsStringsAsCategoryObject );
+
+DeclareAttribute( "UnderlyingString",
+                  IsStringsAsCategoryMorphism );
+
+## Constructors
+
+InstallGlobalFunction( RemovedCharacters,
+    function( str, chars )
+        local copy;
+        
+        copy := ShallowCopy( str );
+        
+        RemoveCharacters( copy, chars );
+        
+        return copy;
+        
+end );
+
+InstallGlobalFunction( DeleteVowels,
+    function( str, n )
+        local vowels;
+        
+        vowels := "aeiou";
+        
+        return RemovedCharacters( str , vowels{[1.. Minimum( Length( vowels ), n )]} );
+        
+end );
+
+##
+InstallMethod( StringsAsCategory,
+               [ ],
+               
+  function( )
+    local category;
+    
+    category := CreateCapCategory( "Category of strings up to vowels" );
+    
+    SetFilterObj( category, IsStringsAsCategory );
+    
+    AddObjectRepresentation( category, IsStringsAsCategoryObject );
+    
+    AddMorphismRepresentation( category, IsStringsAsCategoryMorphism );
+
+    INSTALL_FUNCTIONS_FOR_STRINGS_AS_CATEGORY( category );
+    
+    Finalize( category );
+    
+    return category;
+    
+end );
+
+
+##
+InstallMethod( ViewObj,
+               [ IsStringsAsCategoryMorphism ],
+
+  function( alpha )
+    ViewObj( Source( alpha ) );
+    
+    Print( Concatenation( " -- ", String( UnderlyingString( alpha ) ), " --> " ) );
+    
+    ViewObj( Range( alpha ) );
+    
+end );
+
+##
+InstallMethod( ViewObj,
+               [ IsStringsAsCategoryObject ],
+
+  function( a )
+
+    Print( String( UnderlyingString( a ) ) );
+
+end );
+
+## Basic operations
+
+InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_STRINGS_AS_CATEGORY,
+  
+  function( category )
+    local vec, tunit, vowels;
+    
+    vowels := "aeiou";
+    
+    ##
+    AddIsEqualForCacheForObjects( category,
+      IsIdenticalObj );
+    
+    ##
+    AddIsEqualForCacheForMorphisms( category,
+      IsIdenticalObj );
+    
+    ##
+    AddIsEqualForObjects( category,
+      function( a, b )
+      
+        return UnderlyingString( a ) = UnderlyingString( b );
+      
+    end );
+    
+    ##
+    AddIsEqualForMorphisms( category,
+      function( alpha, beta )
+        
+        return UnderlyingString( alpha ) = UnderlyingString( beta );
+        
+    end );
+    
+    ##
+    AddIsCongruentForMorphisms( category,
+      function( alpha, beta )
+        
+        return RemovedCharacters( UnderlyingString( alpha ), vowels ) = RemovedCharacters( UnderlyingString( beta ), vowels );
+      
+    end );
+    
+    AddIsWellDefinedForObjects( category, ReturnTrue );
+    
+    ##
+    AddIsWellDefinedForMorphisms( category,
+        function( alpha )
+            
+            return RemovedCharacters( Concatenation( UnderlyingString( Source( alpha ) ), UnderlyingString( alpha ) ), vowels )
+                = RemovedCharacters( UnderlyingString( Range( alpha ) ), vowels );
+            
+    end );
+    
+    ##
+    AddPreCompose( category,
+      function( alpha, beta )
+        
+        return StringsAsCategoryMorphism(
+                Source( alpha ),
+                Concatenation( UnderlyingString( alpha ), UnderlyingString( beta ) ),
+                Range( beta )
+        );
+        
+    end );
+    
+    ##
+    AddIdentityMorphism( category,
+      function( a )
+        
+        return StringsAsCategoryMorphism(
+           a,
+           "",
+           a
+        );
+        
+    end );
+    
+    ## SimplifyObject*
+    ##
+    AddSimplifyObject( category,
+        function( a, n )
+            local min;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            min := Minimum( Length( vowels ), n );
+            
+            return StringsAsCategoryObject( RemovedCharacters( UnderlyingString( a ) , vowels{[1..min]} ), category );
+            
+    end );
+    
+    ##
+    AddSimplifyObject_IsoFromInputObject( category,
+        function( a, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                a,
+                "",
+                SimplifyObject( a, n )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifyObject_IsoToInputObject( category,
+        function( a, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                SimplifyObject( a, n ),
+                "",
+                a
+            );
+            
+    end );
+    
+    ## SimplifyMorphism
+    ##
+    AddSimplifyMorphism( category,
+        function( alpha, n )
+            local min;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            min := Minimum( Length( vowels ), n );
+            
+            return StringsAsCategoryMorphism( 
+                    Source( alpha ),
+                    RemovedCharacters( UnderlyingString( alpha ) , vowels{[1..min]} ),
+                    Range( alpha )
+             );
+            
+    end );
+    
+    ## SimplifySource
+    ##
+    AddSimplifySource( category,
+        function( alpha, n )
+            local new_source;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            new_source := StringsAsCategoryObject( DeleteVowels( UnderlyingString( Source( alpha ) ), n ), category );
+            
+            return StringsAsCategoryMorphism( 
+                    new_source,
+                    UnderlyingString( alpha ),
+                    Range( alpha )
+             );
+            
+    end );
+    
+    ##
+    AddSimplifySource_IsoToInputObject( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( SimplifySource( alpha, n ) ),
+                "",
+                Source( alpha )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifySource_IsoFromInputObject( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( alpha ),
+                "",
+                Source( SimplifySource( alpha, n ) )
+            );
+            
+    end );
+    
+    ## SimplifyRange
+    ##
+    AddSimplifyRange( category,
+        function( alpha, n )
+            local new_range;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            new_range := StringsAsCategoryObject( DeleteVowels( UnderlyingString( Range( alpha ) ), n ), category );
+            
+            return StringsAsCategoryMorphism( 
+                    Source( alpha ),
+                    UnderlyingString( alpha ),
+                    new_range
+                    
+             );
+            
+    end );
+    
+    ##
+    AddSimplifyRange_IsoToInputObject( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Range( SimplifyRange( alpha, n ) ),
+                "",
+                Range( alpha )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifyRange_IsoFromInputObject( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Range( alpha ),
+                "",
+                Range( SimplifyRange( alpha, n ) )
+            );
+            
+    end );
+    
+    ## SimplifySourceAndRange
+    ##
+    AddSimplifySourceAndRange( category,
+        function( alpha, n )
+            local new_source, new_range;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            new_source := StringsAsCategoryObject( DeleteVowels( UnderlyingString( Source( alpha ) ), n ), category ); 
+            
+            new_range := StringsAsCategoryObject( DeleteVowels( UnderlyingString( Range( alpha ) ), n ), category );
+            
+            return StringsAsCategoryMorphism( 
+                    new_source,
+                    UnderlyingString( alpha ),
+                    new_range
+                    
+             );
+            
+    end );
+    
+    ##
+    AddSimplifySourceAndRange_IsoToInputSource( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( SimplifySourceAndRange( alpha, n ) ),
+                "",
+                Source( alpha )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifySourceAndRange_IsoFromInputSource( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( alpha ),
+                "",
+                Source( SimplifySourceAndRange( alpha, n ) )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifySourceAndRange_IsoToInputRange( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Range( SimplifySourceAndRange( alpha, n ) ),
+                "",
+                Range( alpha )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifySourceAndRange_IsoFromInputRange( category,
+        function( alpha, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Range( alpha ),
+                "",
+                Range( SimplifySourceAndRange( alpha, n ) )
+            );
+            
+    end );
+    
+    ## SimplifyEndo
+    ##
+    AddSimplifyEndo( category,
+        function( endo, n )
+            local new_object;
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            new_object := StringsAsCategoryObject( DeleteVowels( UnderlyingString( Source( endo ) ), n ), category ); 
+            
+            return StringsAsCategoryMorphism( 
+                    new_object,
+                    UnderlyingString( endo ),
+                    new_object
+                    
+             );
+            
+    end );
+    
+     ##
+    AddSimplifyEndo_IsoToInputObject( category,
+        function( endo, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( SimplifyEndo( endo, n ) ),
+                "",
+                Source( endo )
+            );
+            
+    end );
+    
+    ##
+    AddSimplifyEndo_IsoFromInputObject( category,
+        function( endo, n )
+            
+            if n = 0 then
+                Print( "this case must not be handled here" );
+            fi;
+            
+            return StringsAsCategoryMorphism( 
+                Source( endo ),
+                "",
+                Source( SimplifyEndo( endo, n ) )
+            );
+            
+    end );
+    
+end );
+
+
+##
+InstallMethod( StringsAsCategoryObject,
+               [ IsString, IsCapCategory ],
+               
+  function( string, category )
+    local object;
+    
+    object := rec( );
+    
+    ObjectifyObjectForCAPWithAttributes( object, category,
+                                         UnderlyingString, string
+    );
+    
+    Add( category, object );
+    
+    return object;
+    
+end );
+
+##
+InstallMethod( StringsAsCategoryMorphism,
+               [ IsStringsAsCategoryObject, IsString, IsStringsAsCategoryObject ],
+               
+  function( source, string, range )
+    local morphism, category;
+    
+    morphism := rec( );
+    
+    category := CapCategory( source );
+    
+    ObjectifyMorphismForCAPWithAttributes( morphism, category,
+                                           Source, source,
+                                           Range, range,
+                                           UnderlyingString, string
+    );
+    
+    Add( category, morphism );
+    
+    return morphism;
+    
+end );
+

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1949,3 +1949,495 @@ DeclareOperation( "AddMereExistenceOfSolutionOfLinearSystemInAbCategory",
 
 DeclareOperation( "AddMereExistenceOfSolutionOfLinearSystemInAbCategory",
                   [ IsCapCategory, IsList ] );
+
+###################################
+##
+#! @Section Simplified Morphisms
+##
+###################################
+
+#! Let $\phi: A \rightarrow B$ be a morphism.
+#! There are several different natural ways to look at $\phi$ as an object in an ambient category:
+
+#! - $\mathrm{Hom}( A, B )$, the set of homomorphisms with the equivalence relation $\mathtt{IsCongruentForMorphisms}$ regarded as a category,
+#! - $\sum_{A}\mathrm{Hom}( A, B )$, the category of morphisms where the range is fixed,
+#! - $\sum_{B}\mathrm{Hom}( A, B )$, the category of morphisms where the source is fixed,
+#! - $\sum_{A,B}\mathrm{Hom}( A, B )$, the category of morphisms where neither source nor range is fixed,
+
+#! and furthermore, if $\phi$ happens to be an endomorphism $A \rightarrow A$,
+#! we also have
+
+#! - $\sum_{A}\mathrm{Hom}(A,A)$, the category of endomorphisms.
+
+#! Let $\mathbf{C}$ be one of the categories above in which $\phi$ may reside as an object,
+#! and let $i$ be a non-negative integer or $\infty$.
+#! CAP provides commands for passing from $\phi$ to $\phi_i$, where $\phi_i$ is isomorphic to $\phi$
+#! in $\mathbf{C}$, but "simpler".
+#! The idea is that the greater the $i$, the "simpler" the $\phi_i$ (but this could mean the harder the computation),
+#! with $\infty$ as a possible value.
+#! The case $i = 0$ defaults to the identity operator for all simplifications.
+#! For the Add-operatations, only the cases $i \geq 1$ have to be given as functions.
+#! 
+#! 
+#! $\ $
+#!
+#!
+#! If we regard $\phi$ as an object in the category $\mathrm{Hom}( A, B )$,
+#! $\phi_i$ is again in $\mathrm{Hom}( A, B )$ such that $\phi \sim_{A,B} \phi_i$.
+#! This case is handled by the following commands:
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is a simplified morphism $\phi_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,B)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyMorphism",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyMorphism</C>.
+#! The function $F$ maps $(\phi,i \geq 1)$ to $\phi_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyMorphism",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyMorphism",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyMorphism",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyMorphism",
+                  [ IsCapCategory, IsList ] );
+
+#! $\ $
+#!
+#! If we regard $\phi$ as an object in the category $\sum_{A}\mathrm{Hom}( A, B )$,
+#! then $\phi_i$ is a morphism of type $A_i \rightarrow B$ and there is an isomorphism
+#! $\sigma_i: A \rightarrow A_i$ such that
+#! $\phi_i \circ \sigma_i \sim_{A,B} \phi$.
+#! This case is handled by the following commands:
+
+## SimplifySource
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is a simplified morphism with simplified source $\phi_i: A_i \rightarrow B$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,B)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySource",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySource</C>.
+#! The function $F$ maps $(\phi,i \geq 1)$ to $\phi_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySource",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySource",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySource",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySource",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $(\sigma_i)^{-1}: A_i \rightarrow A$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,A)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySource_IsoToInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySource_IsoToInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySource_IsoToInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySource_IsoToInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySource_IsoToInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySource_IsoToInputObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $\sigma_i: A \rightarrow A_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,A_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySource_IsoFromInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySource_IsoFromInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySource_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySource_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySource_IsoFromInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySource_IsoFromInputObject",
+                  [ IsCapCategory, IsList ] );
+
+## SimplifyRange
+#! $\ $
+#!
+#! If we regard $\phi$ as an object in the category $\sum_{B}\mathrm{Hom}( A, B )$,
+#! then $\phi_i$ is a morphism of type $A \rightarrow B_i$ and there is an isomorphism
+#! $\rho_i: B \rightarrow B_i$ such that
+#! $ \rho_i^{-1} \circ \phi_i\sim_{A,B} \phi$.
+#! This case is handled by the following commands:
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is a simplified morphism with simplified range $\phi_i: A \rightarrow B_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,B_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyRange",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyRange</C>.
+#! The function $F$ maps $(\phi,i \geq 1)$ to $\phi_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyRange",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyRange",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $(\rho_i)^{-1}: B_i \rightarrow B$.
+#! @Returns a morphism in $\mathrm{Hom}(B_i,B)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyRange_IsoToInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyRange_IsoToInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\rho_i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyRange_IsoToInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyRange_IsoToInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange_IsoToInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange_IsoToInputObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $\rho_i: B \rightarrow B_i$.
+#! @Returns a morphism in $\mathrm{Hom}(B,B_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyRange_IsoFromInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyRange_IsoFromInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $\rho_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyRange_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyRange_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange_IsoFromInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyRange_IsoFromInputObject",
+                  [ IsCapCategory, IsList ] );
+
+## SimplifySourceAndRange*
+#! $\ $
+#!
+#! If we regard $\phi$ as an object in the category $\sum_{A, B}\mathrm{Hom}( A, B )$,
+#! then $\phi_i$ is a morphism of type $A_i \rightarrow B_i$ and there is are isomorphisms
+#! $\sigma_i: A \rightarrow A_i$ and
+#! $\rho_i: B \rightarrow B_i$ such that
+#! $ \rho_i^{-1} \circ \phi_i \circ \sigma_i \sim_{A,B} \phi$.
+#! This case is handled by the following commands:
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is a simplified morphism with simplified source and range $\phi_i: A_i \rightarrow B_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,B_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySourceAndRange",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySourceAndRange</C>.
+#! The function $F$ maps $(\phi,i \geq 1)$ to $\phi_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySourceAndRange",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySourceAndRange",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $(\rho_i)^{-1}: B_i \rightarrow B$.
+#! @Returns a morphism in $\mathrm{Hom}(B_i,B)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySourceAndRange_IsoToInputRange",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySourceAndRange_IsoToInputRange</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\rho_i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputRange",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputRange",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputRange",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputRange",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $\rho_i: B \rightarrow B_i$.
+#! @Returns a morphism in $\mathrm{Hom}(B,B_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySourceAndRange_IsoFromInputRange",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySourceAndRange_IsoFromInputRange</C>.
+#! The function $F$ maps $(\phi,i)$ to $\rho_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputRange",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputRange",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputRange",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputRange",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $(\sigma_i)^{-1}: A_i \rightarrow A$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,A)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySourceAndRange_IsoToInputSource",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySourceAndRange_IsoToInputSource</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputSource",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputSource",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputSource",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoToInputSource",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a morphism $\phi: A \rightarrow B$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $\sigma_i: A \rightarrow A_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,A_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifySourceAndRange_IsoFromInputSource",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifySourceAndRange_IsoFromInputSource</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputSource",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputSource",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputSource",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifySourceAndRange_IsoFromInputSource",
+                  [ IsCapCategory, IsList ] );
+
+## SimplifyEndo*
+#! $\ $
+#!
+#! If $\phi:A \rightarrow A$ is an endomorphism, we may regard it as an object in the category $\sum_{A}\mathrm{Hom}( A, A )$.
+#! In this case
+#! $\phi_i$ is a morphism of type $A_i \rightarrow A_i$ and there is an isomorphism
+#! $\sigma_i: A \rightarrow A_i$ such that
+#! $ \sigma_i^{-1} \circ \phi_i \circ \sigma_i \sim_{A,A} \phi$.
+#! This case is handled by the following commands:
+
+#! @Description
+#! The arguments are an endomorphism $\phi: A \rightarrow A$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is a simplified endomorphism $\phi_i: A_i \rightarrow A_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,A_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyEndo",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyEndo</C>.
+#! The function $F$ maps $(\phi,i \geq 1)$ to $\phi_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyEndo",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyEndo",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are an endomorphism $\phi: A \rightarrow A$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $(\sigma_i)^{-1}: A_i \rightarrow A$.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,A)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyEndo_IsoToInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyEndo_IsoToInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyEndo_IsoToInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoToInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoToInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoToInputObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are an endomorphism $\phi: A \rightarrow A$ and a non-negative integer $i$ or <C>infinity</C>.
+#! The output is the isomorphism $\sigma_i: A \rightarrow A_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,A_i)$
+#! @Arguments phi, i
+DeclareOperation( "SimplifyEndo_IsoFromInputObject",
+                  [ IsCapCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyEndo_IsoFromInputObject</C>.
+#! The function $F$ maps $(\phi,i)$ to $(\sigma_i)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyEndo_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoFromInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyEndo_IsoFromInputObject",
+                  [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! This is a convenient method.
+#! The argument is a morphism $\phi: A \rightarrow B$.
+#! The output is a "simplified" version of $\phi$ that may change the
+#! source and range of $\phi$ (up to isomorphism).
+#! To be precise, the output is an $\infty$-th simplified morphism
+#! of $(\iota_A^{\infty})^{-1}\circ \phi \circ \iota_A^{\infty}$.
+#! @Returns a morphism in $\mathrm{Hom}(A_{\infty},B_{\infty})$
+#! @Arguments phi
+DeclareAttribute( "Simplify",
+                  IsCapCategoryMorphism );

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -238,6 +238,21 @@ InstallGlobalFunction( ObjectifyMorphismForCAPWithAttributes,
     
 end );
 
+##
+InstallMethod( Simplify,
+               [ IsCapCategoryMorphism ],
+               
+  function( morphism )
+    local phi;
+    
+    phi := PreCompose( [ SimplifyObject_IsoToInputObject( Source( morphism ), infinity ),
+                         morphism,
+                         SimplifyObject_IsoFromInputObject( Range( morphism ), infinity ) ] );
+    
+    return SimplifyMorphism( phi, infinity );
+    
+end );
+
 ######################################
 ##
 ## Morphism equality functions

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -680,3 +680,106 @@ DeclareOperation( "AddInjectiveColift",
 
 DeclareOperation( "AddInjectiveColift",
                   [ IsCapCategory, IsList ] );
+
+###################################
+##
+#! @Section Simplified Objects
+##
+###################################
+
+#! Let $i$ be a positive integer or $\infty$.
+#! For a given object $A$, an $i$-th simplified object of $A$ consists of
+#! * an object $A_i$, 
+#! * an isomorphism $\iota_A^i: A \rightarrow A_i$.
+#! The idea is that the greater the $i$, the "simpler" the $A_i$ (but this could mean the harder the computation)
+#! with $\infty$ as a possible value.
+
+#! @Description
+#! The argument is an object $A$.
+#! The output is a simplified object $A_{\infty}$.
+#! @Returns an object
+#! @Arguments A
+DeclareAttribute( "Simplify",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The arguments are an object $A$ and a positive integer $i$ or <C>infinity</C>.
+#! The output is a simplified object $A_i$.
+#! @Returns an object
+#! @Arguments A, i
+DeclareOperation( "SimplifyObject",
+                  [ IsCapCategoryObject, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyObject</C>.
+#! The function $F$ maps $(A,i)$ to $A_i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are an object $A$ and a positive integer $i$ or <C>infinity</C>.
+#! The output is an isomorphism to a simplified object $\iota_A^i: A \rightarrow A_i$.
+#! @Returns a morphism in $\mathrm{Hom}(A,A_i)$
+#! @Arguments A, i
+DeclareOperation( "SimplifyObject_IsoFromInputObject",
+                  [ IsCapCategoryObject, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyObject_IsoFromInputObject</C>.
+#! The function $F$ maps $(A,i)$ to $\iota_A^i$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyObject_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyObject_IsoFromInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject_IsoFromInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject_IsoFromInputObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are an object $A$ and a positive integer $i$ or <C>infinity</C>.
+#! The output is an isomorphism from a simplified object $(\iota_A^i)^{-1}: A_i \rightarrow A$
+#! which is the inverse of the output of <C>SimplifyObject_IsoFromInputObject</C>.
+#! @Returns a morphism in $\mathrm{Hom}(A_i,A)$
+#! @Arguments A, i
+DeclareOperation( "SimplifyObject_IsoToInputObject",
+                  [ IsCapCategoryObject, IsObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>SimplifyObject_IsoToInputObject</C>.
+#! The function $F$ maps $(A,i)$ to $(\iota_A^i)^{-1}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSimplifyObject_IsoToInputObject",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSimplifyObject_IsoToInputObject",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject_IsoToInputObject",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSimplifyObject_IsoToInputObject",
+                  [ IsCapCategory, IsList ] );

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -239,6 +239,15 @@ InstallGlobalFunction( ObjectifyObjectForCAPWithAttributes,
     
 end );
 
+##
+InstallMethod( Simplify,
+               [ IsCapCategoryObject ],
+  function( object )
+    
+    return SimplifyObject( object, infinity );
+    
+end );
+
 ###########################
 ##
 ## Print

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3294,6 +3294,245 @@ IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject := rec(
   filter_list := [ "morphism", "morphism" ],
   io_type := [ [ "alpha", "beta" ], [ "A", "B" ] ],
   return_type := "morphism" ),
+  
+## SimplifyObject*
+SimplifyObject := rec(
+  installation_name := "SimplifyObject",
+  filter_list := [ "object", IsObject ],
+  io_type := [ [ "A", "n" ], [ "B" ] ],
+  return_type := "object",
+  dual_operation := "SimplifyObject",
+  redirect_function := function( A, n )
+    
+    if n = 0 then
+        return [ true, A ];
+    fi;
+    
+    return [ false ];
+    
+  end,
+  pre_function := function( A, n )
+    
+    if not ( IsPosInt( n ) or IsInfinity( n ) ) then
+        return [ false, "the second argument must be a non-negative integer or infinity" ];
+    fi;
+    
+    return [ true ];
+    
+  end 
+  ),
+
+SimplifyObject_IsoFromInputObject := rec(
+  installation_name := "SimplifyObject_IsoFromInputObject",
+  filter_list := [ "object", IsObject ],
+  io_type := [ [ "A", "n" ], [ "A", "B" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyObject_IsoToInputObject",
+  redirect_function := function( A, n )
+    
+    if n = 0 then
+        return [ true, IdentityMorphism( A ) ];
+    fi;
+    
+    return [ false ];
+    
+  end,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+SimplifyObject_IsoToInputObject := rec(
+  installation_name := "SimplifyObject_IsoToInputObject",
+  filter_list := [ "object", IsObject ],
+  io_type := [ [ "A", "n" ], [ "B", "A" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyObject_IsoFromInputObject",
+  redirect_function := ~.SimplifyObject_IsoFromInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+## SimplifyMorphism
+SimplifyMorphism := rec(
+  installation_name := "SimplifyMorphism",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [  [ [ "A", "B" ], "n" ], [ "A", "B" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyMorphism",
+  redirect_function := ~.SimplifyObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+## SimplifySource*
+SimplifySource := rec(
+  installation_name := "SimplifySource",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Ap", "B" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyRange",
+  redirect_function := ~.SimplifyObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+SimplifySource_IsoToInputObject := rec(
+  installation_name := "SimplifySource_IsoToInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Ap", "A" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyRange_IsoFromInputObject",
+  redirect_function := function( alpha, n )
+    
+    if n = 0 then
+        return [ true, IdentityMorphism( Source( alpha ) ) ];
+    fi;
+    
+    return [ false ];
+    
+  end,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+  
+SimplifySource_IsoFromInputObject := rec(
+  installation_name := "SimplifySource_IsoFromInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "A", "Ap" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyRange_IsoToInputObject",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+## SimplifyRange*
+SimplifyRange := rec(
+  installation_name := "SimplifyRange",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "A", "Bp" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySource",
+  redirect_function := ~.SimplifyObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+SimplifyRange_IsoToInputObject := rec(
+  installation_name := "SimplifyRange_IsoToInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Bp", "B" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySource_IsoFromInputObject",
+  redirect_function := function( alpha, n )
+    
+    if n = 0 then
+        return [ true, IdentityMorphism( Range( alpha ) ) ];
+    fi;
+    
+    return [ false ];
+    
+  end,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+  
+SimplifyRange_IsoFromInputObject := rec(
+  installation_name := "SimplifyRange_IsoFromInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "B", "Bp" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySource_IsoToInputObject",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+## SimplifySourceAndRange*
+SimplifySourceAndRange := rec(
+  installation_name := "SimplifySourceAndRange",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Ap", "Bp" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySourceAndRange",
+  redirect_function := ~.SimplifyObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+SimplifySourceAndRange_IsoToInputSource := rec(
+  installation_name := "SimplifySourceAndRange_IsoToInputSource",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Ap", "A" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySourceAndRange_IsoFromInputRange",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+  
+SimplifySourceAndRange_IsoFromInputSource := rec(
+  installation_name := "SimplifySourceAndRange_IsoFromInputSource",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "A", "Ap" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySourceAndRange_IsoToInputRange",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+SimplifySourceAndRange_IsoToInputRange := rec(
+  installation_name := "SimplifySourceAndRange_IsoToInputRange",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "Bp", "B" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySourceAndRange_IsoFromInputSource",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+  
+SimplifySourceAndRange_IsoFromInputRange := rec(
+  installation_name := "SimplifySourceAndRange_IsoFromInputRange",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "B" ], "n" ], [ "B", "Bp" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifySourceAndRange_IsoToInputSource",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyObject.pre_function
+  ),
+
+## SimplifyEndo*
+SimplifyEndo := rec(
+  installation_name := "SimplifyEndo",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "A" ], "n" ], [ "Ap", "Ap" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyEndo",
+  redirect_function := ~.SimplifyObject.redirect_function,
+  pre_function := function( endo, n )
+    
+    if not ( IsPosInt( n ) or IsInfinity( n ) ) then
+        return [ false, "the second argument must be a non-negative integer or infinity" ];
+    fi;
+    
+    if not IsEndomorphism( endo ) then
+        return [ false, "the first argument must be an endomorphism" ];
+    fi;
+    
+    return [ true ];
+    
+  end 
+  ),
+
+SimplifyEndo_IsoFromInputObject := rec(
+  installation_name := "SimplifyEndo_IsoFromInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "A" ], "n" ], [ "A", "Ap" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyEndo_IsoToInputObject",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyEndo.pre_function
+  ),
+
+SimplifyEndo_IsoToInputObject := rec(
+  installation_name := "SimplifyEndo_IsoToInputObject",
+  filter_list := [ "morphism", IsObject ],
+  io_type := [ [ [ "A", "A" ], "n" ], [ "Ap", "A" ] ],
+  return_type := "morphism",
+  dual_operation := "SimplifyEndo_IsoFromInputObject",
+  redirect_function := ~.SimplifySource_IsoToInputObject.redirect_function,
+  pre_function := ~.SimplifyEndo.pre_function
+  ),
+
 ) );
 
 InstallValue( CAP_INTERNAL_METHOD_NAME_RECORD_LIMITS, [


### PR DESCRIPTION
In this draft, I suggest a categorical version of a `Simplify` command. The idea is to create "simpler" but isomorphic representations of objects, and "simpler" but congruent versions of morphisms,  
with a complexity of the simplification controlled by a positive integer (or infinity). Moreover, convenience methods that use the infinity values are provided.

As applications, I imagine 
- an analog of homalgs `ByASmallerPresentation` (but without any side effect)
- Canceling of denominators in matrices with fractions
- Usage of `SimplifiedObject` within categorical algorithms whenever an object can be replaced with an isomorphic one

For now, I only suggest a `SimplifiedMorphism` version which fixes its source and its range,
but maybe variants like `SimplifiedMorphismWithVaryingSource`,
`SimplifiedMorphismWithVaryingRange`,
`SimplifiedMorphismWithVaryingSourceAndRange` are also interesting
(e.g., in the category of rows over the integers, `SimplifiedMorphismWithVaryingSourceAndRange`
could yield a Smith normal form, `SimplifiedMorphismWithVaryingSource` could yield a Hermite normal form).

Also, I did not yet specify if complexity `infinity` should yield an idempotent operation
or if the complexity `1` should yield the identity.

Any thoughts on this topic are welcome.