### PR TITLE
Fix getters in sanity checks

### DIFF
--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -292,7 +292,9 @@ InstallGlobalFunction( CapInternalInstallAdd,
                         
                         filter := LowercaseString( filter );
                         
-                        human_readable_identifier_getter := x -> Concatenation( "the ", String(i), "-th argument of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        human_readable_identifier_getter := function ( )
+                            return Concatenation( "the ", String(i), "-th argument of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        end;
                         
                         if filter = "cell" then
                             CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg[ i ], category, human_readable_identifier_getter );
@@ -312,15 +314,15 @@ InstallGlobalFunction( CapInternalInstallAdd,
                             CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ], false, human_readable_identifier_getter );
                         elif filter = "list_of_objects" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
+                                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg[ i ][ j ], category, function ( ) return Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ); end );
                             od;
                         elif filter = "list_of_morphisms" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
+                                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg[ i ][ j ], category, function ( ) return Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ); end );
                             od;
                         elif filter = "list_of_twocells" then
                             for j in [ 1 .. Length( arg[ i ] ) ] do
-                                CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ][ j ], category, x -> Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ) );
+                                CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ i ][ j ], category, function ( ) return Concatenation( "the ", String(j), "-th entry of the ", human_readable_identifier_getter() ); end );
                             od;
                         fi;
                     od;
@@ -349,7 +351,9 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     if category!.add_primitive_output then
                         add_function( category, result );
                     elif category!.output_sanity_check_level > 0 then
-                        human_readable_identifier_getter := x -> Concatenation( "the result of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        human_readable_identifier_getter := function ( )
+                            return Concatenation( "the result of the function \033[1m", record.function_name, "\033[0m of the category named \033[1m", Name( category ), "\033[0m" );
+                        end;
                         
                         if record.return_type = "object" or ( record.return_type = "object_or_fail" and result <> fail ) then
                             CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( result, category, human_readable_identifier_getter );

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -133,13 +133,13 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY,
         Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, x -> Concatenation( "the source of ", human_readable_identifier_getter() ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, function ( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
     
     if not HasRange( morphism ) then
         Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, x -> Concatenation( "the range of ", human_readable_identifier_getter() ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, function ( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
     
 end );
 
@@ -171,12 +171,12 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY,
         Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, x -> Concatenation( "the source of ", human_readable_identifier_getter() ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, function ( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
     
     if not HasRange( two_cell ) then
         Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, x -> Concatenation( "the range of ", human_readable_identifier_getter() ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, function ( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
     
 end );


### PR DESCRIPTION
The short-hand notation `x -> ...` creates unary functions, so all calls of `human_readable_identifier_getter` throw an error currently. Sorry for not testing this properly :/