### PR TITLE
Bug fix by adjusting the morphism constructor in product categories and add convenience methods

### DIFF
--- a/CAP/gap/ProductCategory.gd
+++ b/CAP/gap/ProductCategory.gd
@@ -61,6 +61,9 @@ DeclareOperation( "ProductOp_OnObjects",
 DeclareOperation( "ProductOp_OnTwoCells",
                   [ IsList, IsCapCategory ] );
 
+DeclareOperation( "\/",
+                  [ IsList, IsCapProductCategory ] );
+
 DeclareOperation( "ProductOp",
                   [ IsList, IsCapCategoryCell ] );
 

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -286,6 +286,31 @@ InstallMethod( ProductOp,
 end );
 
 ##
+InstallMethod( \/,
+          [ IsList, IsCapProductCategory ],
+  function( list, category )
+
+    if IsCapCategoryObject( list[ 1 ] ) then
+
+      return ProductOp_OnObjects( list, category );
+
+    elif IsCapCategoryMorphism( list[ 1 ] ) then
+
+      return ProductOp_OnMorphisms( list, category );
+
+    elif IsCapCategoryTwoCell( list[ 1 ] ) then
+
+      return ProductOp_OnTwoCells( list, category );
+
+    else
+
+      Error( "Wrong input!\n" );
+
+    fi;
+
+end );
+
+##
 InstallMethod( ProductOp,
                [ IsList, IsCapCategoryMorphism ],
                

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -210,7 +210,7 @@ InstallMethodWithCrispCache( ProductOp,
     
     return product_category;
     
-end : ArgumentNumber := 2 );
+end );
 
 ##
 InstallMethodWithCacheFromObject( ProductOp_OnObjects,

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -175,7 +175,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_PRODUCT_ADDS_FROM_CATEGORY",
 end );
 
 ##
-InstallMethodWithCacheFromObject( ProductOp,
+InstallMethodWithCrispCache( ProductOp,
                                   [ IsList, IsCapCategory ],
                         
   function( category_list, selector )


### PR DESCRIPTION
```
LoadPackage( "LinearAlgebraForCAP" );
LoadPackage( "RingsForHomalg" );
field := HomalgFieldOfRationals( );
mat_1 := MatrixCategory( field );
mat_2 := MatrixCategory( field );
SetCachingOfCategory( mat_1, "none" );
SetCachingOfCategory( mat_2, "none" );
IsIdenticalObj( Product( mat_1, mat_2 ), Product( mat_1, mat_2 ) );
#! false
```
This leads to the following error:

```
P := Product( mat_1, mat_2 );
#! Product of: Category of matrices over Q, Category of matrices over Q
ProductOp_OnMorphisms( [ ZeroObjectFunctorial(mat_1), ZeroObjectFunctorial(mat_2) ], P );
    Error, an object that lies in the CAP-category with the name
    Product of: Category of matrices over Q, Category of matrices over Q
   was tried to be added to a different CAP-category with the name
   Product of: Category of matrices over Q, Category of matrices over Q
```
This PR computes the source and range so that they lies in P and then sets them.