### PR TITLE
Call func before installation of a derived method

### DIFF
--- a/CAP/gap/Derivations.gd
+++ b/CAP/gap/Derivations.gd
@@ -156,6 +156,12 @@ DeclareOperation( "InstallDerivationForCategory",
 DeclareOperation( "DerivationResultWeight",
                   [ IsDerivedMethod, IsDenseList ] );
 
+#! @Description
+#! Input is a derived method. Output is a unary function that takes as an input
+#! a category and does not output anything. This function is always called before
+#! the installation of the derived method for a concrete instance of a category.
+#! @Arguments d
+DeclareAttribute( "FunctionCalledBeforeInstallation", IsDerivedMethod );
 
 ####################################
 ##

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -98,7 +98,8 @@ InstallMethod( InstallDerivationForCategory,
                [ IsDerivedMethod, IsPosInt, IsCapCategory ],
 function( d, weight, C )
   local method_name, implementation_list, add_method, add_name, general_filter_list,
-        installation_name, nr_arguments, cache_name, current_filters, current_implementation;
+        installation_name, nr_arguments, cache_name, current_filters, current_implementation,
+        function_called_before_installation;
   
   Info( DerivationInfo, 1, Concatenation( "install(",
                                           String( weight ),
@@ -140,6 +141,11 @@ function( d, weight, C )
 #       fi;
 #       
 #   else
+      if HasFunctionCalledBeforeInstallation( d ) then
+          
+          FunctionCalledBeforeInstallation( d )( C );
+          
+      fi;
       
       add_method := ValueGlobal( add_name );
       add_method( C, implementation_list, 1 : SetPrimitive := false, IsDerivation := true ); ##The third argument is ignored
@@ -268,13 +274,14 @@ InstallMethod( AddDerivation,
             implementations_with_extra_filters )
     local weight, category_filter, description, derivation, collected_list,
           operations_in_graph, current_list, current_implementation, loop_multiplier,
-          preconditions_complete;
+          preconditions_complete, function_called_before_installation;
     
     weight := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "Weight", 1 );
     category_filter := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "CategoryFilter", IsCapCategory );
     description := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "Description", "" );
     loop_multiplier := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "WeightLoopMultiple", 2 );
     preconditions_complete := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "ConditionsListComplete", false );
+    function_called_before_installation := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FunctionCalledBeforeInstallation", false );
     
     ## get used ops
     ## Is this the right place? Or should this only be done when no ops are given?
@@ -300,6 +307,12 @@ InstallMethod( AddDerivation,
                                   weight,
                                   implementations_with_extra_filters,
                                   category_filter );
+    
+    if function_called_before_installation <> false then
+        
+        SetFunctionCalledBeforeInstallation( derivation, function_called_before_installation );
+        
+    fi;
     
     ## This sanity check should be obsolete
     # CAP_INTERNAL_DERIVATION_SANITY_CHECK( graph, derivation );

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -58,7 +58,7 @@ InstallGlobalFunction( AddFinalDerivation,
                
   function( name, can, cannot, func_list, additional_functions... )
     local final_derivation, loop_multiplier, collected_list, current_implementation, current_list,
-          operations_in_graph, used_ops_with_multiples, preconditions_complete, i, current_additional_func;
+          operations_in_graph, used_ops_with_multiples, preconditions_complete, i, current_additional_func, function_called_before_installation;
 
     if IsFunction( func_list ) then
         func_list := [ [ func_list, [] ] ];
@@ -71,6 +71,7 @@ InstallGlobalFunction( AddFinalDerivation,
     final_derivation.category_filter := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "CategoryFilter", IsCapCategory );
     loop_multiplier := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "WeightLoopMultiple", 2 );
     preconditions_complete := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "ConditionsListComplete", false );
+    function_called_before_installation := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FunctionCalledBeforeInstallation", false );
     
     for i in [ 1 .. Length( additional_functions ) ] do
         if IsFunction( additional_functions[ i ][ 2 ] ) then
@@ -112,6 +113,7 @@ InstallGlobalFunction( AddFinalDerivation,
     final_derivation.name := name;
     final_derivation.cannot_compute := cannot;
     final_derivation.function_list := func_list;
+    final_derivation.function_called_before_installation := function_called_before_installation;
     
     CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK( final_derivation );
     
@@ -185,6 +187,14 @@ InstallMethod( IsFinalized,
                                           NameFunction( current_final_derivation.name ),
                                           ": ",
                                           current_final_derivation.description, "\n" ) );
+            
+            ## call function before adding the method
+            
+            if current_final_derivation.function_called_before_installation <> false then
+                
+                current_final_derivation.function_called_before_installation( category );
+                
+            fi;
             
             ## Add method
             add_name := ValueGlobal( Concatenation( [ "Add", NameFunction( current_final_derivation.name ) ] ) );


### PR DESCRIPTION
@kamalsaleh 
This is the mechanism that should resolve the problem addressed in #457 concerning `SetRangeCategoryOfHomomorphismStructure`.
Please try if it works in your context. If yes, I can merge this PR.

To provide a function that is called before the installation of a derived method, simply put
`FunctionCalledBeforeInstallation := my_func( cat )`
in the options of `AddDerivationToCAP`.
Note that the function is assumed to be unary and expects a category as an input.