### PR TITLE
Add Coclosed methods to MonoidalCategories

### DIFF
--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -22,7 +22,8 @@ Version := Maximum( [
   "2021.03-01", ## Fabian's version
   ## this line prevents merge conflicts
   "2020.01-10", ## Kamal's version
-
+  ## this line prevents merge conflicts
+  "2021.04-23", ## Tom's version
 ] ),
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/LinearAlgebraForCAP/examples/Example.gi
+++ b/LinearAlgebraForCAP/examples/Example.gi
@@ -134,4 +134,106 @@ right_side := PreCompose( [ i1, DualOnMorphisms( u ), u ] );;
 x := SolveLinearSystemInAbCategory( [ [ i1 ] ], [ [ u ] ], [ right_side ] )[1];;
 IsCongruentForMorphisms( PreCompose( [ i1, x, u ] ), right_side );
 #! true
+a_otimes_b := TensorProductOnObjects( a, b );
+#! <A vector space object over Q of dimension 12>
+hom_ab := InternalHomOnObjects( a, b );
+#! <A vector space object over Q of dimension 12>
+cohom_ab := InternalCoHomOnObjects( a, b );
+#! <A vector space object over Q of dimension 12>
+1_ab := VectorSpaceMorphism(
+          a_otimes_b,
+          HomalgIdentityMatrix( Dimension( a_otimes_b ), Q ),
+          a_otimes_b
+          );
+#! <A morphism in Category of matrices over Q>
+1_hom_ab := VectorSpaceMorphism(
+              hom_ab,
+              HomalgIdentityMatrix( Dimension( hom_ab ), Q ),
+              hom_ab
+            );
+#! <A morphism in Category of matrices over Q>
+1_cohom_ab := VectorSpaceMorphism(
+                cohom_ab,
+                HomalgIdentityMatrix( Dimension( cohom_ab ), Q ),
+                cohom_ab
+              );
+#! <A morphism in Category of matrices over Q>
+ev_ab := EvaluationMorphism( a, b );
+#! <A morphism in Category of matrices over Q>
+coev_ab := CoevaluationMorphism( a, b );
+#! <A morphism in Category of matrices over Q>
+cocl_ev_ab := CoclosedEvaluationMorphism( a, b );
+#! <A morphism in Category of matrices over Q>
+cocl_coev_ab := CoclosedCoevaluationMorphism( a, b );
+#! <A morphism in Category of matrices over Q>
+UnderlyingMatrix( ev_ab ) = UnderlyingMatrix( cocl_coev_ab );
+#! true
+UnderlyingMatrix( coev_ab ) = UnderlyingMatrix( cocl_ev_ab );
+#! true
+tensor_hom_adj_1_hom_ab := InternalHomToTensorProductAdjunctionMap( a, b, 1_hom_ab );
+#! <A morphism in Category of matrices over Q>
+cohom_tensor_adj_1_cohom_ab := InternalCoHomToTensorProductAdjunctionMap( a, b, 1_cohom_ab );
+#! <A morphism in Category of matrices over Q>
+tensor_hom_adj_1_ab := TensorProductToInternalHomAdjunctionMap( a, b, 1_ab );
+#! <A morphism in Category of matrices over Q>
+cohom_tensor_adj_1_ab := TensorProductToInternalCoHomAdjunctionMap( a, b, 1_ab );
+#! <A morphism in Category of matrices over Q>
+ev_ab = tensor_hom_adj_1_hom_ab;
+#! true
+cocl_ev_ab = cohom_tensor_adj_1_cohom_ab;
+#! true
+coev_ab = tensor_hom_adj_1_ab;
+#! true
+cocl_coev_ab = cohom_tensor_adj_1_ab;
+#! true
+c := VectorSpaceObject(2,Q);
+#! <A vector space object over Q of dimension 2>
+d := VectorSpaceObject(1,Q);
+#! <A vector space object over Q of dimension 1>
+pre_compose := MonoidalPreComposeMorphism( a, b, c );
+#! <A morphism in Category of matrices over Q>
+post_compose := MonoidalPostComposeMorphism( a, b, c );
+#! <A morphism in Category of matrices over Q>
+pre_cocompose := MonoidalPreCoComposeMorphism( a, b, c );
+#! <A morphism in Category of matrices over Q>
+post_cocompose := MonoidalPostCoComposeMorphism( a, b, c );
+#! <A morphism in Category of matrices over Q>
+UnderlyingMatrix( pre_compose ) = Involution( UnderlyingMatrix( pre_cocompose ) );
+#! true
+UnderlyingMatrix( post_compose ) = Involution( UnderlyingMatrix( post_cocompose ) );
+#! true
+tp_hom_comp := TensorProductInternalHomCompatibilityMorphism( a, b, c, d );
+#! <A morphism in Category of matrices over Q>
+cohom_tp_comp := InternalCoHomTensorProductCompatibilityMorphism( a, c, b, d);
+#! <A morphism in Category of matrices over Q>
+UnderlyingMatrix( tp_hom_comp ) = Involution( UnderlyingMatrix( cohom_tp_comp ) );
+#! true
+lambda := LambdaIntroduction( alpha );
+#! <A morphism in Category of matrices over Q>
+lambda_elim := LambdaElimination( a, b, lambda );
+#! <A morphism in Category of matrices over Q>
+alpha = lambda_elim;
+#! true
+colambda := CoLambdaIntroduction( alpha );
+#! <A morphism in Category of matrices over Q>
+colambda_elim := CoLambdaElimination( a, b, colambda );
+#! <A morphism in Category of matrices over Q>
+alpha = colambda_elim;
+#! true
+UnderlyingMatrix( lambda ) = Involution( UnderlyingMatrix( colambda ) );
+#! true
+delta := PreCompose( colambda, lambda);
+#! <A morphism in Category of matrices over Q>
+Display( TraceMap( delta ) );
+#! [ [  9 ] ]
+#!
+#! A morphism in Category of matrices over Q
+Display( CoTraceMap( delta ) );
+#! [ [  9 ] ]
+#!
+#! A morphism in Category of matrices over Q
+TraceMap( delta ) = CoTraceMap( delta );
+#! true
+RankMorphism( a ) = CoRankMorphism( a );
+#! true
 #! @EndExample

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -44,6 +44,8 @@ InstallMethod( MatrixCategory,
     
     SetIsRigidSymmetricClosedMonoidalCategory( category, true );
     
+    SetIsRigidSymmetricCoclosedMonoidalCategory( category, true );
+    
     SetIsStrictMonoidalCategory( category, true );
     
     SetIsLinearCategoryOverCommutativeRing( category, true );
@@ -607,7 +609,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     
     ##
     AddTensorProductOnMorphismsWithGivenTensorProducts( category,
-      
       function( cat, new_source, morphism_1, morphism_2, new_range )
         
         return VectorSpaceMorphism( new_source,
@@ -618,7 +619,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     
     ##
     AddTensorUnit( category,
-      
       function( cat )
         
         return VectorSpaceObject( 1, homalg_field );
@@ -648,6 +648,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
     end );
     
+    ## Basic Operations for Closed Monoidal Categories
     ##
     AddDualOnObjects( category, { cat, space } -> space );
     
@@ -694,7 +695,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     
     ##
     AddCoevaluationForDualWithGivenTensorProduct( category,
-      
       function( cat, unit, object, tensor_object )
         local dimension, row, zero_row, i;
         
@@ -733,6 +733,93 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
                                     bidual_of_object
                                   );
         
+    end );
+    
+    ## Basic Operations for Coclosed Monoidal Categories
+    ##
+    AddCoDualOnObjects( category, { cat, space } -> space );
+    
+    ##
+    AddCoDualOnMorphismsWithGivenCoDuals( category,
+      function( cat, codual_source, morphism, codual_range )
+        
+        return VectorSpaceMorphism( codual_source,
+                                    Involution( UnderlyingMatrix( morphism ) ),
+                                    codual_range );
+        
+    end );
+    
+    ##
+    AddCoclosedEvaluationForCoDualWithGivenTensorProduct( category,
+      function( cat, unit, object, tensor_object )
+        local dimension, row, zero_row, i;
+        
+        dimension := Dimension( object );
+        
+        row := [ ];
+        
+        zero_row := List( [ 1 .. dimension ], i -> 0 );
+        
+        for i in [ 1 .. dimension - 1 ] do
+          
+          Add( row, 1 );
+          
+          Append( row, zero_row );
+          
+        od;
+        
+        if dimension > 0 then
+          
+          Add( row, 1 );
+          
+        fi;
+        
+        return VectorSpaceMorphism( unit,
+                                    HomalgMatrix( row, 1, Dimension( tensor_object ), homalg_field ),
+                                    tensor_object );
+        
+    end );
+    
+    ##
+    AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( category,
+      function( cat, tensor_object, object, unit )
+        local dimension, column, zero_column, i;
+        
+        dimension := Dimension( object );
+        
+        column := [ ];
+        
+        zero_column := List( [ 1 .. dimension ], i -> 0 );
+        
+        for i in [ 1 .. dimension - 1 ] do
+          
+          Add( column, 1 );
+          
+          Append( column, zero_column );
+          
+        od;
+        
+        if dimension > 0 then
+          
+          Add( column, 1 );
+          
+        fi;
+        
+        return VectorSpaceMorphism( tensor_object,
+                                    HomalgMatrix( column, Dimension( tensor_object ), 1, homalg_field ),
+                                    unit );
+                                    
+    end );
+    
+    ##
+    AddMorphismFromCoBidualWithGivenCoBidual( category,
+      function( cat, object, cobidual_of_object )
+        
+        return VectorSpaceMorphism( cobidual_of_object,
+                                    HomalgIdentityMatrix( Dimension( object ), homalg_field ),
+                                    object
+                                  );
+                                  
     end );
     
     ## Homomorphism structure
@@ -879,7 +966,3 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     end );
 
 end );
-
-
-
-


### PR DESCRIPTION
I'm quite happy that the fixes in MonoidalCategories were finally merged, so here is the code for the coclosed structures. Also, thanks for your nice words. :)

As the amount of code is rather large, I created this as a draft to discuss on how to merge it. I would propose to split this PR into the following parts:

- CoclosedMonoidal*
- SymmetricCoclosedMonoidal*
- RigidSymmetricCoclosedMonoidal*
- Create*MonoidalCategories (the rewriting mechanism used to create the Topos package)
- Coclosed methods and examples for LinearAlgebraForCAP

Also, if you wish, I can send you my thesis which has TikZ diagrams for almost every method/derivation/etc. Since a high amount of the code translates directly into diagrams, this should make it far less painful to review. :) 