### PR TITLE
Add mandatory filters to type for obj/mor

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -11,7 +11,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2019.06.05", ## Sebas' version
   ## this line prevents merge conflicts
-  "2019.10.04", ## Sepp's version
+  "2019.10.29", ## Sepp's version
   ## this line prevents merge conflicts
   "2019.08.10", ## Fabian's version
   ## this line prevents merge conflicts

--- a/CAP/examples/testfiles/FieldAsCategory.gi
+++ b/CAP/examples/testfiles/FieldAsCategory.gi
@@ -50,7 +50,7 @@ InstallMethod( FieldAsCategory,
     
     AddObjectRepresentation( category, IsFieldAsCategoryObject );
     
-    AddMorphismRepresentation( category, IsFieldAsCategoryMorphism );
+    AddMorphismRepresentation( category, IsFieldAsCategoryMorphism and HasUnderlyingFieldElement );
 
     INSTALL_FUNCTIONS_FOR_FIELD_AS_CATEGORY( category );
     
@@ -90,9 +90,9 @@ InstallMethod( FieldAsCategoryMorphism,
     
     unique_object := FieldAsCategoryUniqueObject( category );
     
-    ObjectifyMorphismForCAPWithAttributes( morphism, category,
-                                           Source, unique_object,
-                                           Range, unique_object,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( morphism, category,
+                                           unique_object,
+                                           unique_object,
                                            UnderlyingFieldElement, element
     );
     

--- a/CAP/examples/testfiles/StringsAsCategory.gi
+++ b/CAP/examples/testfiles/StringsAsCategory.gi
@@ -73,7 +73,7 @@ InstallMethod( StringsAsCategory,
     
     AddObjectRepresentation( category, IsStringsAsCategoryObject );
     
-    AddMorphismRepresentation( category, IsStringsAsCategoryMorphism );
+    AddMorphismRepresentation( category, IsStringsAsCategoryMorphism and HasUnderlyingString );
 
     INSTALL_FUNCTIONS_FOR_STRINGS_AS_CATEGORY( category );
     
@@ -529,9 +529,9 @@ InstallMethod( StringsAsCategoryMorphism,
     
     category := CapCategory( source );
     
-    ObjectifyMorphismForCAPWithAttributes( morphism, category,
-                                           Source, source,
-                                           Range, range,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( morphism, category,
+                                           source,
+                                           range,
                                            UnderlyingString, string
     );
     

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -708,16 +708,18 @@ DeclareOperation( "AddMorphism",
 DeclareOperation( "AddMorphismRepresentation",
                   [ IsCapCategory, IsObject ] );
 
-#! @Arguments morphism, category, [attribute1, value1, ...]
+#! @Arguments morphism, category, source, range[, attr1, val1, attr2, val2, ...]
 #! @Description
 #!  Objectifies the morphism <A>morphism</A> with the type created
 #!  for morphisms in the category <A>category</A>. The type
 #!  is created by passing a representation to <C>AddMorphismRepresentation</C>.
 #!  Morphisms which are objectified using this method do not have to be passed
 #!  to the <C>AddMorphism</C> function.
-#!
-#!  Please note that the <C>Source</C> and <C>Range</C> attribute need to be passed to
-#!  this function. The values belonging to these attrbutes will not be objectified.
+#!  The arguments <C>source</C> and <C>range</C> are assumed to be objectified.
+#! The optional arguments behave like the corresponding arguments in <C>ObjectifyWithAttributes</C>.
+DeclareGlobalFunction( "ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes" );
+
+##
 DeclareGlobalFunction( "ObjectifyMorphismForCAPWithAttributes" );
 
 ###################################

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -225,14 +225,16 @@ InstallGlobalFunction( ObjectifyMorphismForCAPWithAttributes,
   function( arg_list... )
     local category, morphism;
     
+    category := arg_list[ 2 ];
+    
     Print(
       Concatenation(
-      "WARNING: ObjectifyMorphismForCAPWithAttributes is deprecated and will not be supported after 2020.10.29. ",
+      "WARNING (", Name( category ), "): \n",
+      "ObjectifyMorphismForCAPWithAttributes is deprecated and will not be supported after 2020.10.29. \n",
       "Please use ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( morphism, category, source, range[, attr1, val1, attr2, val2, ...] ) instead.\n"
       )
     );
     
-    category := arg_list[ 2 ];
     arg_list[ 2 ] := category!.morphism_type;
     Append( arg_list, [ CapCategory, category ] );
     CallFuncList( ObjectifyWithAttributes, arg_list );

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -219,11 +219,18 @@ InstallMethod( RandomMorphism,
 InstallMethod( RandomMorphism,
     [ IsCapCategory, IsList ], RandomMorphismByList );
 
-
+##
 InstallGlobalFunction( ObjectifyMorphismForCAPWithAttributes,
                        
   function( arg_list... )
     local category, morphism;
+    
+    Print(
+      Concatenation(
+      "WARNING: ObjectifyMorphismForCAPWithAttributes is deprecated and will not be supported after 2020.10.29. ",
+      "Please use ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( morphism, category, source, range[, attr1, val1, attr2, val2, ...] ) instead.\n"
+      )
+    );
     
     category := arg_list[ 2 ];
     arg_list[ 2 ] := category!.morphism_type;
@@ -237,6 +244,26 @@ InstallGlobalFunction( ObjectifyMorphismForCAPWithAttributes,
     fi;
     
 end );
+
+##
+InstallGlobalFunction( ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes,
+                       
+  function( morphism, category, source, range, additional_arguments_list... )
+    local arg_list;
+    
+    arg_list := Concatenation( 
+        [ morphism, category!.morphism_type, CapCategory, category, Source, source, Range, range ], additional_arguments_list
+    );
+    
+    CallFuncList( ObjectifyWithAttributes, arg_list );
+    
+    if category!.predicate_logic then
+        INSTALL_TODO_FOR_LOGICAL_THEOREMS( "Source", [ morphism ], source, category );
+        INSTALL_TODO_FOR_LOGICAL_THEOREMS( "Range", [ morphism ], range, category );
+    fi;
+    
+end );
+
 
 ##
 InstallMethod( Simplify,

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -195,7 +195,7 @@ InstallMethod( AddMorphismRepresentation,
   function( category, representation )
     
     category!.morphism_representation := representation;
-    category!.morphism_type := NewType( TheFamilyOfCapCategoryMorphisms, representation and MorphismFilter( category ) and IsCapCategoryMorphismRep );
+    category!.morphism_type := NewType( TheFamilyOfCapCategoryMorphisms, representation and MorphismFilter( category ) and IsCapCategoryMorphismRep and HasSource and HasRange and HasCapCategory );
     
 end );
 

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -218,7 +218,7 @@ InstallMethod( AddObjectRepresentation,
   function( category, representation )
     
     category!.object_representation := representation;
-    category!.object_type := NewType( TheFamilyOfCapCategoryObjects, representation and ObjectFilter( category ) and IsCapCategoryObjectRep );
+    category!.object_type := NewType( TheFamilyOfCapCategoryObjects, representation and ObjectFilter( category ) and IsCapCategoryObjectRep and HasCapCategory );
     
 end );
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -35,7 +35,7 @@ InstallMethod( AdditiveClosure,
     
     AddObjectRepresentation( category, IsAdditiveClosureObject );
     
-    AddMorphismRepresentation( category, IsAdditiveClosureMorphism );
+    AddMorphismRepresentation( category, IsAdditiveClosureMorphism and HasMorphismMatrix );
     
     INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE( category );
     
@@ -106,10 +106,10 @@ InstallMethod( AdditiveClosureMorphism,
     
     category := CapCategory( source );
 
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
                              additive_closure_morphism, category,
-                             Source, source,
-                             Range, range,
+                             source,
+                             range,
                              MorphismMatrix, matrix
     );
     

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -48,7 +48,7 @@ InstallMethod( AdelmanCategory,
     
     AddObjectRepresentation( adelman_category, IsAdelmanCategoryObject );
     
-    AddMorphismRepresentation( adelman_category, IsAdelmanCategoryMorphism );
+    AddMorphismRepresentation( adelman_category, IsAdelmanCategoryMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY( adelman_category );
     
@@ -136,10 +136,10 @@ InstallMethod( AdelmanCategoryMorphism,
     
     category :=  CapCategory( source );
     
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
                              adelman_category_morphism, category,
-                             Source, source,
-                             Range, range,
+                             source,
+                             range,
                              MorphismDatum, morphism_datum
     );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -33,7 +33,7 @@ InstallMethod( CategoryOfColumns,
     
     AddObjectRepresentation( category, IsCategoryOfColumnsObject );
     
-    AddMorphismRepresentation( category, IsCategoryOfColumnsMorphism );
+    AddMorphismRepresentation( category, IsCategoryOfColumnsMorphism and HasUnderlyingMatrix );
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS( category );
     
@@ -139,9 +139,9 @@ InstallMethod( CategoryOfColumnsMorphism,
     
     category_of_columns_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( category_of_columns_morphism, category,
-                                           Source, source,
-                                           Range, range,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( category_of_columns_morphism, category,
+                                           source,
+                                           range,
                                            UnderlyingMatrix, homalg_matrix
     );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
@@ -27,7 +27,7 @@ InstallMethod( CategoryOfGradedColumns,
       
       AddObjectRepresentation( category, IsGradedColumnRep );
       
-      AddMorphismRepresentation( category, IsGradedColumnMorphismRep );
+      AddMorphismRepresentation( category, IsGradedColumnMorphismRep and HasUnderlyingHomalgGradedRing and HasUnderlyingHomalgMatrix );
       
       SetUnderlyingGradedRing( category, homalg_graded_ring );
       

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/GradedRowOrColumnMorphism.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/GradedRowOrColumnMorphism.gi
@@ -97,10 +97,10 @@ InstallMethod( GradedRowOrColumnMorphism,
     # now create the morphism
     graded_row_or_column_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes(
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes(
       graded_row_or_column_morphism, category,
-      Source, source,
-      Range, range,
+      source,
+      range,
       UnderlyingHomalgGradedRing, homalg_graded_ring,
       UnderlyingHomalgMatrix, homalg_matrix
     );
@@ -128,10 +128,10 @@ InstallMethod( GradedRowOrColumnMorphism,
     # construct the morphism
     graded_row_or_column_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
       graded_row_or_column_morphism, category,
-      Source, source,
-      Range, range,
+      source,
+      range,
       UnderlyingHomalgGradedRing, homalg_graded_ring,
       UnderlyingHomalgMatrix, homalg_matrix
     );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -33,7 +33,7 @@ InstallMethod( CategoryOfRows,
     
     AddObjectRepresentation( category, IsCategoryOfRowsObject );
     
-    AddMorphismRepresentation( category, IsCategoryOfRowsMorphism );
+    AddMorphismRepresentation( category, IsCategoryOfRowsMorphism and HasUnderlyingMatrix );
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS( category );
     
@@ -137,9 +137,9 @@ InstallMethod( CategoryOfRowsMorphism,
     
     category_of_rows_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( category_of_rows_morphism, category,
-                                           Source, source,
-                                           Range, range,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( category_of_rows_morphism, category,
+                                           source,
+                                           range,
                                            UnderlyingMatrix, homalg_matrix
     );
     

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -61,7 +61,7 @@ InstallMethod( CokernelImageClosure,
     
     AddObjectRepresentation( cokernel_image_closure, IsCokernelImageClosureObject );
     
-    AddMorphismRepresentation( cokernel_image_closure, IsCokernelImageClosureMorphism );
+    AddMorphismRepresentation( cokernel_image_closure, IsCokernelImageClosureMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE( cokernel_image_closure );
     
@@ -150,10 +150,10 @@ InstallMethod( CokernelImageClosureMorphism,
     
     category :=  CapCategory( source );
 
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
                              cokernel_image_closure_morphism, category,
-                             Source, source,
-                             Range, range,
+                             source,
+                             range,
                              MorphismDatum, morphism_datum
     );
     

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -86,7 +86,7 @@ InstallGlobalFunction( FREYD_CATEGORY,
 
     AddObjectRepresentation( freyd_category, IsFreydCategoryObject );
     
-    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism );
+    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY( freyd_category );
     
@@ -194,10 +194,10 @@ InstallGlobalFunction( FREYD_CATEGORY_MORPHISM,
     
     category :=  CapCategory( source );
 
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
                              freyd_category_morphism, category,
-                             Source, source,
-                             Range, range,
+                             source,
+                             range,
                              MorphismDatum, morphism_datum
     );
     

--- a/FreydCategoriesForCAP/gap/QuiverRows.gi
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gi
@@ -124,7 +124,7 @@ InstallMethod( QuiverRows,
     
     AddObjectRepresentation( category, IsQuiverRowsObject );
     
-    AddMorphismRepresentation( category, IsQuiverRowsMorphism );
+    AddMorphismRepresentation( category, IsQuiverRowsMorphism and HasMorphismMatrix );
     
     INSTALL_FUNCTIONS_FOR_QUIVER_ROWS( category, over_Z );
     
@@ -209,10 +209,10 @@ InstallMethod( QuiverRowsMorphism,
     
     category := CapCategory( source );
 
-    ObjectifyMorphismForCAPWithAttributes( 
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
                              quiver_rows_morphism, category,
-                             Source, source,
-                             Range, range,
+                             source,
+                             range,
                              MorphismMatrix, matrix
     );
 

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
@@ -273,7 +273,7 @@ InstallMethod( GeneralizedMorphismCategoryByCospans,
     
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryByCospansObject );
     
-    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByCospan );
+    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByCospan and HasArrow and HasReversedArrow );
     
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
@@ -331,9 +331,9 @@ InstallMethodWithCacheFromObject( GeneralizedMorphismByCospan,
     
     generalized_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( generalized_morphism, generalized_category,
-                             Source, GeneralizedMorphismByCospansObject( Source( arrow ) ),
-                             Range, GeneralizedMorphismByCospansObject( Source( reversed_arrow ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( generalized_morphism, generalized_category,
+                             GeneralizedMorphismByCospansObject( Source( arrow ) ),
+                             GeneralizedMorphismByCospansObject( Source( reversed_arrow ) ),
                              Arrow, arrow,
                              ReversedArrow, reversed_arrow );
     

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
@@ -269,7 +269,7 @@ InstallMethod( GeneralizedMorphismCategoryBySpans,
     
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryBySpansObject );
     
-    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismBySpan );
+    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismBySpan and HasArrow and HasReversedArrow );
     
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
@@ -327,9 +327,9 @@ InstallMethodWithCacheFromObject( GeneralizedMorphismBySpan,
     
     generalized_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( generalized_morphism, generalized_category,
-                             Source, GeneralizedMorphismBySpansObject( Range( reversed_arrow ) ),
-                             Range, GeneralizedMorphismBySpansObject( Range( arrow ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( generalized_morphism, generalized_category,
+                             GeneralizedMorphismBySpansObject( Range( reversed_arrow ) ),
+                             GeneralizedMorphismBySpansObject( Range( arrow ) ),
                              Arrow, arrow,
                              ReversedArrow, reversed_arrow );
     

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -291,7 +291,7 @@ InstallMethod( GeneralizedMorphismCategoryByThreeArrows,
     
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryByThreeArrowsObject );
     
-    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByThreeArrows );
+    AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByThreeArrows and HasSourceAid and HasRangeAid and HasArrow );
     
     generalized_morphism_category!.predicate_logic := category!.predicate_logic;
     
@@ -353,9 +353,9 @@ InstallMethodWithCacheFromObject( GeneralizedMorphismByThreeArrows,
     
     generalized_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( generalized_morphism, generalized_category,
-                             Source, GeneralizedMorphismByThreeArrowsObject( Range( source_aid ) ),
-                             Range, GeneralizedMorphismByThreeArrowsObject( Source( range_aid ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( generalized_morphism, generalized_category,
+                             GeneralizedMorphismByThreeArrowsObject( Range( source_aid ) ),
+                             GeneralizedMorphismByThreeArrowsObject( Source( range_aid ) ),
                              SourceAid, source_aid,
                              RangeAid, range_aid,
                              Arrow, morphism_aid );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
@@ -362,7 +362,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospans,
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByCospansObject );
     
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByCospansMorphism );
+    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByCospansMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     
@@ -430,9 +430,9 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospansMorphism,
     
     serre_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( serre_morphism, serre_category,
-                             Source, AsSerreQuotientCategoryByCospansObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
-                             Range, AsSerreQuotientCategoryByCospansObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( serre_morphism, serre_category,
+                             AsSerreQuotientCategoryByCospansObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
+                             AsSerreQuotientCategoryByCospansObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
                              UnderlyingGeneralizedMorphism, gen_morphism );
     
     if HasSpecializedMorphismFilterForSerreQuotients( serre_category ) then

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
@@ -429,7 +429,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpans,
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryBySpansObject );
     
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryBySpansMorphism );
+    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryBySpansMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     
@@ -497,9 +497,9 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpansMorphism,
     
     serre_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( serre_morphism, serre_category,
-                             Source, AsSerreQuotientCategoryBySpansObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
-                             Range, AsSerreQuotientCategoryBySpansObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( serre_morphism, serre_category,
+                             AsSerreQuotientCategoryBySpansObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
+                             AsSerreQuotientCategoryBySpansObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
                              UnderlyingGeneralizedMorphism, gen_morphism );
     
     if HasSpecializedMorphismFilterForSerreQuotients( serre_category ) then

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -383,7 +383,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrows,
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsObject );
     
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsMorphism );
+    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     
@@ -451,9 +451,9 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrowsMorphism,
     
     serre_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( serre_morphism, serre_category,
-                             Source, AsSerreQuotientCategoryByThreeArrowsObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
-                             Range, AsSerreQuotientCategoryByThreeArrowsObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( serre_morphism, serre_category,
+                             AsSerreQuotientCategoryByThreeArrowsObject( serre_category, UnderlyingHonestObject( Source( gen_morphism ) ) ),
+                             AsSerreQuotientCategoryByThreeArrowsObject( serre_category, UnderlyingHonestObject( Range( gen_morphism ) ) ),
                              UnderlyingGeneralizedMorphism, gen_morphism );
     
     if HasSpecializedMorphismFilterForSerreQuotients( serre_category ) then

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -24,7 +24,7 @@ InstallMethod( MatrixCategory,
     
     AddObjectRepresentation( category, IsVectorSpaceObject );
     
-    AddMorphismRepresentation( category, IsVectorSpaceMorphism );
+    AddMorphismRepresentation( category, IsVectorSpaceMorphism and HasUnderlyingFieldForHomalg and HasUnderlyingMatrix );
     
     category!.field_for_matrix_category := homalg_field;
     

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
@@ -67,9 +67,9 @@ InstallMethod( VectorSpaceMorphism,
     
     vector_space_morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( vector_space_morphism, category,
-                                           Source, source,
-                                           Range, range,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( vector_space_morphism, category,
+                                           source,
+                                           range,
                                            UnderlyingFieldForHomalg, homalg_field,
                                            UnderlyingMatrix, homalg_matrix
     );

--- a/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
@@ -68,9 +68,9 @@ InstallMethod( PresentationMorphism,
     
     morphism := rec( );
     
-    ObjectifyMorphismForCAPWithAttributes( morphism, category,
-                             Source, source,
-                             Range, range,
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( morphism, category,
+                             source,
+                             range,
                              UnderlyingHomalgRing, HomalgRing( matrix ),
                              UnderlyingMatrix, matrix );
     

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -20,7 +20,7 @@ InstallMethod( LeftPresentations,
     
     AddObjectRepresentation( category, IsLeftPresentation );
     
-    AddMorphismRepresentation( category, IsLeftPresentationMorphism );
+    AddMorphismRepresentation( category, IsLeftPresentationMorphism and HasUnderlyingHomalgRing and HasUnderlyingMatrix );
     
     category!.ring_for_representation_category := ring;
     


### PR DESCRIPTION
If I understand the documentation of `ObjectifyWithAttributes` correctly, this might lead to a speed-up.