### PR TITLE
Relations and Linear closure

### DIFF
--- a/FreydCategoriesForCAP/examples/Relations.g
+++ b/FreydCategoriesForCAP/examples/Relations.g
@@ -1,0 +1,26 @@
+#! @Chapter Examples and Tests
+
+#! @Section Category of relations
+
+LoadPackage( "RingsForHomalg" );;
+LoadPackage( "LinearAlgebraForCAP" );;
+LoadPackage( "FreydCategoriesForCAP" );;
+LoadPackage( "GeneralizedM" );
+
+#! @Example
+F := HomalgRingOfIntegers( 3 );;
+mat := MatrixCategory( F );;
+rel := RelCategory( mat );;
+A := 1/mat/rel;;
+id := IdentityMorphism( A );;
+IsWellDefined( id );
+#! true
+alpha := HomalgMatrix( "[ 1, 2 ]", 2, 1, F )/mat;;
+alpha_rel := alpha/rel;;
+alpha_rel_inv := rel/alpha;;
+beta := PreCompose( alpha_rel_inv, alpha_rel );;
+IsCongruentForMorphisms( beta, id );
+#! true
+IsEqualForMorphisms( beta, id );
+#! false
+#! @EndExample

--- a/FreydCategoriesForCAP/examples/Relations.g
+++ b/FreydCategoriesForCAP/examples/Relations.g
@@ -9,13 +9,13 @@ LoadPackage( "GeneralizedM" );
 
 #! @Example
 F := HomalgRingOfIntegers( 3 );;
-mat := MatrixCategory( F );;
-rel := RelCategory( mat );;
-A := 1/mat/rel;;
+vec := CategoryOfRows( F );;
+rel := RelCategory( vec );;
+A := 1/vec/rel;;
 id := IdentityMorphism( A );;
 IsWellDefined( id );
 #! true
-alpha := HomalgMatrix( "[ 1, 2 ]", 2, 1, F )/mat;;
+alpha := HomalgMatrix( "[ 1, 2 ]", 2, 1, F )/vec;;
 alpha_rel := alpha/rel;;
 alpha_rel_inv := rel/alpha;;
 beta := PreCompose( alpha_rel_inv, alpha_rel );;
@@ -23,4 +23,29 @@ IsCongruentForMorphisms( beta, id );
 #! true
 IsEqualForMorphisms( beta, id );
 #! false
+R := HomalgFieldOfRationalsInSingular() * "t";;
+t := IndeterminatesOfPolynomialRing( R )[1];;
+cocycle := function( a, b, c )
+    local e;
+    
+    e := 
+        CoastrictionToImage(
+            UniversalMorphismIntoDirectSum( ReversedArrow( c ), Arrow( c ) )
+        );
+    
+    return t^RankOfObject( KernelObject( e ) );
+    
+end;;
+T := TwistedLinearClosure( R, rel, cocycle );;
+gamma := beta/T;;
+delta := ZeroMorphism( 1/vec, 1/vec )/rel/T;
+IsZero( 3*gamma - 3*gamma );
+#! true
+IsCongruentForMorphisms( delta, gamma );
+#! false
+beta := PreCompose( alpha_rel_inv/T, alpha_rel/T );;
+IsZero( beta - t * IdentityMorphism( Range( alpha_rel/T ) ) );
+#! true
+IsZero( ( gamma * delta ) * gamma - gamma * ( delta * gamma ) );
+#! true
 #! @EndExample

--- a/FreydCategoriesForCAP/gap/LinearClosure.gd
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gd
@@ -24,6 +24,10 @@ DeclareCategory( "IsLinearClosureMorphism",
 DeclareCategory( "IsLinearClosure",
                  IsCapCategory );
 
+DeclareGlobalFunction( "LINEAR_CLOSURE_CONSTRUCTOR" );
+
+DeclareGlobalFunction( "LINEAR_CLOSURE_MORPHISM_SIMPLIFY" );
+
 DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE" );
 
 ####################################
@@ -32,8 +36,14 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE" );
 ##
 ####################################
 
+DeclareOperation( "TwistedLinearClosure",
+                  [ IsHomalgRing, IsCapCategory, IsFunction, IsFunction ] );
+
+DeclareOperation( "TwistedLinearClosure",
+                  [ IsHomalgRing, IsCapCategory, IsFunction ] );
+
 DeclareOperation( "LinearClosure",
-                  [ IsHomalgRing, IsGroupAsCategory ] );
+                  [ IsHomalgRing, IsCapCategory ] );
 
 DeclareOperation( "LinearClosure",
                   [ IsHomalgRing, IsCapCategory, IsFunction ] );

--- a/FreydCategoriesForCAP/gap/Relations.gd
+++ b/FreydCategoriesForCAP/gap/Relations.gd
@@ -1,0 +1,84 @@
+#############################################################################
+##
+##     FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+##
+##  Copyright 2020, Sebastian Posur, RWTH Aachen
+##
+#! @Chapter Category of relations
+#!
+#############################################################################
+
+####################################
+##
+#! @Section GAP Categories
+##
+####################################
+
+##
+DeclareCategory( "IsRelCategoryObject",
+                 IsCapCategoryObject );
+
+DeclareCategory( "IsRelCategoryMorphism",
+                 IsCapCategoryMorphism );
+
+DeclareCategory( "IsRelCategory",
+                 IsCapCategory );
+
+DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_RELATIONS_CATEGORY" );
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareOperation( "RelCategory",
+                  [ IsCapCategory ] );
+
+DeclareOperation( "RelCategoryObject",
+                  [ IsCapCategoryObject, IsRelCategory ] );
+
+DeclareOperation( "RelCategoryMorphism",
+                  [ IsRelCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsRelCategoryObject ] );
+
+####################################
+##
+#! @Section Attributes
+##
+####################################
+
+DeclareAttribute( "UnderlyingCategory",
+                  IsRelCategory );
+
+DeclareAttribute( "UnderlyingOriginalObject",
+                  IsRelCategoryObject );
+
+DeclareAttribute( "Arrow",
+                  IsRelCategoryMorphism );
+
+DeclareAttribute( "ReversedArrow",
+                  IsRelCategoryMorphism );
+
+DeclareAttribute( "AssociatedSubobject",
+                  IsRelCategoryMorphism );
+
+DeclareAttribute( "PseudoInverse",
+                  IsRelCategoryMorphism );
+
+####################################
+##
+#! @Section Operations
+##
+####################################
+
+##
+DeclareOperation( "\/",
+                  [ IsCapCategoryObject, IsRelCategory ] );
+
+##
+DeclareOperation( "\/",
+                  [ IsCapCategoryMorphism, IsRelCategory ] );
+
+##
+DeclareOperation( "\/",
+                  [ IsRelCategory, IsCapCategoryMorphism ] );

--- a/FreydCategoriesForCAP/gap/Relations.gi
+++ b/FreydCategoriesForCAP/gap/Relations.gi
@@ -1,0 +1,310 @@
+#############################################################################
+##
+##     FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+##
+##  Copyright 2020, Sebastian Posur, RWTH Aachen
+##
+#############################################################################
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallMethod( RelCategory,
+               [ IsCapCategory ],
+               
+  function( underlying_category )
+    local category, is_finite;
+    
+    ## TODO: is underlying_category regular?
+    
+    category := CreateCapCategory( Concatenation( "Rel( ", Name( underlying_category )," )" ) );
+    
+    SetFilterObj( category, IsRelCategory );
+    
+    SetUnderlyingCategory( category, underlying_category );
+    
+    AddObjectRepresentation( category, IsRelCategoryObject );
+    
+    AddMorphismRepresentation( category, IsRelCategoryMorphism );
+    
+    INSTALL_FUNCTIONS_FOR_RELATIONS_CATEGORY( category );
+    
+    Finalize( category );
+    
+    return category;
+    
+end );
+
+##
+InstallMethod( RelCategoryObject,
+               [ IsCapCategoryObject, IsRelCategory ],
+               
+  function( original_object, rel )
+    local object;
+    
+    object := rec( );
+    
+    ObjectifyObjectForCAPWithAttributes( object, rel,
+                                         UnderlyingOriginalObject, original_object
+    );
+    
+    return object;
+    
+end );
+
+##
+InstallMethod( RelCategoryMorphism,
+               [ IsRelCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsRelCategoryObject ],
+               
+  function( source, reversed_arrow, arrow, range ) 
+    local morphism, rel;
+    
+    rel := CapCategory( source );
+    
+    morphism := rec();
+    
+    ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( 
+                             morphism, rel,
+                             source,
+                             range,
+                             Arrow, arrow,
+                             ReversedArrow, reversed_arrow
+    );
+    
+    return morphism;
+    
+end );
+
+##
+InstallMethod( PseudoInverse,
+               [ IsRelCategoryMorphism ],
+               
+  function( mor )
+    
+    return RelCategoryMorphism( 
+        Range( mor ),
+        Arrow( mor ),
+        ReversedArrow( mor ),
+        Source( mor )
+    );
+    
+end );
+
+##
+InstallMethod( AssociatedSubobject,
+               [ IsRelCategoryMorphism ],
+               
+  function( mor )
+    
+    return ImageEmbedding( 
+            UniversalMorphismIntoDirectProduct( ReversedArrow( mor ), Arrow( mor ) ) 
+    );
+    
+end );
+
+####################################
+##
+## Basic operations
+##
+####################################
+
+InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RELATIONS_CATEGORY,
+  
+  function( category )
+    
+    ##
+    AddIsEqualForObjects( category,
+      function( a, b ) 
+        
+        return IsEqualForObjects( UnderlyingOriginalObject( a ), UnderlyingOriginalObject( b ) );
+        
+    end );
+    
+    ##
+    AddIsEqualForMorphisms( category,
+      function( alpha, beta ) 
+        local arrow_alpha, arrow_beta;
+        
+        arrow_alpha := Arrow( alpha );
+        
+        arrow_beta := Arrow( beta );
+        
+        return
+          IsEqualForObjects( Source( arrow_alpha ), Source( arrow_beta ) )
+          and
+          IsEqualForMorphisms( arrow_alpha, arrow_beta )
+          and
+          IsEqualForMorphisms( ReversedArrow( alpha ), ReversedArrow( beta ) );
+          
+    end );
+    
+    ##
+    AddIsCongruentForMorphisms( category,
+      function( alpha, beta ) 
+        
+        return IsEqualAsSubobjects( 
+          AssociatedSubobject( alpha ),
+          AssociatedSubobject( beta )
+        );
+        
+    end );
+    
+    ##
+    AddIsWellDefinedForObjects( category,
+      function( object )
+        
+        return IsWellDefinedForObjects( UnderlyingOriginalObject( object ) );
+        
+    end );
+    
+    ##
+    AddIsWellDefinedForMorphisms( category, 
+      function( alpha ) 
+        local arrow, reversed;
+        
+        arrow := Arrow( alpha );
+        
+        reversed := ReversedArrow( alpha );
+        
+        if not IsWellDefinedForMorphisms( arrow ) then
+          
+          return false;
+          
+        fi;
+        
+        if not IsWellDefinedForMorphisms( reversed ) then
+          
+          return false;
+          
+        fi;
+        
+        if not IsEqualForObjects( Source( arrow ), Source( reversed ) ) then
+          
+          return false;
+          
+        fi;
+        
+        if not IsEqualForObjects( UnderlyingOriginalObject( Range( alpha ) ), Range( arrow ) ) then
+          
+          return false;
+          
+        fi;
+        
+        if not IsEqualForObjects( UnderlyingOriginalObject( Source( alpha ) ), Range( reversed ) ) then
+          
+          return false;
+          
+        fi;
+        
+        return true;
+        
+    end );
+    
+    ##
+    AddPreCompose( category,
+      function( alpha, beta )
+        local diagram, pi_left, pi_right;
+        
+        diagram := [ Arrow( alpha ), ReversedArrow( beta ) ];
+        
+        pi_left := ProjectionInFactorOfFiberProduct( diagram, 1 );
+        
+        pi_right := ProjectionInFactorOfFiberProduct( diagram, 2 );
+        
+        return RelCategoryMorphism( Source( alpha ),
+                                    PreCompose( pi_left, ReversedArrow( alpha ) ),
+                                    PreCompose( pi_right, Arrow( beta ) ),
+                                    Range( beta ) 
+        );
+        
+    end );
+    
+    ##
+    AddIdentityMorphism( category,
+      function( object )
+        local id;
+        
+        id := IdentityMorphism( UnderlyingOriginalObject( object ) );
+        
+        return RelCategoryMorphism( object, id, id, object );
+        
+    end );
+    
+end );
+
+####################################
+##
+## View
+##
+####################################
+
+##
+InstallMethod( Display,
+               [ IsRelCategoryMorphism ],
+    
+    function( alpha )
+        
+        Display(  "Reversed arrow: \n" );
+        
+        Display( ReversedArrow( alpha ) );
+        
+        Display( "Arrow: \n" );
+        
+        Display( Arrow( alpha ) );
+        
+end );
+
+##
+InstallMethod(  Display,
+               [ IsRelCategoryObject ],
+
+  function( obj )
+    
+    Display( UnderlyingOriginalObject( obj ) );
+    
+end );
+
+####################################
+##
+## Convenience
+##
+####################################
+
+##
+InstallMethod( \/,
+               [ IsCapCategoryObject, IsRelCategory ],
+               RelCategoryObject );
+
+##
+InstallMethod( \/,
+               [ IsCapCategoryMorphism, IsRelCategory ],
+               
+  function( mor, rel )
+    local source, range, id;
+    
+    source := Source( mor );
+    
+    id := IdentityMorphism( source );
+    
+    return RelCategoryMorphism( 
+            source/rel,
+            id,
+            mor,
+            Range( mor )/rel
+    );
+    
+end );
+
+##
+InstallMethod( \/,
+               [ IsRelCategory, IsCapCategoryMorphism ],
+               
+  function( rel, mor )
+    
+    return PseudoInverse( mor/rel );
+    
+end );

--- a/FreydCategoriesForCAP/init.g
+++ b/FreydCategoriesForCAP/init.g
@@ -48,4 +48,4 @@ ReadPackage( "FreydCategoriesForCAP", "gap/GradeFiltration.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/SerreSubcategoryFunctions.gd" );
 
-
+ReadPackage( "FreydCategoriesForCAP", "gap/Relations.gd" );

--- a/FreydCategoriesForCAP/read.g
+++ b/FreydCategoriesForCAP/read.g
@@ -48,3 +48,5 @@ ReadPackage( "FreydCategoriesForCAP", "gap/RingsAsAbCats.gi" );
 ReadPackage( "FreydCategoriesForCAP", "gap/GradeFiltration.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/SerreSubcategoryFunctions.gi" );
+
+ReadPackage( "FreydCategoriesForCAP", "gap/Relations.gi" );


### PR DESCRIPTION
- Implementation of a raw version of the category of relations  that is also applicable in a non-abelian context.
- Enhancing the R-linear closure in two ways:
  1) allow input which does not come with a sorting function (which, of course, should only be used if no sorting function is available, since sorting functions give a speedup)
  2) allow for a cocycle with values in R that twists the multiplication of morphisms in the category.