### PR TITLE
Fix bug

### DIFF
--- a/FreydCategoriesForCAP/gap/LinearClosure.gd
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gd
@@ -41,8 +41,8 @@ DeclareOperation( "LinearClosure",
 DeclareOperation( "LinearClosureObject",
                   [ IsCapCategory, IsLinearClosure ] );
 
-KeyDependentOperation( "LinearClosureObject",
-                       IsLinearClosure, IsCapCategoryObject, ReturnTrue );
+DeclareOperation( "LinearClosureObject",
+                  [ IsLinearClosure, IsCapCategoryObject ] );
 
 DeclareOperation( "LinearClosureMorphism",
                   [ IsLinearClosureObject, IsList, IsList, IsLinearClosureObject ] );

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -68,7 +68,7 @@ InstallMethod( LinearClosure,
 end );
 
 ##
-InstallMethod( LinearClosureObjectOp,
+InstallMethod( LinearClosureObject,
                [ IsLinearClosure, IsCapCategoryObject ],
                
   function( category, object )


### PR DESCRIPTION
KeyDependentOperation uses < for its caching and thus must not be used.
Closes #462