### PR TITLE
Adding two new categorical methods BasisOfExternalHom and CoefficientsOfMorphismWithGivenBasisOfExternalHom for k-linear categories.

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -15,7 +15,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2019.08.10", ## Fabian's version
   ## this line prevents merge conflicts
-  "2019.12.01", ## Kamal's version
+  "2020.01.10", ## Kamal's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -2003,10 +2003,11 @@ DeclareOperation( "HomStructure",
 
 
 #! @Description
-#! The arguments are object  $a,b$ in a pre-additive or $k$-linear category $C$.
-#! The output is a list $L$ of morphisms which is a basis of $\mathrm{Hom}_{C}(a,b)$ in the sense
-#! that any given morphism $\alpha: a \to b$ is the linear combination of $L$ with the
-#! coefficients in <C>CoefficientsOfMorphismWRTBasisOfExternalHom</C>($\alpha$).
+#! The arguments are objects $a,b$ in a $k$-linear category $C$.
+#! The output is a list $L$ of morphisms which is a basis of $\mathrm{Hom}_{C}(a,b)$ in
+#! the sense that any given morphism $\alpha: a \to b$ can uniquely be written as a
+#! linear combination of $L$ with the coefficients in
+#! <C>CoefficientsOfMorphismWithGivenBasisOfExternalHom</C>($\alpha,L$).
 #! @Returns a list of morphisms in $\mathrm{Hom}_{C}(a,b)$
 #! @Arguments a, b
 DeclareOperation( "BasisOfExternalHom",
@@ -2031,31 +2032,42 @@ DeclareOperation( "AddBasisOfExternalHom",
                   [ IsCapCategory, IsList ] );
 
 #! @Description
-#! The argument is a morhpism  $\alpha: a \to b$ in a pre-additive or $k$-linear category $C$.
-#! The output is a list of coefficients of $\alpha$ with respect to the list
-#! <C>BasisOfExternalHom</C>(<A>a</A>,<A>b</A>).
-#! @Returns a list of ring elements
-#! @Arguments alpha
-DeclareAttribute( "CoefficientsOfMorphismWRTBasisOfExternalHom",
-                  IsCapCategoryMorphism );
+#! The arguments are a morphism  $\alpha: a \to b$ in a $k$-linear category $C$ and
+#! a list <A>L</A><C>=BasisOfExternalHom</C>($a,b$).
+#! The output is a list of coefficients of $\alpha$ with respect to $L$.
+#! @Returns a list of elements in $k$
+#! @Arguments alpha, L
+DeclareOperation( "CoefficientsOfMorphismWithGivenBasisOfExternalHom",
+                  [ IsCapCategoryMorphism, IsList ] );
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
-#! to the category for the basic operation <C>CoefficientsOfMorphismWRTBasisOfExternalHom</C>.
+#! to the category for the basic operation <C>CoefficientsOfMorphismWithGivenBasisOfExternalHom</C>.
 #! @Returns nothing
 #! @Arguments C, F
-DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
                   [ IsCapCategory, IsFunction ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
                   [ IsCapCategory, IsFunction, IsInt ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
                   [ IsCapCategory, IsList, IsInt ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
                   [ IsCapCategory, IsList ] );
+
+#! @Description
+#! This is a convenience method.
+#! The argument is a morphism  $\alpha: a \to b$ in a $k$-linear category $C$.
+#! The output is a list of coefficients of $\alpha$ with respect to the list
+#! <C>BasisOfExternalHom</C>(<A>a</A>,<A>b</A>).
+#! @Returns a list of elements in $k$
+#! @Arguments alpha
+DeclareAttribute( "CoefficientsOfMorphism",
+                  IsCapCategoryMorphism );
+
 
 ###################################
 ##

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -2002,6 +2002,61 @@ DeclareOperation( "HomStructure",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
 
+#! @Description
+#! The arguments are object  $a,b$ in a pre-additive or $k$-linear category $C$.
+#! The output is a list $L$ of morphisms which is a basis of $\mathrm{Hom}_{C}(a,b)$ in the sense
+#! that any given morphism $\alpha: a \to b$ is the linear combination of $L$ with the
+#! coefficients in <C>CoefficientsOfMorphismWRTBasisOfExternalHom</C>($\alpha$).
+#! @Returns a list of morphisms in $\mathrm{Hom}_{C}(a,b)$
+#! @Arguments a, b
+DeclareOperation( "BasisOfExternalHom",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>BasisOfExternalHom</C>.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddBasisOfExternalHom",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddBasisOfExternalHom",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddBasisOfExternalHom",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddBasisOfExternalHom",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The argument is a morhpism  $\alpha: a \to b$ in a pre-additive or $k$-linear category $C$.
+#! The output is a list of coefficients of $\alpha$ with respect to the list
+#! <C>BasisOfExternalHom</C>(<A>a</A>,<A>b</A>).
+#! @Returns a list of ring elements
+#! @Arguments alpha
+DeclareAttribute( "CoefficientsOfMorphismWRTBasisOfExternalHom",
+                  IsCapCategoryMorphism );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation <C>CoefficientsOfMorphismWRTBasisOfExternalHom</C>.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoefficientsOfMorphismWRTBasisOfExternalHom",
+                  [ IsCapCategory, IsList ] );
+
 ###################################
 ##
 #! @Section Simplified Morphisms

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -317,6 +317,17 @@ InstallMethod( Simplify,
     
 end );
 
+
+##
+InstallMethod( CoefficientsOfMorphism,
+              [ IsCapCategoryMorphism ],
+  function( alpha )
+    
+    return CoefficientsOfMorphismWithGivenBasisOfExternalHom( alpha, BasisOfExternalHom( Source( alpha ), Range( alpha ) ) );
+    
+end );
+
+
 ######################################
 ##
 ## Morphism equality functions

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -3329,3 +3329,97 @@ AddFinalDerivation( IsEqualForCacheForMorphisms,
                     [ IsEqualForMorphisms ],
                     
   IsIdenticalObj : Description := "Use IsIdenticalObj for IsEqualForCacheForMorphisms" );
+
+## Final methods for BasisOfExternalHom & CoefficientsOfMorphism
+
+##
+AddFinalDerivation( BasisOfExternalHom,
+                    [
+                      [ HomomorphismStructureOnObjects ],
+                      [ HomomorphismStructureOnMorphismsWithGivenObjects ],
+                      [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism ],
+                      [ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure ],
+                      [ DistinguishedObjectOfHomomorphismStructure ],
+                      [ MultiplyWithElementOfCommutativeRingForMorphisms ]
+                    ],
+                    [
+                      BasisOfExternalHom,
+                      CoefficientsOfMorphismWithGivenBasisOfExternalHom
+                    ],
+  function( a, b )
+    local hom_a_b, D, B;
+    
+    hom_a_b := HomomorphismStructureOnObjects( a, b );
+    
+    D := DistinguishedObjectOfHomomorphismStructure( CapCategory( a ) );
+    
+    B := ValueGlobal( "BasisOfExternalHom" )( D, hom_a_b );
+    
+    return List( B, m -> InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( a, b, m ) );
+  
+  end,
+[
+  CoefficientsOfMorphismWithGivenBasisOfExternalHom,
+  function( alpha, L )
+    local beta;
+        
+    beta := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( alpha );
+    
+    return CoefficientsOfMorphism( beta );
+    
+  end
+] : ConditionsListComplete := true,
+  CategoryFilter :=
+    function( category )
+      local range_cat, required_methods;
+      
+      if not ( HasIsLinearCategoryOverCommutativeRing( category ) and IsLinearCategoryOverCommutativeRing( category ) ) then
+        
+        return false;
+        
+      fi;
+      
+      if not HasRangeCategoryOfHomomorphismStructure( category ) then
+        
+        return false;
+        
+      fi;
+      
+      range_cat := RangeCategoryOfHomomorphismStructure( category );
+      
+      if IsIdenticalObj( category, range_cat ) then
+        
+        return false;
+        
+      fi;
+      
+      if not ( HasIsLinearCategoryOverCommutativeRing( range_cat ) and IsLinearCategoryOverCommutativeRing( range_cat ) ) then
+        
+        return false;
+        
+      fi;
+      
+      if not IsIdenticalObj( CommutativeRingOfLinearCategory( category ), CommutativeRingOfLinearCategory( range_cat ) ) then
+        
+        return false;
+        
+      fi;
+      
+      required_methods := [
+                            "BasisOfExternalHom",
+                            "CoefficientsOfMorphismWithGivenBasisOfExternalHom",
+                            "MultiplyWithElementOfCommutativeRingForMorphisms"
+                          ];
+      
+      if not ForAll( required_methods, m -> CanCompute( range_cat, m ) ) then
+        
+        return false;
+        
+      fi;
+      
+      return true;
+      
+  end,
+  Description := "Adding BasisOfExternalHom using homomorphism structure"
+);
+

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3114,10 +3114,10 @@ BasisOfExternalHom := rec(
   dual_postprocessor_func := IdFunc
 ),
 
-CoefficientsOfMorphismWRTBasisOfExternalHom := rec(
-  installation_name := "CoefficientsOfMorphismWRTBasisOfExternalHom",
-  filter_list := [ "morphism" ],
-  return_type := "morphism",
+CoefficientsOfMorphismWithGivenBasisOfExternalHom := rec(
+  installation_name := "CoefficientsOfMorphismWithGivenBasisOfExternalHom",
+  filter_list := [ "morphism", IsList ],
+  return_type := IsList,
   ## TODO: add support for dual_*
 ),
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3105,6 +3105,22 @@ MereExistenceOfSolutionOfLinearSystemInAbCategory := rec(
   return_type := "bool"
 ),
 
+BasisOfExternalHom := rec(
+  installation_name := "BasisOfExternalHom",
+  filter_list := [ "object", "object" ],
+  return_type := IsList,
+  dual_operation := "BasisOfExternalHom",
+  dual_arguments_reversed := true,
+  dual_postprocessor_func := IdFunc
+),
+
+CoefficientsOfMorphismWRTBasisOfExternalHom := rec(
+  installation_name := "CoefficientsOfMorphismWRTBasisOfExternalHom",
+  filter_list := [ "morphism" ],
+  return_type := "morphism",
+  ## TODO: add support for dual_*
+),
+
 RandomObjectByInteger := rec(
   installation_name := "RandomObjectByInteger",
   filter_list := [ "category", IsInt ],

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -20,6 +20,9 @@ Version := Maximum( [
   "2018.10.11", ## Sepp's version
   ## this line prevents merge conflicts
   "2019.08.07", ## Fabian's version
+  ## this line prevents merge conflicts
+  "2020.01.10", ## Kamal's version
+
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -96,7 +99,7 @@ Dependencies := rec(
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
                            [ "ToolsForHomalg", ">=2015.09.18" ],
                            [ "MatricesForHomalg", ">= 2019.02.01" ],
-                           [ "CAP", ">= 2019.01.16" ],
+                           [ "CAP", ">= 2020.01.10" ],
                            [ "MonoidalCategories", ">= 2019.01.16" ],
                            ],
   SuggestedOtherPackages := [ ],

--- a/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
+++ b/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
@@ -1,0 +1,172 @@
+
+BindGlobal( "CATEGORY_FILTER_CHECKER",
+  function( cat )
+    local k;
+    
+    # if the category is matrix category of some homalg field then do nothing
+    if IsBound( cat!.field_for_matrix_category ) then
+      
+      return false;
+      
+    fi;
+    
+    if not ( HasIsLinearCategoryOverCommutativeRing( cat ) and IsLinearCategoryOverCommutativeRing( cat ) ) then
+      
+      return false;
+      
+    fi;
+    
+    k := CommutativeRingOfLinearCategory( cat );
+    
+    if not ( HasIsFieldForHomalg( k ) and IsFieldForHomalg( k ) ) then
+      
+      return false;
+      
+    fi;
+    
+    if HasRangeCategoryOfHomomorphismStructure( cat ) and
+        not IsIdenticalObj( RangeCategoryOfHomomorphismStructure( cat ), MatrixCategory( k ) ) then
+      
+      return false;
+      
+    fi;
+    
+    return true;
+    
+end );
+
+##
+AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
+                    [
+                      [ BasisOfExternalHom, 1 ],
+                      [ CoefficientsOfMorphismWithGivenBasisOfExternalHom, 1 ],
+                      [ MultiplyWithElementOfCommutativeRingForMorphisms, 1 ]
+                    ],
+                    [
+                      HomomorphismStructureOnObjects,
+                      HomomorphismStructureOnMorphismsWithGivenObjects,
+                      DistinguishedObjectOfHomomorphismStructure,
+                      InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure,
+                      InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism
+                    ],
+  
+  function( cat )
+    local k;
+    
+    k := CommutativeRingOfLinearCategory( cat );
+    
+    return VectorSpaceObject( 1, k );
+    
+  end,
+[
+  HomomorphismStructureOnObjects,
+  function( a, b )
+    local cat, k, dimension;
+    
+    cat := CapCategory( a );
+    
+    k := CommutativeRingOfLinearCategory( cat );
+    
+    dimension := Length( BasisOfExternalHom( a, b ) );
+    
+    return VectorSpaceObject( dimension, k );
+    
+  end
+],
+[
+  HomomorphismStructureOnMorphismsWithGivenObjects,
+    
+    #          alpha
+    #      a --------> a'     s = H(a',b) ---??--> r = H(a,b')
+    #      |           |
+    # alpha.h.beta     h
+    #      |           |
+    #      v           v
+    #      b' <------- b
+    #          beta
+    
+  function( hom_source, alpha, beta, hom_range )
+    local cat, k, dim_hom_source, dim_hom_range, B, mat;
+    
+    cat := CapCategory( alpha );
+    
+    k := CommutativeRingOfLinearCategory( cat );
+    
+    dim_hom_source := Dimension( hom_source );
+    
+    dim_hom_range := Dimension( hom_range );
+    
+    if dim_hom_source * dim_hom_range = 0 then
+      
+      return ValueGlobal( "ZeroMorphism" )( hom_source, hom_range ); # sanity checks for final derivations
+                                                                     # thinks this ZeroMorphism is being used in cat;
+    fi;                                                              # hence, insists that it should be in the list of required
+                                                                     # primitive methods.
+    B := BasisOfExternalHom( Range( alpha ), Source( beta ) );
+    
+    B := List( B, b -> PreCompose( [ alpha, b, beta ] ) );
+    
+    B := List( B, CoefficientsOfMorphism );
+    
+    mat := HomalgMatrix( B, dim_hom_source, dim_hom_range, k );
+    
+    return VectorSpaceMorphism( hom_source, mat, hom_range );
+    
+  end
+],
+[
+  InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure,
+  function( alpha )
+    local cat, k, coeff, D;
+    
+    cat := CapCategory( alpha );
+    
+    k := CommutativeRingOfLinearCategory( cat );
+    
+    coeff := CoefficientsOfMorphism( alpha );
+    
+    coeff := HomalgMatrix( coeff, 1, Size( coeff ), k );
+    
+    D := VectorSpaceObject( 1, k );
+    
+    return VectorSpaceMorphism( D, coeff, VectorSpaceObject( NrCols( coeff ), k ) );
+    
+  end
+],
+[
+  InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism,
+  function( a, b, iota )
+    local mat, coeff, B, L;
+    
+    mat := UnderlyingMatrix( iota );
+    
+    coeff := EntriesOfHomalgMatrix( mat );
+    
+    B := BasisOfExternalHom( a, b );
+    
+    L := List( [ 1 .. Length( coeff ) ],
+      i -> MultiplyWithElementOfCommutativeRingForMorphisms( coeff[ i ], B[ i ] ) );
+      
+    if L = [  ] then
+      
+      return ZeroMorphism( a, b );
+      
+    else
+      
+      return Sum( L );
+      
+    fi;
+    
+  end
+] : ConditionsListComplete := true,
+  FunctionCalledBeforeInstallation :=
+    function( cat )
+      local matrix_cat;
+      matrix_cat := MatrixCategory( CommutativeRingOfLinearCategory( cat ) );
+      SetRangeCategoryOfHomomorphismStructure( cat, matrix_cat );
+      return;
+    end,
+  CategoryFilter := CATEGORY_FILTER_CHECKER,
+  Description := "Adding homomorphism structure using external hom methods"
+);
+

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -907,6 +907,31 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     ##
     AddIsInjective( category, ReturnTrue );
    
+    ##
+    AddBasisOfExternalHom( category,
+      function( object_1, object_2 )
+        local dim_1, dim_2, identity, matrices;
+        
+        dim_1 := Dimension( object_1 );
+        
+        dim_2 := Dimension( object_2 );
+        
+        identity := IdentityMat( dim_1 * dim_2 );
+        
+        matrices := List( identity, row -> HomalgMatrix( row, dim_1, dim_2, homalg_field ) );
+        
+        return List( matrices, mat -> VectorSpaceMorphism( object_1, mat, object_2 ) );
+        
+    end );
+    
+    ##
+    AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( category,
+      function( morphism, L )
+        
+        return EntriesOfHomalgMatrix( UnderlyingMatrix( morphism ) );
+        
+    end );
+
 end );
 
 

--- a/LinearAlgebraForCAP/read.g
+++ b/LinearAlgebraForCAP/read.g
@@ -8,3 +8,5 @@ ReadPackage( "LinearAlgebraForCAP", "gap/LinearAlgebraForCAP.gi" );
 ReadPackage( "LinearAlgebraForCAP", "gap/MatrixCategoryObject.gi" );
 
 ReadPackage( "LinearAlgebraForCAP", "gap/MatrixCategoryMorphism.gi" );
+
+ReadPackage( "LinearAlgebraForCAP", "gap/DerivedMethodsForMatrixCategories.gi" );


### PR DESCRIPTION
Hallo @sebastianpos  :)

Main use of them:
1- We can now work with external hom
2- We can use them to derive homomorphism strucutre in certain cases, for example if k is a field.

This PR contains:
* Declaration & documentation of the above methods.
* Adding these operations to the category of matrices.
* Adding final derivation to derived homomorphism-structure in certain cases.
* Adding final derivation to derive the above methods from homomorphism-structure in certain cases.

I created this as a draft in case it needs some adjustments.
