### PR TITLE
Convenience method for IsRat multiplication

### DIFF
--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -952,11 +952,24 @@ DeclareOperation( "AddAdditiveInverseForMorphisms",
 DeclareOperation( "MultiplyWithElementOfCommutativeRingForMorphisms",
                   [ IsRingElement, IsCapCategoryMorphism ] );
 
+#! @Description
+#! This is a convenience method. It has two arguments.
+#! The first argument is either a rational number $q$
+#! or an element $r$ of a commutative ring $R$.
+#! The second argument is a morphism $\alpha: a \rightarrow b$ in a linear category
+#! of the commutative ring $R$.
+#! In the case where the first element is a rational number, this method tries to interpret $q$ as an element $r$ of $R$ via
+#! <C>R!.interpret_rationals_func</C>. If no such interpretation
+#! exists, this method throws an error.
+#! The output is the multiplication with the ring element $r \cdot \alpha$.
+#! @Returns a morphism in $\mathrm{Hom}(a,b)$
+#! @Arguments r, alpha
 DeclareOperation( "\*",
                   [ IsRingElement, IsCapCategoryMorphism ] );
 
 DeclareOperation( "\*",
                   [ IsCapCategoryMorphism, IsRingElement ] );
+
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -957,7 +957,7 @@ DeclareOperation( "MultiplyWithElementOfCommutativeRingForMorphisms",
 #! The first argument is either a rational number $q$
 #! or an element $r$ of a commutative ring $R$.
 #! The second argument is a morphism $\alpha: a \rightarrow b$ in a linear category
-#! of the commutative ring $R$.
+#! over the commutative ring $R$.
 #! In the case where the first element is a rational number, this method tries to interpret $q$ as an element $r$ of $R$ via
 #! <C>R!.interpret_rationals_func</C>. If no such interpretation
 #! exists, this method throws an error.

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -183,6 +183,41 @@ InstallMethod( \*,
 end );
 
 ##
+InstallMethod( \*,
+               [ IsRingElement and IsRat, IsCapCategoryMorphism ],
+               
+function( q, mor )
+    local cat, ring, r;
+    
+    cat := CapCategory( mor );
+    
+    ring := CommutativeRingOfLinearCategory( cat );
+    
+    if not IsIdenticalObj( ring, Rationals ) then
+        
+        if IsBound( ring!.interpret_rationals_func ) then
+            
+            r := ring!.interpret_rationals_func( q );
+            
+            if r = fail then
+                
+                Error( "cannot interpret ", String( q ), " as an element of the commutative ring of ", Name( cat ) );
+                
+            fi;
+            
+        else
+            
+            Error( "The commutative ring of ", Name( cat ), "doesn't know how to interpret rationals" );
+            
+        fi;
+        
+    fi;
+    
+    return MultiplyWithElementOfCommutativeRingForMorphisms( r, mor );
+    
+end );
+
+##
 InstallMethod( IsEqualForCacheForMorphisms,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
                

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -98,7 +98,7 @@ Dependencies := rec(
   GAP := ">= 4.8",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
                            [ "CAP", ">= 2019.10.04" ],
-                           [ "MatricesForHomalg", ">= 2019.02.01" ],
+                           [ "MatricesForHomalg", ">= 2019.11.01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "LinearAlgebraForCAP", ">= 2017.12.30" ],
                            [ "GeneralizedMorphismsForCAP", ">= 2018.06.15" ]


### PR DESCRIPTION
This PR can only work properly if every homalg ring provides a function 
`interpret_rationals_func`, which takes an `IsRat` as an input and outputs
an interpretation of that `IsRat` as a ring element or `fail` else.