### PR TITLE
Display warning if IsIdenticalObj is used for IsEqualForObjects but caching is not crisp

### DIFF
--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -486,6 +486,11 @@ InstallGlobalFunction( CapInternalInstallAdd,
         end;
         
         for i in method_list do
+            
+            if record.installation_name = "IsEqualForObjects" and IsIdenticalObj( i[ 1 ], IsIdenticalObj ) and category!.default_cache_type <> "crisp" and not ValueOption( "SuppressCacheWarning" ) = true then
+                Display( "WARNING: IsIdenticalObj is used for deciding the equality of objects but the caching is not set to crisp. Thus, probably the specification that equal input gives equal output is not fulfilled. You can suppress this warning by passing the option \"SuppressCacheWarning := true\" to AddIsEqualForObjects." );
+            fi;
+            
             install_func( i[ 1 ], i[ 2 ] );
         od;
         


### PR DESCRIPTION
This should prevent that one forgets to set the caching to crisp when using `IsIdenticalObj` for `IsEqualForObjects`. The warning can be suppressed by passing the option `SuppressCacheWarning := true` to `AddIsEqualForObjects`.