### PR TITLE
added convenience operation/methods InternalHom

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
 Version := Maximum( [
-  "2019.01.17", ## Mohamed's version
+  "2020.03.01", ## Mohamed's version
   ## this line prevents merge conflicts
   "2019.06.07", ## Sebas' version
   ## this line prevents merge conflicts

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gd
@@ -797,6 +797,7 @@ DeclareOperation( "AddIsomorphismFromInternalHomToObjectWithGivenInternalHom",
 
 ##
 #! @Description
+#! This is a convenience method.
 #! The arguments are two cells $a,b$.
 #! The output is the internal hom cell .
 #! If $a,b$ are two CAP objects the output is the internal Hom object

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gd
@@ -799,7 +799,7 @@ DeclareOperation( "AddIsomorphismFromInternalHomToObjectWithGivenInternalHom",
 #! @Description
 #! This is a convenience method.
 #! The arguments are two cells $a,b$.
-#! The output is the internal hom cell .
+#! The output is the internal hom cell.
 #! If $a,b$ are two CAP objects the output is the internal Hom object
 #! $\mathrm{\underline{Hom}}(a,b)$.
 #! If at least on of the arguments is a CAP morphism the output is a CAP morphism,

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gd
@@ -788,3 +788,22 @@ DeclareOperation( "AddIsomorphismFromInternalHomToObjectWithGivenInternalHom",
 
 DeclareOperation( "AddIsomorphismFromInternalHomToObjectWithGivenInternalHom",
                   [ IsCapCategory, IsList ] );
+
+####################################
+##
+#! @Section Convenience Methods
+##
+####################################
+
+##
+#! @Description
+#! The arguments are two cells $a,b$.
+#! The output is the internal hom cell .
+#! If $a,b$ are two CAP objects the output is the internal Hom object
+#! $\mathrm{\underline{Hom}}(a,b)$.
+#! If at least on of the arguments is a CAP morphism the output is a CAP morphism,
+#! namely the internal Hom on morphisms, where any object is replaced by its identity morphism.
+#! @Returns a cell
+#! @Arguments a, b
+DeclareOperation( "InternalHom",
+                  [ IsCapCategoryCell, IsCapCategoryCell ] );

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gi
@@ -262,3 +262,39 @@ InstallMethod( IsomorphismFromObjectToInternalHom,
 end );
 
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD( CAP_INTERNAL_CLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS );
+
+####################################
+# Convenience Methods
+####################################
+
+##
+InstallMethod( InternalHom,
+        [ IsCapCategoryObject, IsCapCategoryObject ],
+        
+  InternalHomOnObjects );
+
+##
+InstallMethod( InternalHom,
+        [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+        
+  InternalHomOnMorphisms );
+
+##
+InstallMethod( InternalHom,
+        [ IsCapCategoryObject, IsCapCategoryMorphism ],
+        
+  function( a, beta )
+    
+    return InternalHomOnMorphisms( IdentityMorphism( a ), beta );
+    
+end );
+
+##
+InstallMethod( InternalHom,
+        [ IsCapCategoryMorphism, IsCapCategoryObject ],
+        
+  function( alpha, b )
+    
+    return InternalHomOnMorphisms( alpha, IdentityMorphism( b ) );
+    
+end );


### PR DESCRIPTION
The new convenience operation `InternalHom` accepts two CAP cells
as arguments and invokes either `InternalHomOnObjects` if the arguments
are two objects and `InternalHomOnMorphisms` otherwise. If in the latter case
one of the arguments is an object, it is replaced by its identity morphism.