### PR TITLE
The action/coaction category of a noncomputable category is again noncomputable

### DIFF
--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -84,7 +84,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.6",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2019.01.16" ],
+                           [ "CAP", ">= 2019.09.16" ],
                            [ "MonoidalCategories", ">= 2019.01.16" ],
                            [ "AttributeCategoryForCAP", ">=2016.09.14" ]
                          ],

--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -12,7 +12,7 @@ PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
 
 Version := Maximum( [
-  "2019.09.15", ## Mohamed's version
+  "2019.09.16", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.08.19", ## Sebas' version
   ## this line prevents merge conflicts

--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -521,6 +521,7 @@ end );
 InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
   
   function( category )
+    local underlying_category;
     
     ##
     AddIsEqualForCacheForObjects( category,
@@ -529,6 +530,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
     ##
     AddIsEqualForCacheForMorphisms( category,
       IsIdenticalObj );
+    
+    underlying_category := UnderlyingCategory( category );
+    
+    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
     
     ##
     AddIsEqualForObjects( category,
@@ -540,6 +545,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
+    if CanCompute( underlying_category, "IsEqualForMorphisms" ) then
+    
     ##
     AddIsEqualForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -548,6 +557,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
+    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
+
     ##
     AddIsCongruentForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -555,6 +568,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
         
     end );
+    
+    fi;
     
 end );
 

--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -545,10 +545,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         
     end );
     
-    fi;
-    
-    if CanCompute( underlying_category, "IsEqualForMorphisms" ) then
-    
     ##
     AddIsEqualForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -557,10 +553,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         
     end );
     
-    fi;
-    
-    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
-
     ##
     AddIsCongruentForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -569,6 +561,18 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         
     end );
     
+    else
+        
+        SetCachingOfCategoryCrisp( category );
+        
+        ##
+        AddIsEqualForObjects( category, IsIdenticalObj );
+        
+        ##
+        AddIsEqualForMorphisms( category, IsIdenticalObj );
+        
+        ## cannot AddIsCongruentForMorphisms
+        
     fi;
     
 end );

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -546,10 +546,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         
     end );
     
-    fi;
-    
-    if CanCompute( underlying_category, "IsEqualForMorphisms" ) then
-    
     ##
     AddIsEqualForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -557,10 +553,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
         
     end );
-    
-    fi;
-    
-    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
     
     ##
     AddIsCongruentForMorphisms( category,
@@ -570,6 +562,18 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         
     end );
     
+    else
+        
+        SetCachingOfCategoryCrisp( category );
+        
+        ##
+        AddIsEqualForObjects( category, IsIdenticalObj );
+        
+        ##
+        AddIsEqualForMorphisms( category, IsIdenticalObj );
+        
+        ## cannot AddIsCongruentForMorphisms
+        
     fi;
     
 end );

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -522,6 +522,7 @@ end );
 InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
   
   function( category )
+    local underlying_category;
     
     ##
     AddIsEqualForCacheForObjects( category,
@@ -530,6 +531,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
     ##
     AddIsEqualForCacheForMorphisms( category,
       IsIdenticalObj );
+    
+    underlying_category := UnderlyingCategory( category );
+    
+    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
     
     ##
     AddIsEqualForObjects( category,
@@ -541,6 +546,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
+    if CanCompute( underlying_category, "IsEqualForMorphisms" ) then
+    
     ##
     AddIsEqualForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -549,6 +558,10 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         
     end );
     
+    fi;
+    
+    if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
+    
     ##
     AddIsCongruentForMorphisms( category,
       function( morphism_1, morphism_2 )
@@ -556,6 +569,8 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
         
     end );
+    
+    fi;
     
 end );
 


### PR DESCRIPTION
to allow having categories without decidable congruence of morphisms.