### PR TITLE
Fixes and performance improvements of sanity checks

### DIFF
--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -415,7 +415,7 @@ InstallGlobalFunction( ApplyFunctor,
     if Length( arguments ) = 1 and functor!.number_arguments > 1 then
         
         if source_category!.input_sanity_check_level > 0 then
-            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], source_category, Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ) );
+            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], source_category, function( ) return Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ); end );
         fi;
 
         arguments := ShallowCopy( Components( arguments[ 1 ] ) );
@@ -428,7 +428,7 @@ InstallGlobalFunction( ApplyFunctor,
         
     elif Length( arguments ) = 1 and input_signature[ 1 ][ 2 ] = true then
         if source_category!.input_sanity_check_level > 0 then
-            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], "any", Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ) );
+            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], false, function( ) return Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ); end );
         fi;
 
         if IsIdenticalObj( CapCategory( arguments[ 1 ] ), Opposite( input_signature[ 1 ][ 1 ] ) ) then
@@ -436,7 +436,7 @@ InstallGlobalFunction( ApplyFunctor,
         fi;
     elif Length( arguments ) = 1 then
         if source_category!.input_sanity_check_level > 0 then
-            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], source_category, Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ) );
+            CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arguments[ 1 ], source_category, function( ) return Concatenation( "the argument passed to the functor named \033[1m", Name(functor), "\033[0m" ); end );
         fi;
     fi;
     
@@ -449,14 +449,14 @@ InstallGlobalFunction( ApplyFunctor,
             fi;
 
             for i in [ 1 .. Length( input_signature ) ] do
-                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arguments[ i ], input_signature[ i ][ 1 ], Concatenation( "the ", String(i), "-th argument passed to the functor named \033[1m", Name(functor), "\033[0m" ) );
+                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arguments[ i ], input_signature[ i ][ 1 ], function( ) return Concatenation( "the ", String(i), "-th argument passed to the functor named \033[1m", Name(functor), "\033[0m" ); end );
             od;
         fi;
         
         computed_value := CallFuncList( FunctorObjectOperation( functor ), arguments );
 
         if range_category!.output_sanity_check_level > 0 and not range_category!.add_primitive_output then
-            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( computed_value, range_category, Concatenation( "the result of the object function of the functor named \033[1m", Name(functor), "\033[0m" ) );
+            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( computed_value, range_category, function( ) return Concatenation( "the result of the object function of the functor named \033[1m", Name(functor), "\033[0m" ); end );
         fi;
         
         if range_category!.add_primitive_output then
@@ -473,7 +473,7 @@ InstallGlobalFunction( ApplyFunctor,
             fi;
 
             for i in [ 1 .. Length( input_signature ) ] do
-                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arguments[ i ], input_signature[ i ][ 1 ], Concatenation( "the ", String(i), "-th argument passed to the functor named \033[1m", Name(functor), "\033[0m" ) );
+                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arguments[ i ], input_signature[ i ][ 1 ], function( ) return Concatenation( "the ", String(i), "-th argument passed to the functor named \033[1m", Name(functor), "\033[0m" ); end );
             od;
         fi;
         
@@ -496,7 +496,7 @@ InstallGlobalFunction( ApplyFunctor,
         computed_value := CallFuncList( FunctorMorphismOperation( functor ), Concatenation( [ source_value ], arguments, [ range_value ] ) );
 
         if range_category!.output_sanity_check_level > 0 and not range_category!.add_primitive_output then
-            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( computed_value, range_category, Concatenation( "the result of the morphism function of the functor named \033[1m", Name(functor), "\033[0m" ) );
+            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( computed_value, range_category, function( ) return Concatenation( "the result of the morphism function of the functor named \033[1m", Name(functor), "\033[0m" ); end );
         fi;
         
         if range_category!.add_primitive_output then

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -133,13 +133,13 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY,
         Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, function ( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, function( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
     
     if not HasRange( morphism ) then
         Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, function ( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, function( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
     
 end );
 
@@ -171,12 +171,12 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY,
         Error( Concatenation( human_readable_identifier_getter(), " has no source.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, function ( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, function( ) return Concatenation( "the source of ", human_readable_identifier_getter() ); end );
     
     if not HasRange( two_cell ) then
         Error( Concatenation( human_readable_identifier_getter(), " has no range.", generic_help_string ) );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, function ( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, function( ) return Concatenation( "the range of ", human_readable_identifier_getter() ); end );
     
 end );


### PR DESCRIPTION
This creates input and output sanity check functions in advance to save time when the actual function call happens. This decreases the time the Freyd tests take on my notebook from 3:33 min to 3:21 min (with #423 reverted).