### PR TITLE
Option in category constructor for avoiding any overhead

### DIFF
--- a/CAP/examples/testfiles/FieldAsCategory.gi
+++ b/CAP/examples/testfiles/FieldAsCategory.gi
@@ -38,7 +38,7 @@ InstallMethod( FieldAsCategory,
   function( field )
     local category;
     
-    category := CreateCapCategory( Concatenation( "Field as category( ", RingName( field )," )"  ) );
+    category := CreateCapCategory( Concatenation( "Field as category( ", RingName( field )," )"  ) : overhead := false );
     
     SetFilterObj( category, IsFieldAsCategory );
     

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -500,17 +500,29 @@ InstallMethod( CreateCapCategory,
                [ IsString ],
                
   function( name )
-    local category;
+    local overhead, category;
+    
+    overhead := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "overhead", true );
     
     category := rec( );
     
     category := CREATE_CAP_CATEGORY_OBJECT( category, [ [ "Name", name ] ] );
     
+    category!.overhead := overhead;
+    
     CREATE_CAP_CATEGORY_FILTERS( category );
     
-    AddCategoryToFamily( category, "general" );
+    if overhead then
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "General" );
+      AddCategoryToFamily( category, "general" );
+      
+      INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "General" );
+      
+    else
+      
+      category!.predicate_logic := false;
+      
+    fi;
     
     return category;
     

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -37,7 +37,7 @@ InstallGlobalFunction( CAP_INTERNAL_CREATE_Cat,
                
   function(  )
     
-    InstallValue( CapCat, rec( caching_info := rec( ) ) );
+    InstallValue( CapCat, rec( caching_info := rec( ), overhead := true ) );
     
     CREATE_CAP_CATEGORY_OBJECT( CapCat, [ [ "Name", "Cat" ] ] );
     

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -263,6 +263,8 @@ InstallGlobalFunction( CapInternalInstallAdd,
             
             new_filter_list := CAP_INTERNAL_MERGE_FILTER_LISTS( replaced_filter_list, filter_list );
             
+            if category!.overhead then
+            
             install_method( ValueGlobal( install_name ),
                             new_filter_list,
                             
@@ -370,6 +372,30 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 return result;
                 
             end );
+            
+            else #category!.overhead = false
+                
+                if Size( filter_list ) <> Size( argument_list ) then
+                    
+                    InstallMethod( ValueGlobal( install_name ),
+                                new_filter_list,
+                                    
+                        function( arg )
+                            
+                            return CallFuncList( func_to_install, arg{ argument_list } );
+                            
+                    end );
+                    
+                else
+                    
+                    InstallMethod( ValueGlobal( install_name ),
+                                new_filter_list,
+                                func_to_install
+                    );
+                    
+                fi;
+                
+            fi;
             
         end;
         

--- a/CAP/gap/LogicForCAP.gi
+++ b/CAP/gap/LogicForCAP.gi
@@ -506,9 +506,15 @@ InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
                         
   function( category )
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsEnrichedOverCommutativeRegularSemigroup" );
+    if category!.overhead then
+        
+        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsEnrichedOverCommutativeRegularSemigroup" );
+        
+        TryNextMethod( );
+        
+    fi;
     
-    TryNextMethod( );
+    return false;
     
 end );
 
@@ -518,9 +524,15 @@ InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
                         
   function( category )
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAdditiveCategory" );
+    if category!.overhead then
+        
+        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAdditiveCategory" );
+        
+        TryNextMethod( );
+        
+    fi;
     
-    TryNextMethod( );
+    return false;
     
 end );
 
@@ -530,9 +542,15 @@ InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
                         
   function( category )
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsPreAbelianCategory" );
+    if category!.overhead then
+        
+        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsPreAbelianCategory" );
+        
+        TryNextMethod( );
+        
+    fi;
     
-    TryNextMethod( );
+    return false;
     
 end );
 
@@ -542,9 +560,15 @@ InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
                         
   function( category )
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbelianCategory" );
+    if category!.overhead then
+        
+        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbelianCategory" );
+        
+        TryNextMethod( );
+        
+    fi;
     
-    TryNextMethod( );
+    return false;
     
 end );
 
@@ -554,9 +578,15 @@ InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
                         
   function( category )
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbCategory" );
+    if category!.overhead then
+        
+        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbCategory" );
+        
+        TryNextMethod( );
+        
+    fi;
     
-    TryNextMethod( );
+    return false;
     
 end );
 


### PR DESCRIPTION
The idea is to provide an option in the category constructor that reduces CAP's overhead to zero, e.g., when the option is enabled, the call of `KernelLift` directly triggers GAP's method selection in order to search for the function that was given by the user (or by the derivation machinery).