### PR TITLE
Improve performance of generic sanity checks

### DIFF
--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -269,7 +269,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                             new_filter_list,
                             
               function( arg )
-                local redirect_return, filter, human_readable_identifier, pre_func_return, result, i, j;
+                local redirect_return, filter, human_readable_identifier_getter, pre_func_return, result, i, j;
                 
                 if (redirect_function <> false) and (not IsBound( category!.redirects.( function_name ) ) or category!.redirects.( function_name ) <> false) then
                     redirect_return := CallFuncList( redirect_function, Concatenation( [ category ], arg ) );
@@ -292,35 +292,35 @@ InstallGlobalFunction( CapInternalInstallAdd,
                         
                         filter := LowercaseString( filter );
                         
-                        human_readable_identifier := Concatenation( "the ", String(i), "-th argument of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        human_readable_identifier_getter := x -> Concatenation( "the ", String(i), "-th argument of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
                         
                         if filter = "cell" then
-                            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg[ i ], category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg[ i ], category, human_readable_identifier_getter );
                         elif filter = "object" then
-                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ], category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ], category, human_readable_identifier_getter );
                         elif filter = "morphism" then
-                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ], category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ], category, human_readable_identifier_getter );
                         elif filter = "twocell" then
-                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ], category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ], category, human_readable_identifier_getter );
                         elif filter = "other_cell" then
-                            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg[ i ], "any", human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg[ i ], false, human_readable_identifier_getter );
                         elif filter = "other_object" then
-                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ], "any", human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ], false, human_readable_identifier_getter );
                         elif filter = "other_morphism" then
-                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ], "any", human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ], false, human_readable_identifier_getter );
                         elif filter = "other_twocell" then
-                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ], "any", human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ], false, human_readable_identifier_getter );
                         elif filter = "list_of_objects" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ][ j ], category, Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier ) );
+                                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
                             od;
                         elif filter = "list_of_morphisms" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ][ j ], category, Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier ) );
+                                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
                             od;
                         elif filter = "list_of_twocells" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ][ j ], category, Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier ) );
+                                CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
                             od;
                         fi;
                     od;
@@ -349,14 +349,14 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     if category!.add_primitive_output then
                         add_function( category, result );
                     elif category!.output_sanity_check_level > 0 then
-                        human_readable_identifier := Concatenation( "the result of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        human_readable_identifier_getter := x -> Concatenation( "the result of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
                         
                         if record.return_type = "object" or ( record.return_type = "object_or_fail" and result <> fail ) then
-                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( result, category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( result, category, human_readable_identifier_getter );
                         elif record.return_type = "morphism" or ( record.return_type = "morphism_or_fail" and result <> fail ) then
-                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( result, category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( result, category, human_readable_identifier_getter );
                         elif record.return_type = "twocell" then
-                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( result, category, human_readable_identifier );
+                            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( result, category, human_readable_identifier_getter );
                         fi;
                     fi;
                 fi;

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -92,32 +92,32 @@ DeclareGlobalFunction( "CAP_INTERNAL_MERGE_PRECONDITIONS_LIST" );
 
 DeclareGlobalFunction( "CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS" );
 
-#! @Arguments cell, category, human_readable_identifier
+#! @Arguments cell, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>cell</A> is not a cell of <A>category</A>.
-#!  If <A>category</A> is the string <C>"any"</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier</A> is used to refer to <A>cell</A> in the error message.
+#!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY" );
 
-#! @Arguments object, category, human_readable_identifier
+#! @Arguments object, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>object</A> is not an object of <A>category</A>.
-#!  If <A>category</A> is the string <C>"any"</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier</A> is used to refer to <A>object</A> in the error message.
+#!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>object</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY" );
 
-#! @Arguments morphism, category, human_readable_identifier
+#! @Arguments morphism, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>morphism</A> is not a morphism of <A>category</A>.
-#!  If <A>category</A> is the string <C>"any"</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier</A> is used to refer to <A>morphism</A> in the error message.
+#!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>morphism</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY" );
 
-#! @Arguments two_cell, category, human_readable_identifier
+#! @Arguments two_cell, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>two_cell</A> is not a 2-cell of <A>category</A>.
-#!  If <A>category</A> is the string <C>"any"</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier</A> is used to refer to <A>two_cell</A> in the error message.
+#!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>two_cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY" );
 
 DeclareGlobalFunction( "ListKnownCategoricalProperties" );

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -56,25 +56,25 @@ fi;
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY,
   
-  function( cell, category, human_readable_identifier )
+  function( cell, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the category cell and category via the local variables 'cell' and 'category' in a break loop.";
     
     if not IsCapCategoryCell( cell ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the filter IsCapCategoryCell.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the filter IsCapCategoryCell.", generic_help_string ) );
     fi;
     
     if not HasCapCategory( cell ) then
-        Error( Concatenation( human_readable_identifier, " has no CAP category.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no CAP category.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not IsIdenticalObj( CapCategory( cell ), category ) then
-        Error( Concatenation( "The CapCategory of ", human_readable_identifier, " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not IsIdenticalObj( CapCategory( cell ), category ) then
+        Error( Concatenation( "The CapCategory of ", human_readable_identifier_getter(), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not CellFilter( category )( cell ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not CellFilter( category )( cell ) then
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
 end );
@@ -82,25 +82,25 @@ end );
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY,
   
-  function( object, category, human_readable_identifier )
+  function( object, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the object and category via the local variables 'object' and 'category' in a break loop.";
     
     if not IsCapCategoryObject( object ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the filter IsCapCategoryObject.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the filter IsCapCategoryObject.", generic_help_string ) );
     fi;
     
     if not HasCapCategory( object ) then
-        Error( Concatenation( human_readable_identifier, " has no CAP category.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no CAP category.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not IsIdenticalObj( CapCategory( object ), category ) then
-        Error( Concatenation( "The CapCategory of ", human_readable_identifier, " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not IsIdenticalObj( CapCategory( object ), category ) then
+        Error( Concatenation( "The CapCategory of ", human_readable_identifier_getter(), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not ObjectFilter( category )( object ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the object filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not ObjectFilter( category )( object ) then
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the object filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
 end );
@@ -108,75 +108,75 @@ end );
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY,
   
-  function( morphism, category, human_readable_identifier )
+  function( morphism, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the morphism and category via the local variables 'morphism' and 'category' in a break loop.";
     
     if not IsCapCategoryMorphism( morphism ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the filter IsCapCategoryMorphism.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the filter IsCapCategoryMorphism.", generic_help_string ) );
     fi;
     
     if not HasCapCategory( morphism ) then
-        Error( Concatenation( human_readable_identifier, " has no CAP category.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no CAP category.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not IsIdenticalObj( CapCategory( morphism ), category ) then
-        Error( Concatenation( "the CAP-category of ", human_readable_identifier, " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not IsIdenticalObj( CapCategory( morphism ), category ) then
+        Error( Concatenation( "the CAP-category of ", human_readable_identifier_getter(), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not MorphismFilter( category )( morphism ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the morphism filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not MorphismFilter( category )( morphism ) then
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the morphism filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
     if not HasSource( morphism ) then
-        Error( Concatenation( human_readable_identifier, " has no source.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, Concatenation( "the source of ", human_readable_identifier ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, x -> Concatenation( "the source of ", human_readable_identifier_getter() ) );
     
     if not HasRange( morphism ) then
-        Error( Concatenation( human_readable_identifier, " has no range.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, Concatenation( "the range of ", human_readable_identifier ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, x -> Concatenation( "the range of ", human_readable_identifier_getter() ) );
     
 end );
 
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY,
   
-  function( two_cell, category, human_readable_identifier )
+  function( two_cell, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the 2-cell and category via the local variables 'two_cell' and 'category' in a break loop.";
     
     if not IsCapCategoryTwoCell( two_cell ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the filter IsCapCategoryTwoCell.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the filter IsCapCategoryTwoCell.", generic_help_string ) );
     fi;
     
     if not HasCapCategory( two_cell ) then
-        Error( Concatenation( human_readable_identifier, " has no CAP category.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no CAP category.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not IsIdenticalObj( CapCategory( two_cell ), category ) then
-        Error( Concatenation( "the CapCategory of ", human_readable_identifier, " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not IsIdenticalObj( CapCategory( two_cell ), category ) then
+        Error( Concatenation( "the CapCategory of ", human_readable_identifier_getter(), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
-    if category <> "any" and not TwoCellFilter( category )( two_cell ) then
-        Error( Concatenation( human_readable_identifier, " does not lie in the 2-cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
+    if category <> false and not TwoCellFilter( category )( two_cell ) then
+        Error( Concatenation( human_readable_identifier_getter(), " does not lie in the 2-cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ) );
     fi;
     
     if not HasSource( two_cell ) then
-        Error( Concatenation( human_readable_identifier, " has no source.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, Concatenation( "the source of ", human_readable_identifier ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, x -> Concatenation( "the source of ", human_readable_identifier_getter() ) );
     
     if not HasRange( two_cell ) then
-        Error( Concatenation( human_readable_identifier, " has no range.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, Concatenation( "the range of ", human_readable_identifier ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, x -> Concatenation( "the range of ", human_readable_identifier_getter() ) );
     
 end );


### PR DESCRIPTION
Approximate runtimes for `make test` in `FreydCategories` on my notebook:

* before the generic sanity checks where introduced: 2:38 min
* after the generic sanity checks where introduced: 4:32 min
* with this commit: 3:11 min

So with this commit, the new sanity checks increase the runtime by about 20% which seems acceptable for me. Nevertheless, I will try to profile this a bit more once I find the time.