### PR TITLE
Revert "Do not upload code coverage information when testing with gap-master"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           cd CAP_project
           echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           TERM=dumb make ci-test
-          [ "$GAP_HOME" != "/home/gap/inst/gap-master" ] && bash <(curl -s https://codecov.io/bash) || true
+          bash <(curl -s https://codecov.io/bash)
 workflows:
   version: 2
   commit:


### PR DESCRIPTION
Reverts homalg-project/CAP_project#387

Now that GAP 4.11 is released this workaround is no longer necessary.