### PR TITLE
Additive closures Documentations + 3 functors

### DIFF
--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -102,14 +102,6 @@ DeclareAttribute( "ExtendFunctorToAdditiveClosures",
 DeclareAttribute( "ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource",
                   IsCapFunctor );
 
-#! @Description
-#! The input is a functor $F:C\to D$, where $C$ is an additive category. The output is the extension functor
-#! $F^\oplus:C \to D^\oplus$, which is nothing but the composition of $F:C\to D$ with the inclusion functor $\iota:D\to D^\oplus$.
-#! @Arguments F
-#! @Returns a CapFunctor
-DeclareAttribute( "ExtendFunctorWithAdditiveSourceToFunctorToAdditiveClosureOfRange",
-                  IsCapFunctor );
-
 ####################################
 ##
 #! @Section Attributes

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -102,6 +102,15 @@ DeclareAttribute( "ExtendFunctorToAdditiveClosures",
 DeclareAttribute( "ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource",
                   IsCapFunctor );
 
+#! @Description
+#! The input is a functor $F:C\to D$. If $D$ is not known to be an additive category, then return
+#! <C>ExtendFunctorToAdditiveClosures</C>(<A>F</A>), otherwise return
+#! <C>ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource</C>(<A>F</A>).
+#! @Arguments F
+#! @Returns a CapFunctor
+DeclareAttribute( "ExtendFunctorToAdditiveClosureOfSource",
+                  IsCapFunctor );
+
 ####################################
 ##
 #! @Section Attributes

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -14,16 +14,25 @@
 ##
 ####################################
 
+#! @Description
+#! The GAP category of additive closures of Ab-categories.
+#! @Arguments object
+DeclareCategory( "IsAdditiveClosureCategory",
+                 IsCapCategory );
+
+#! @Description
+#! The GAP category of objects in additive closures of Ab-categories.
+#! @Arguments object
 DeclareCategory( "IsAdditiveClosureObject",
                  IsCapCategoryObject );
 
+#! @Description
+#! The GAP category of morphisms in additive closures of Ab-categories.
+#! @Arguments object
 DeclareCategory( "IsAdditiveClosureMorphism",
                  IsCapCategoryMorphism );
 
 DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE" );
-
-DeclareCategory( "IsAdditiveClosureCategory",
-                 IsCapCategory );
 
 ####################################
 ##
@@ -31,19 +40,42 @@ DeclareCategory( "IsAdditiveClosureCategory",
 ##
 ####################################
 
+
+#! @Description
+#! The input is an Ab-category $C$. The output is its additive closure $C^\oplus$.
+#! @Arguments C
+#! @Returns a CapCategory
 DeclareAttribute( "AdditiveClosure",
                   IsCapCategory );
 
-
+#! @Description
+#! The input is a list of objects $L=[A_1,\dots,A_n]$ in an Ab-category $C$. The output is the formal direct sum
+#! $A_1\oplus\dots\oplus A_n$ in the additive closure $C^\oplus$.
+#! @Arguments L, C^\oplus
+#! @Returns a CapCategoryObject
 DeclareOperation( "AdditiveClosureObject",
                   [ IsList, IsAdditiveClosureCategory ] );
 
+#! @Description
+#! The input is an object $A$ in an Ab-category $C$. The output is the image of $A$ under the inclusion functor $\iota:C\to C^\oplus$.
+#! @Arguments A
+#! @Returns a CapCategoryObject
 DeclareAttribute( "AsAdditiveClosureObject",
                   IsCapCategoryObject );
 
+#! @Description
+#! The input is a formal direct sums $A=A_1\oplus\dots\oplus A_m$, $B=B_1\oplus\dots\oplus B_n$ and 
+#! an $m\times n$ matrix $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
+#! The output is the formal morphism between $A$ and $B$ that is defined by $M$.
+#! @Arguments A, M, B
+#! @Returns a CapCategoryMorphism
 DeclareOperation( "AdditiveClosureMorphism",
                   [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
 
+#! @Description
+#! The input is a morphism $\alpha$ in an Ab-category $C$. The output is the image of $\alpha$ under the inclusion functor $\iota:C\to C^\oplus$.
+#! @Arguments alpha
+#! @Returns a CapCategoryMorphism
 DeclareAttribute( "AsAdditiveClosureMorphism",
                   IsCapCategoryMorphism );
 
@@ -53,18 +85,38 @@ DeclareAttribute( "AsAdditiveClosureMorphism",
 ##
 ####################################
 
+#! @Description
+#! The input is some additive closure category $C^\oplus$. The output is $C$.
+#! @Arguments C^\oplus
+#! @Returns a CapCategory
 DeclareAttribute( "UnderlyingCategory",
                   IsAdditiveClosureCategory );
 
+#! @Description
+#! The input is a formal direct sum $A_1\oplus\dots\oplus A_m$. The output is the list $[A_1,\dots,A_m]$.
+#! @Arguments A
+#! @Returns IsList
 DeclareAttribute( "ObjectList",
                   IsAdditiveClosureObject );
 
+#! @Description
+#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the defining matrix of $\alpha$.
+#! @Arguments alpha
+#! @Returns IsList
 DeclareAttribute( "MorphismMatrix",
                   IsAdditiveClosureMorphism );
 
+#! @Description
+#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the source.
+#! @Arguments alpha
+#! @Returns IsInt
 DeclareAttribute( "NrRows",
                   IsAdditiveClosureMorphism );
 
+#! @Description
+#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the range.
+#! @Arguments alpha
+#! @Returns IsInt
 DeclareAttribute( "NrColumns",
                   IsAdditiveClosureMorphism );
 
@@ -76,3 +128,4 @@ DeclareAttribute( "NrColumns",
 
 DeclareOperation( "\[\]",
                   [ IsAdditiveClosureMorphism, IsInt ] );
+

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -17,18 +17,21 @@
 #! @Description
 #! The GAP category of additive closures of Ab-categories.
 #! @Arguments object
+#! @Returns true or false
 DeclareCategory( "IsAdditiveClosureCategory",
                  IsCapCategory );
 
 #! @Description
 #! The GAP category of objects in additive closures of Ab-categories.
 #! @Arguments object
+#! @Returns true or false
 DeclareCategory( "IsAdditiveClosureObject",
                  IsCapCategoryObject );
 
 #! @Description
 #! The GAP category of morphisms in additive closures of Ab-categories.
 #! @Arguments object
+#! @Returns true or false
 DeclareCategory( "IsAdditiveClosureMorphism",
                  IsCapCategoryMorphism );
 
@@ -42,72 +45,72 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE" );
 
 
 #! @Description
-#! The input is an Ab-category $C$. The output is its additive closure $C^\oplus$.
+#! The argument is an Ab-category $C$. The output is its additive closure $C^\oplus$.
 #! @Arguments C
-#! @Returns a CapCategory
+#! @Returns the category $C^\oplus$
 DeclareAttribute( "AdditiveClosure",
                   IsCapCategory );
 
 #! @Description
-#! The input is a list of objects $L=[A_1,\dots,A_n]$ in an Ab-category $C$. The output is the formal direct sum
+#! The argument is a list of objects $L=[A_1,\dots,A_n]$ in an Ab-category $C$. The output is the formal direct sum
 #! $A_1\oplus\dots\oplus A_n$ in the additive closure $C^\oplus$.
 #! @Arguments L, C^\oplus
-#! @Returns a CapCategoryObject
+#! @Returns an object in $C^\oplus$
 DeclareOperation( "AdditiveClosureObject",
                   [ IsList, IsAdditiveClosureCategory ] );
 
 #! @Description
-#! The input is an object $A$ in an Ab-category $C$. The output is the image of $A$ under the inclusion functor $\iota:C\to C^\oplus$.
+#! The argument is an object $A$ in an Ab-category $C$. The output is the image of $A$ under the inclusion functor $\iota:C\to C^\oplus$.
 #! @Arguments A
-#! @Returns a CapCategoryObject
+#! @Returns an object in $C^\oplus$
 DeclareAttribute( "AsAdditiveClosureObject",
                   IsCapCategoryObject );
 
 #! @Description
-#! The input is a formal direct sums $A=A_1\oplus\dots\oplus A_m$, $B=B_1\oplus\dots\oplus B_n$ and 
-#! an $m\times n$ matrix $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
+#! The arguments are formal direct sums $A=A_1\oplus\dots\oplus A_m$, $B=B_1\oplus\dots\oplus B_n$ in some additive category $C^\oplus$
+#! and an $m\times n$ matrix $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
 #! The output is the formal morphism between $A$ and $B$ that is defined by $M$.
 #! @Arguments A, M, B
-#! @Returns a CapCategoryMorphism
+#! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
 DeclareOperation( "AdditiveClosureMorphism",
                   [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
 
 #! @Description
-#! The input is a morphism $\alpha$ in an Ab-category $C$. The output is the image of $\alpha$ under the inclusion functor $\iota:C\to C^\oplus$.
+#! The argument is a morphism $\alpha$ in an Ab-category $C$. The output is the image of $\alpha$ under the inclusion functor $\iota:C\to C^\oplus$.
 #! @Arguments alpha
-#! @Returns a CapCategoryMorphism
+#! @Returns a morphism in $C^\oplus$
 DeclareAttribute( "AsAdditiveClosureMorphism",
                   IsCapCategoryMorphism );
 
 #! @Description
-#! The input is an Ab-category $C$. The output is the inclusion functor $\iota:C\to C^\oplus$.
+#! The argument is an Ab-category $C$. The output is the inclusion functor $\iota:C\to C^\oplus$.
 #! @Arguments C
-#! @Returns a CapFunctor
+#! @Returns a functor $C\to C^\oplus$
 DeclareAttribute( "InclusionFunctorInAdditiveClosure",
                   IsCapCategory );
 
 #! @Description
-#! The input is a functor $F:C\to D$, and the output is the extension functor
+#! The argument is a functor $F:C\to D$, and the output is the extension functor
 #! $F^\oplus:C^\oplus \to D^\oplus$.
 #! @Arguments F
-#! @Returns a CapFunctor
+#! @Returns a functor $C^\oplus \to D^\oplus$
 DeclareAttribute( "ExtendFunctorToAdditiveClosures",
                   IsCapFunctor );
 
 #! @Description
-#! The input is a functor $F:C\to D$, where $D$ is an additive category. The output is the extension functor
+#! The argument is a functor $F:C\to D$, where $D$ is an additive category. The output is the extension functor
 #! $F^\oplus:C^\oplus \to D$.
 #! @Arguments F
-#! @Returns a CapFunctor
+#! @Returns a functor $C^\oplus \to D$
 DeclareAttribute( "ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource",
                   IsCapFunctor );
 
 #! @Description
-#! The input is a functor $F:C\to D$. If $D$ is not known to be an additive category, then return
+#! The argument is a functor $F:C\to D$. If $D$ is not known to be an additive category, then return
 #! <C>ExtendFunctorToAdditiveClosures</C>(<A>F</A>), otherwise return
 #! <C>ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource</C>(<A>F</A>).
 #! @Arguments F
-#! @Returns a CapFunctor
+#! @Returns a functor $C^\oplus \to D^\oplus$ or $C^\oplus \to D$
 DeclareAttribute( "ExtendFunctorToAdditiveClosureOfSource",
                   IsCapFunctor );
 
@@ -118,37 +121,39 @@ DeclareAttribute( "ExtendFunctorToAdditiveClosureOfSource",
 ####################################
 
 #! @Description
-#! The input is some additive closure category $C^\oplus$. The output is $C$.
-#! @Arguments C^\oplus
-#! @Returns a CapCategory
+#! The argument is some additive closure category $A:=C^\oplus$. The output is $C$.
+#! @Arguments A
+#! @Returns the category $C$
 DeclareAttribute( "UnderlyingCategory",
                   IsAdditiveClosureCategory );
 
 #! @Description
-#! The input is a formal direct sum $A_1\oplus\dots\oplus A_m$. The output is the list $[A_1,\dots,A_m]$.
+#! The argument is a formal direct sum $A:=A_1\oplus\dots\oplus A_m$ in some additive closure category $C^\oplus$.
+#! The output is the list $[A_1,\dots,A_m]$.
 #! @Arguments A
-#! @Returns IsList
+#! @Returns a list of the objects in $C$
 DeclareAttribute( "ObjectList",
                   IsAdditiveClosureObject );
 
 #! @Description
-#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the defining matrix of $\alpha$.
+#! The argument is a morphism $\alpha:A\to B$ between formal direct sums in some additive closure category $C^\oplus$.
+#! The output is the defining matrix of $\alpha$.
 #! @Arguments alpha
-#! @Returns IsList
+#! @Returns a list of lists the morphisms in $C$
 DeclareAttribute( "MorphismMatrix",
                   IsAdditiveClosureMorphism );
 
 #! @Description
-#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the source.
+#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the source.
 #! @Arguments alpha
-#! @Returns IsInt
+#! @Returns a non-negative integer
 DeclareAttribute( "NrRows",
                   IsAdditiveClosureMorphism );
 
 #! @Description
-#! The input is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the range.
+#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the range.
 #! @Arguments alpha
-#! @Returns IsInt
+#! @Returns a non-negative integer
 DeclareAttribute( "NrColumns",
                   IsAdditiveClosureMorphism );
 
@@ -158,6 +163,11 @@ DeclareAttribute( "NrColumns",
 ##
 ####################################
 
+#! @Description
+#! The arguments are morphism $\alpha:A\to B$ between formal direct sums in some additive category $C^\oplus$ and an integer $i$.
+#! The output is the $i$'th entry in <C>MorphismMatrix</C>($\alpha$).
+#! @Arguments alpha, i
+#! @Returns a list of morphisms in $C$
 DeclareOperation( "\[\]",
                   [ IsAdditiveClosureMorphism, IsInt ] );
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -79,6 +79,37 @@ DeclareOperation( "AdditiveClosureMorphism",
 DeclareAttribute( "AsAdditiveClosureMorphism",
                   IsCapCategoryMorphism );
 
+#! @Description
+#! The input is an Ab-category $C$. The output is the inclusion functor $\iota:C\to C^\oplus$.
+#! @Arguments C
+#! @Returns a CapFunctor
+DeclareAttribute( "InclusionFunctorInAdditiveClosure",
+                  IsCapCategory );
+
+#! @Description
+#! The input is a functor $F:C\to D$, and the output is the extension functor
+#! $F^\oplus:C^\oplus \to D^\oplus$.
+#! @Arguments F
+#! @Returns a CapFunctor
+DeclareAttribute( "ExtendFunctorToAdditiveClosures",
+                  IsCapFunctor );
+
+#! @Description
+#! The input is a functor $F:C\to D$, where $D$ is an additive category. The output is the extension functor
+#! $F^\oplus:C^\oplus \to D$.
+#! @Arguments F
+#! @Returns a CapFunctor
+DeclareAttribute( "ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource",
+                  IsCapFunctor );
+
+#! @Description
+#! The input is a functor $F:C\to D$, where $C$ is an additive category. The output is the extension functor
+#! $F^\oplus:C \to D^\oplus$, which is nothing but the composition of $F:C\to D$ with the inclusion functor $\iota:D\to D^\oplus$.
+#! @Arguments F
+#! @Returns a CapFunctor
+DeclareAttribute( "ExtendFunctorWithAdditiveSourceToFunctorToAdditiveClosureOfRange",
+                  IsCapFunctor );
+
 ####################################
 ##
 #! @Section Attributes

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -143,6 +143,134 @@ InstallMethod( NrColumns,
     
 end );
 
+##
+InstallMethod( InclusionFunctorInAdditiveClosure,
+              [ IsCapCategory ],
+  function( C )
+    local additive_closure, name, G;
+    
+    additive_closure := AdditiveClosure( C );
+    
+    name := Concatenation( "Inclusion functor of ", Name( C ), " in its additive closure" );
+    
+    G := CapFunctor( name, C, additive_closure );
+    
+    AddObjectFunction( G, AsAdditiveClosureObject );
+    
+    AddMorphismFunction( G, { s, alpha, r } -> AsAdditiveClosureMorphism( alpha ) );
+    
+    return G;
+    
+end );
+
+##
+InstallMethod( ExtendFunctorToAdditiveClosures,
+              [ IsCapFunctor ],
+  function( F )
+    local source_cat, range_cat, additive_closure_source, additive_closure_range, name, G;
+    
+    source_cat := AsCapCategory( Source( F ) );
+    
+    range_cat := AsCapCategory( Range( F ) );
+    
+    additive_closure_source := AdditiveClosure( source_cat );
+    
+    additive_closure_range := AdditiveClosure( range_cat );
+    
+    name := Concatenation( "Extension of ", Name( F ), " to additive closures" );
+    
+    G := CapFunctor( name, additive_closure_source, additive_closure_range );
+    
+    AddObjectFunction( G,
+      function( a )
+        local objs;
+        
+        objs := ObjectList( a );
+        
+        objs := List( objs, obj -> ApplyFunctor( F, obj ) );
+        
+        return AdditiveClosureObject( objs, additive_closure_range );
+        
+    end );
+    
+    AddMorphismFunction( G,
+      function( source, alpha, range )
+        local mat;
+        
+        mat := MorphismMatrix( alpha );
+        
+        mat := List( mat, row -> List( row, morphism -> ApplyFunctor( F, morphism ) ) );
+        
+        return AdditiveClosureMorphism( source, mat, range );
+        
+    end );
+    
+    return G;
+    
+end );
+
+##
+InstallMethod( ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource,
+              [ IsCapFunctor ],
+  function( F )
+    local source_cat, range_cat, additive_closure_source, name, G;
+    
+    source_cat := AsCapCategory( Source( F ) );
+    
+    range_cat := AsCapCategory( Range( F ) );
+    
+    if not ( HasIsAdditiveCategory( range_cat ) and IsAdditiveCategory( range_cat ) ) then
+      
+      Error( "The range category must be additive!\n" );
+      
+    fi;
+    
+    additive_closure_source := AdditiveClosure( source_cat );
+    
+    name := Concatenation( "Extension of ", Name( F ), " to a functor from the additive closure of the source" );
+    
+    G := CapFunctor( name, additive_closure_source, range_cat );
+    
+    AddObjectFunction( G,
+      function( a )
+        local objs;
+        
+        objs := ObjectList( a );
+        
+        objs := List( objs, obj -> ApplyFunctor( F, obj ) );
+        
+        return DirectSum( objs );
+        
+    end );
+    
+    AddMorphismFunction( G,
+      function( source, alpha, range )
+        local mat;
+        
+        mat := MorphismMatrix( alpha );
+        
+        mat := List( mat, row -> List( row, morphism -> ApplyFunctor( F, morphism ) ) );
+        
+        return MorphismBetweenDirectSums( source, mat, range );
+        
+    end );
+    
+    return G;
+    
+end );
+
+##
+InstallMethod( ExtendFunctorWithAdditiveSourceToFunctorToAdditiveClosureOfRange,
+              [ IsCapFunctor ],
+  function( F )
+    local range_cat;
+    
+    range_cat := AsCapCategory( Range( F ) );
+    
+    return PreCompose( F, InclusionFunctorInAdditiveClosure( range_cat ) );
+    
+end );
+
 ####################################
 ##
 ## Operations

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -259,18 +259,6 @@ InstallMethod( ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSourc
     
 end );
 
-##
-InstallMethod( ExtendFunctorWithAdditiveSourceToFunctorToAdditiveClosureOfRange,
-              [ IsCapFunctor ],
-  function( F )
-    local range_cat;
-    
-    range_cat := AsCapCategory( Range( F ) );
-    
-    return PreCompose( F, InclusionFunctorInAdditiveClosure( range_cat ) );
-    
-end );
-
 ####################################
 ##
 ## Operations

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -259,6 +259,24 @@ InstallMethod( ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSourc
     
 end );
 
+##
+InstallMethod( ExtendFunctorToAdditiveClosureOfSource,
+              [ IsCapFunctor ],
+  function( F )
+    local range_cat;
+    
+    range_cat := AsCapCategory( Range( F ) );
+    
+    if not ( HasIsAdditiveCategory( range_cat ) and IsAdditiveCategory( range_cat ) ) then
+      
+      return ExtendFunctorToAdditiveClosures( F );
+      
+    fi;
+    
+    return ExtendFunctorWithAdditiveRangeToFunctorFromAdditiveClosureOfSource( F );
+    
+end );
+
 ####################################
 ##
 ## Operations


### PR DESCRIPTION
1- For Ab-category C construct the inclusion functor C --> AdditiveClosure(C).
2- For  F:C-->D construct G: AdditiveClosure(C) --> AdditiveClosure(D).
3- For  F:C-->D with additive D construct G: AdditiveClosure(C) --> D.