### PR TITLE
declared IsHomSetInhabited

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2019.09.15", ## Mohamed's version
+  "2020.02.16", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1736,6 +1736,40 @@ DeclareOperation( "TransportHom",
 
 ###################################
 ##
+#! @Section IsHomSetInhabited
+##
+###################################
+
+#! @Description
+#!  The argument are two objects <A>A</A> and <A>B</A>.
+#!  The output is <C>true</C> if there exists a morphism from <A>A</A> to <A>B</A>,
+#!  otherwise the output is <C>false</C>.
+#! @Arguments A, B
+#! @Returns a boolean
+DeclareOperation( "IsHomSetInhabited",
+        [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#!  The arguments are a category $C$ and a function $F$.
+#!  This operation adds the given function $F$
+#!  to the category for the basic operation <C>IsHomSetInhabited</C>.
+#!  $F: A, B \mapsto \mathrm{IsHomSetInhabited}(A, B)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsHomSetInhabited",
+        [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsHomSetInhabited",
+        [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsHomSetInhabited",
+        [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsHomSetInhabited",
+        [ IsCapCategory, IsList ] );
+
+###################################
+##
 #! @Section Homomorphism structures
 ##
 ###################################

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1741,7 +1741,7 @@ DeclareOperation( "TransportHom",
 ###################################
 
 #! @Description
-#!  The argument are two objects <A>A</A> and <A>B</A>.
+#!  The arguments are two objects <A>A</A> and <A>B</A>.
 #!  The output is <C>true</C> if there exists a morphism from <A>A</A> to <A>B</A>,
 #!  otherwise the output is <C>false</C>.
 #! @Arguments A, B

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3160,8 +3160,7 @@ MorphismBetweenDirectSums := rec(
 IsHomSetInhabited := rec(
   installation_name := "IsHomSetInhabited",
   filter_list := [ "object", "object" ],
-  return_type := "bool",
-  is_merely_set_theoretic := true ),
+  return_type := "bool" ),
 
 HomomorphismStructureOnObjects := rec(
   installation_name := "HomomorphismStructureOnObjects",

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3157,6 +3157,12 @@ MorphismBetweenDirectSums := rec(
   end
 ),
 
+IsHomSetInhabited := rec(
+  installation_name := "IsHomSetInhabited",
+  filter_list := [ "object", "object" ],
+  return_type := "bool",
+  is_merely_set_theoretic := true ),
+
 HomomorphismStructureOnObjects := rec(
   installation_name := "HomomorphismStructureOnObjects",
   filter_list := [ "object", "object" ],


### PR DESCRIPTION
moving IsHomSetInhabited to CAP reduces unnecessary interdependencies
between further CAP-based packages