### PR TITLE
Add identifiers to cells which record how the cell was created

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -29,6 +29,8 @@ DeclareGlobalVariable( "CAP_INTERNAL" );
 
 DeclareGlobalFunction( "CAP_INTERNAL_NAME_COUNTER" );
 
+DeclareGlobalFunction( "CAP_INTERNAL_IDENTIFIER_COUNTER" );
+
 DeclareGlobalFunction( "CATEGORIES_CACHE_GETTER" );
 
 DeclareGlobalFunction( "GET_METHOD_CACHE" );

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -32,6 +32,7 @@ InstallTrueMethod( IsPreAbelianCategory, IsAbelianCategory );
 InstallValue( CAP_INTERNAL,
               rec(
                    name_counter := 0,
+                   identifier_counter := 0,
                    default_cache_type := "weak",
               )
 );
@@ -45,6 +46,20 @@ InstallGlobalFunction( CAP_INTERNAL_NAME_COUNTER,
     counter := CAP_INTERNAL.name_counter + 1;
     
     CAP_INTERNAL.name_counter := counter;
+    
+    return counter;
+    
+end );
+
+##
+InstallGlobalFunction( CAP_INTERNAL_IDENTIFIER_COUNTER,
+                       
+  function( )
+    local counter;
+    
+    counter := CAP_INTERNAL.identifier_counter + 1;
+    
+    CAP_INTERNAL.identifier_counter := counter;
     
     return counter;
     

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -392,7 +392,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                             new_filter_list,
                             
               function( arg )
-                local redirect_return, filter, human_readable_identifier_getter, pre_func_return, result, i, j;
+                local redirect_return, filter, human_readable_identifier_getter, pre_func_return, result, identifiers, i, j;
                 
                 if (redirect_function <> false) and (not IsBound( category!.redirects.( function_name ) ) or category!.redirects.( function_name ) <> false) then
                     redirect_return := CallFuncList( redirect_function, Concatenation( [ category ], arg ) );
@@ -435,6 +435,19 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     elif category!.output_sanity_check_level > 0 then
                         output_sanity_check_function( result );
                     fi;
+                fi;
+
+                if category!.output_sanity_check_level > 0 and IsCapCategoryCell( result ) and not IsBound( result!.identifier ) then
+                    identifiers := [];
+                    for i in [ 1 .. Length( argument_list) ] do
+                        if IsCapCategoryCell( arg[ argument_list[ i ] ] ) and IsBound( arg[ argument_list[ i ] ]!.identifier ) then
+                            identifiers[i] := arg[ argument_list[ i ] ]!.identifier;
+                        else
+                            identifiers[i] := Concatenation( "cell_", String( CAP_INTERNAL_NAME_COUNTER( ) ) );
+                        fi;
+                    od;
+
+                    result!.identifier := Concatenation( install_name, "( ", JoinStringsWithSeparator( identifiers, ", " ), " )" );
                 fi;
                 
                 if post_function <> false then


### PR DESCRIPTION
When debugging I often have the problem that at some point in the computation, e.g. in a break-loop somewhere in the code, I get a "wrong" object/morphism but do not know how this object/morphism was created (it might have been created by going through lots of derivations for example). This PR tries to add an identifier to category cells, which records how the cell was created. Example:
```
LoadPackage( "ModulePresentationsForCAP" );
QQ := HomalgFieldOfRationals();
o := ZeroObject( QQ );
o!.identifier := "0";
id := IdentityMorphism( o );
iota := KernelEmbedding( id );
```
Then `iota!.identifier` is `KernelEmbedding( IdentityMorphism( 0 ) )`.

The current state is just the most simple demo and does not even handle lists etc.

If you think this might be a useful addition to CAP, my plan would be to provide a PR which handles the most basic things (like lists etc.), and then expand on this in the future when I'm debugging and need more features.