### PR TITLE
Ensure that (co)action category of a non-computable category is non-computable

### DIFF
--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -572,6 +572,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
         AddIsEqualForMorphisms( category, IsIdenticalObj );
         
         ## cannot AddIsCongruentForMorphisms
+        category!.is_computable := false;
         
     fi;
     

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -573,6 +573,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
         AddIsEqualForMorphisms( category, IsIdenticalObj );
         
         ## cannot AddIsCongruentForMorphisms
+        category!.is_computable := false;
         
     fi;
     


### PR DESCRIPTION
Without this the derivation mechanism adds `IsCongruentForMorphisms`.