### PR TITLE
Use UnionOfRows/Columns for lists

### DIFF
--- a/CAP/examples/testfiles/VectorSpacesAllMethods.gi
+++ b/CAP/examples/testfiles/VectorSpacesAllMethods.gi
@@ -218,13 +218,10 @@ AddInjectionOfCofactorOfDirectSum( vecspaces,
     
     coproduct := QVectorSpace( dim );
     
-    injection_of_cofactor := HomalgZeroMatrix( dim_cofactor, dim_pre ,VECTORSPACES_FIELD );
-    
-    injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                         HomalgIdentityMatrix( dim_cofactor, VECTORSPACES_FIELD ) );
-    
-    injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                         HomalgZeroMatrix( dim_cofactor, dim_post, VECTORSPACES_FIELD ) );
+    injection_of_cofactor := UnionOfColumns( HomalgZeroMatrix( dim_cofactor, dim_pre ,VECTORSPACES_FIELD ),
+                                             HomalgIdentityMatrix( dim_cofactor, VECTORSPACES_FIELD ),
+                                             HomalgZeroMatrix( dim_cofactor, dim_post, VECTORSPACES_FIELD )
+                                           );
     
     return VectorSpaceMorphism( object_product_list[ injection_number ], injection_of_cofactor, coproduct );
 
@@ -247,13 +244,10 @@ AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( vecspaces,
     
     dim_cofactor := Dimension( object_product_list[ injection_number ] );
     
-    injection_of_cofactor := HomalgZeroMatrix( dim_cofactor, dim_pre ,VECTORSPACES_FIELD );
-    
-    injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                         HomalgIdentityMatrix( dim_cofactor, VECTORSPACES_FIELD ) );
-    
-    injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                         HomalgZeroMatrix( dim_cofactor, dim_post, VECTORSPACES_FIELD ) );
+    injection_of_cofactor := UnionOfColumns( HomalgZeroMatrix( dim_cofactor, dim_pre ,VECTORSPACES_FIELD ),
+                                             HomalgIdentityMatrix( dim_cofactor, VECTORSPACES_FIELD ),
+                                             HomalgZeroMatrix( dim_cofactor, dim_post, VECTORSPACES_FIELD )
+                                           );
     
     return VectorSpaceMorphism( object_product_list[ injection_number ], injection_of_cofactor, coproduct );
 
@@ -263,7 +257,7 @@ end );
 AddUniversalMorphismFromDirectSum( vecspaces,
 
   function( diagram, sink )
-    local dim, coproduct, components, universal_morphism, morphism;
+    local dim, coproduct, components, universal_morphism;
     
     components := sink;
     
@@ -271,14 +265,8 @@ AddUniversalMorphismFromDirectSum( vecspaces,
     
     coproduct := QVectorSpace( dim );
     
-    universal_morphism := sink[1]!.morphism;
+    universal_morphism := UnionOfRows( List( components, c -> c!.morphism ) );
     
-    for morphism in components{ [ 2 .. Length( components ) ] } do
-    
-      universal_morphism := UnionOfRows( universal_morphism, morphism!.morphism );
-  
-    od;
-  
     return VectorSpaceMorphism( coproduct, universal_morphism, Range( sink[1] ) );
   
 end );
@@ -287,18 +275,12 @@ end );
 AddUniversalMorphismFromDirectSumWithGivenDirectSum( vecspaces,
 
   function( diagram, sink, coproduct )
-    local components, universal_morphism, morphism;
+    local components, universal_morphism;
     
     components := sink;
     
-    universal_morphism := sink[1]!.morphism;
-    
-    for morphism in components{ [ 2 .. Length( components ) ] } do
-    
-      universal_morphism := UnionOfRows( universal_morphism, morphism!.morphism );
-  
-    od;
-  
+    universal_morphism := UnionOfRows( List( components, c -> c!.morphism ) );
+
     return VectorSpaceMorphism( coproduct, universal_morphism, Range( sink[1] ) );
   
 end );
@@ -336,13 +318,10 @@ AddProjectionInFactorOfDirectSum( vecspaces,
     
     direct_product := QVectorSpace( dim );
     
-    projection_in_factor := HomalgZeroMatrix( dim_pre, dim_factor, VECTORSPACES_FIELD );
-    
-    projection_in_factor := UnionOfRows( projection_in_factor, 
-                                         HomalgIdentityMatrix( dim_factor, VECTORSPACES_FIELD ) );
-    
-    projection_in_factor := UnionOfRows( projection_in_factor, 
-                                         HomalgZeroMatrix( dim_post, dim_factor, VECTORSPACES_FIELD ) );
+    projection_in_factor := UnionOfRows( HomalgZeroMatrix( dim_pre, dim_factor, VECTORSPACES_FIELD ),
+                                         HomalgIdentityMatrix( dim_factor, VECTORSPACES_FIELD ),
+                                         HomalgZeroMatrix( dim_post, dim_factor, VECTORSPACES_FIELD )
+                                       );
     
     return VectorSpaceMorphism( direct_product, projection_in_factor, object_product_list[ projection_number ] );
 
@@ -365,13 +344,10 @@ AddProjectionInFactorOfDirectSumWithGivenDirectSum( vecspaces,
     
     dim_factor := Dimension( object_product_list[ projection_number ] );
     
-    projection_in_factor := HomalgZeroMatrix( dim_pre, dim_factor, VECTORSPACES_FIELD );
-    
-    projection_in_factor := UnionOfRows( projection_in_factor, 
-                                         HomalgIdentityMatrix( dim_factor, VECTORSPACES_FIELD ) );
-    
-    projection_in_factor := UnionOfRows( projection_in_factor, 
-                                         HomalgZeroMatrix( dim_post, dim_factor, VECTORSPACES_FIELD ) );
+    projection_in_factor := UnionOfRows( HomalgZeroMatrix( dim_pre, dim_factor, VECTORSPACES_FIELD ),
+                                         HomalgIdentityMatrix( dim_factor, VECTORSPACES_FIELD ),
+                                         HomalgZeroMatrix( dim_post, dim_factor, VECTORSPACES_FIELD )
+                                       );
     
     return VectorSpaceMorphism( direct_product, projection_in_factor, object_product_list[ projection_number ] );
 
@@ -380,7 +356,7 @@ end );
 AddUniversalMorphismIntoDirectSum( vecspaces,
 
   function( diagram, sink )
-    local dim, direct_product, components, universal_morphism, morphism;
+    local dim, direct_product, components, universal_morphism;
     
     components := sink;
     
@@ -388,14 +364,8 @@ AddUniversalMorphismIntoDirectSum( vecspaces,
     
     direct_product := QVectorSpace( dim );
     
-    universal_morphism := sink[1]!.morphism;
+    universal_morphism := UnionOfColumns( List( components, c -> c!.morphism ) );
     
-    for morphism in components{ [ 2 .. Length( components ) ] } do
-    
-      universal_morphism := UnionOfColumns( universal_morphism, morphism!.morphism );
-  
-    od;
-  
     return VectorSpaceMorphism( Source( sink[1] ), universal_morphism, direct_product );
   
 end );
@@ -403,17 +373,11 @@ end );
 AddUniversalMorphismIntoDirectSumWithGivenDirectSum( vecspaces,
 
   function( diagram, sink, direct_product )
-    local components, universal_morphism, morphism;
+    local components, universal_morphism;
     
     components := sink;
     
-    universal_morphism := sink[1]!.morphism;
-    
-    for morphism in components{ [ 2 .. Length( components ) ] } do
-    
-      universal_morphism := UnionOfColumns( universal_morphism, morphism!.morphism );
-  
-    od;
+    universal_morphism := UnionOfColumns( List( components, c -> c!.morphism ) );
   
     return VectorSpaceMorphism( Source( sink[1] ), universal_morphism, direct_product );
   

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -508,13 +508,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
         
         rank_factor := RankOfObject( object_list[ projection_number ] );
         
-        projection_in_factor := HomalgZeroMatrix( rank_factor, rank_pre, ring );
-
-        projection_in_factor := UnionOfColumns( projection_in_factor,
-                                                HomalgIdentityMatrix( rank_factor, ring ) );
-
-        projection_in_factor := UnionOfColumns( projection_in_factor,
-                                                HomalgZeroMatrix( rank_factor, rank_post, ring ) );
+        projection_in_factor := UnionOfColumns( HomalgZeroMatrix( rank_factor, rank_pre, ring ),
+                                                HomalgIdentityMatrix( rank_factor, ring ),
+                                                HomalgZeroMatrix( rank_factor, rank_post, ring )
+                                              );
 
         return CategoryOfColumnsMorphism( direct_sum_object, projection_in_factor, object_list[ projection_number ] );
         
@@ -548,14 +545,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
         rank_cofactor := RankOfObject( object_list[ injection_number ] );
 
         # now construct the mapping matrix
-        injection_of_cofactor := HomalgZeroMatrix( rank_pre, rank_cofactor, ring );
+        injection_of_cofactor := UnionOfRows( HomalgZeroMatrix( rank_pre, rank_cofactor, ring ),
+                                              HomalgIdentityMatrix( rank_cofactor, ring ),
+                                              HomalgZeroMatrix( rank_post, rank_cofactor, ring )
+                                            );
 
-        injection_of_cofactor := UnionOfRows( injection_of_cofactor,
-                                              HomalgIdentityMatrix( rank_cofactor, ring ) );
-        
-        injection_of_cofactor := UnionOfRows( injection_of_cofactor,
-                                              HomalgZeroMatrix( rank_post, rank_cofactor, ring ) );
-        
         return CategoryOfColumnsMorphism( object_list[ injection_number ], injection_of_cofactor, coproduct );
         
     end );
@@ -808,7 +802,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
                 
             elif nr_columns > 1 then
                 
-                underlying_matrix := Iterated( List( [ 1 .. nr_columns ], i -> CertainColumns( underlying_matrix, [ i ] ) ), UnionOfRows );
+                underlying_matrix := UnionOfRows( List( [ 1 .. nr_columns ], i -> CertainColumns( underlying_matrix, [ i ] ) ) );
                 
             fi;
             
@@ -837,7 +831,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
             
             underlying_matrix := UnderlyingMatrix( morphism );
 
-            underlying_matrix := Iterated( List( [ 1 .. nr_columns ], i -> CertainRows( underlying_matrix, [ ((i - 1) * nr_rows + 1) .. i * nr_rows ] ) ), UnionOfColumns );
+            underlying_matrix := UnionOfColumns( List( [ 1 .. nr_columns ], i -> CertainRows( underlying_matrix, [ ((i - 1) * nr_rows + 1) .. i * nr_rows ] ) ) );
             
             return CategoryOfColumnsMorphism( A, underlying_matrix, B );
             

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
@@ -489,13 +489,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_COLUMNS,
         rank_factor := Rank( object_list[ projection_number ] );
         
         # construct the mapping as homalg matrix
-        projection_in_factor := HomalgZeroMatrix( rank_factor, rank_pre, underlying_graded_ring );
-        projection_in_factor := Iterated( [ projection_in_factor,
-                                            HomalgIdentityMatrix( rank_factor, underlying_graded_ring ) ],
-                                           UnionOfColumns );
-        projection_in_factor := Iterated( [ projection_in_factor,
-                                            HomalgZeroMatrix( rank_factor, rank_post, underlying_graded_ring ) ],
-                                           UnionOfColumns );
+        projection_in_factor := UnionOfColumns( HomalgZeroMatrix( rank_factor, rank_pre, underlying_graded_ring ),
+                                                HomalgIdentityMatrix( rank_factor, underlying_graded_ring ),
+                                                HomalgZeroMatrix( rank_factor, rank_post, underlying_graded_ring )
+                                              );
         
         # and return the corresonding morphism
         return GradedRowOrColumnMorphism( direct_sum_object,
@@ -513,18 +510,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_COLUMNS,
     # @Arguments diagram, sink, direct_sum
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
       function( diagram, sink, direct_sum )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
         # construct the homalg matrix to represent the universal morphism
-        underlying_matrix_of_universal_morphism := UnderlyingHomalgMatrix( sink[ 1 ] );
-        
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-          
-          underlying_matrix_of_universal_morphism := 
-            Iterated( [ underlying_matrix_of_universal_morphism, UnderlyingHomalgMatrix( morphism ) ],
-                      UnionOfRows );
-        
-        od;
+        underlying_matrix_of_universal_morphism := UnionOfRows( List( sink, s -> UnderlyingHomalgMatrix( s ) ) );
         
         # and then construct from it the corresponding morphism
         return GradedRowOrColumnMorphism( Source( sink[ 1 ] ),
@@ -552,13 +541,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_COLUMNS,
         rank_cofactor := Rank( object_list[ injection_number ] );
         
         # now construct the mapping matrix
-        injection_of_cofactor := HomalgZeroMatrix( rank_pre, rank_cofactor, underlying_graded_ring );
-        injection_of_cofactor := Iterated( [ injection_of_cofactor, 
-                                             HomalgIdentityMatrix( rank_cofactor, underlying_graded_ring ) ],
-                                            UnionOfRows );
-        injection_of_cofactor := Iterated( [ injection_of_cofactor,
-                                             HomalgZeroMatrix( rank_post, rank_cofactor, underlying_graded_ring ) ],
-                                            UnionOfRows );
+        injection_of_cofactor := UnionOfRows( HomalgZeroMatrix( rank_pre, rank_cofactor, underlying_graded_ring ),
+                                              HomalgIdentityMatrix( rank_cofactor, underlying_graded_ring ),
+                                              HomalgZeroMatrix( rank_post, rank_cofactor, underlying_graded_ring )
+                                            );
         
         # and construct the associated morphism
         return GradedRowOrColumnMorphism( object_list[ injection_number ],
@@ -576,17 +562,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_COLUMNS,
     # @Arguments diagram, sink, coproduct
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
       function( diagram, sink, coproduct )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
-        underlying_matrix_of_universal_morphism := UnderlyingHomalgMatrix( sink[1] );
-        
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-          
-          underlying_matrix_of_universal_morphism := 
-            Iterated( [ underlying_matrix_of_universal_morphism, UnderlyingHomalgMatrix( morphism ) ],
-                      UnionOfColumns );
-          
-        od;
+        underlying_matrix_of_universal_morphism := UnionOfColumns( List( sink, s -> UnderlyingHomalgMatrix( s ) ) );
         
         return GradedRowOrColumnMorphism( coproduct,
                                           underlying_matrix_of_universal_morphism,

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
@@ -493,13 +493,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_ROWS,
         rank_factor := Rank( object_list[ projection_number ] );
         
         # construct the mapping as homalg matrix
-        projection_in_factor := HomalgZeroMatrix( rank_pre, rank_factor, underlying_graded_ring );
-        projection_in_factor := Iterated( [ projection_in_factor,
-                                            HomalgIdentityMatrix( rank_factor, underlying_graded_ring ) ],
-                                            UnionOfRows );
-        projection_in_factor := Iterated( [ projection_in_factor,
-                                            HomalgZeroMatrix( rank_post, rank_factor, underlying_graded_ring ) ],
-                                            UnionOfRows );
+        projection_in_factor := UnionOfRows( HomalgZeroMatrix( rank_pre, rank_factor, underlying_graded_ring ),
+                                             HomalgIdentityMatrix( rank_factor, underlying_graded_ring ),
+                                             HomalgZeroMatrix( rank_post, rank_factor, underlying_graded_ring )
+                                           );
         
         # and return the corresonding morphism
         return GradedRowOrColumnMorphism( direct_sum_object,
@@ -517,18 +514,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_ROWS,
     # @Arguments diagram, sink, direct_sum
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
       function( diagram, sink, direct_sum )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
         # construct the homalg matrix to represent the universal morphism
-        underlying_matrix_of_universal_morphism := UnderlyingHomalgMatrix( sink[ 1 ] );
-        
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-        
-          underlying_matrix_of_universal_morphism := 
-            Iterated( [ underlying_matrix_of_universal_morphism, UnderlyingHomalgMatrix( morphism ) ],
-                      UnionOfColumns );
-        
-        od;
+        underlying_matrix_of_universal_morphism := UnionOfColumns( List( sink, s -> UnderlyingHomalgMatrix( s ) ) );
         
         # and then construct from it the corresponding morphism
         return GradedRowOrColumnMorphism( Source( sink[ 1 ] ),
@@ -556,13 +545,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_ROWS,
         rank_cofactor := Rank( object_list[ injection_number ] );
         
         # now construct the mapping matrix
-        injection_of_cofactor := HomalgZeroMatrix( rank_cofactor, rank_pre ,underlying_graded_ring );
-        injection_of_cofactor := Iterated( [ injection_of_cofactor,
-                                             HomalgIdentityMatrix( rank_cofactor, underlying_graded_ring ) ],
-                                            UnionOfColumns );
-        injection_of_cofactor := Iterated( [ injection_of_cofactor,
-                                             HomalgZeroMatrix( rank_cofactor, rank_post, underlying_graded_ring ) ],
-                                            UnionOfColumns );
+        injection_of_cofactor := UnionOfColumns( HomalgZeroMatrix( rank_cofactor, rank_pre ,underlying_graded_ring ),
+                                                 HomalgIdentityMatrix( rank_cofactor, underlying_graded_ring ),
+                                                 HomalgZeroMatrix( rank_cofactor, rank_post, underlying_graded_ring )
+                                               );
         
         # and construct the associated morphism
         return GradedRowOrColumnMorphism( object_list[ injection_number ],
@@ -580,16 +566,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_ROWS,
     # @Arguments diagram, sink, coproduct
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
       function( diagram, sink, coproduct )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
         underlying_matrix_of_universal_morphism := UnderlyingHomalgMatrix( sink[1] );
         
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-        
-          underlying_matrix_of_universal_morphism := 
-            Iterated( [ underlying_matrix_of_universal_morphism, UnderlyingHomalgMatrix( morphism ) ], UnionOfRows );
-        
-        od;
+        underlying_matrix_of_universal_morphism := UnionOfRows( List( sink, s -> UnderlyingHomalgMatrix( s ) ) );
         
         return GradedRowOrColumnMorphism( coproduct,
                                           underlying_matrix_of_universal_morphism,

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -530,13 +530,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         
         rank_factor := RankOfObject( object_list[ projection_number ] );
         
-        projection_in_factor := HomalgZeroMatrix( rank_pre, rank_factor, ring );
-        
-        projection_in_factor := UnionOfRows( projection_in_factor, 
-                                             HomalgIdentityMatrix( rank_factor, ring ) );
-        
-        projection_in_factor := UnionOfRows( projection_in_factor, 
-                                             HomalgZeroMatrix( rank_post, rank_factor, ring ) );
+        projection_in_factor := UnionOfRows( HomalgZeroMatrix( rank_pre, rank_factor, ring ),
+                                             HomalgIdentityMatrix( rank_factor, ring ),
+                                             HomalgZeroMatrix( rank_post, rank_factor, ring )
+                                           );
         
         return CategoryOfRowsMorphism( direct_sum_object, projection_in_factor, object_list[ projection_number ] );
         
@@ -570,13 +567,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         rank_cofactor := RankOfObject( object_list[ injection_number ] );
         
         # now construct the mapping matrix
-        injection_of_cofactor := HomalgZeroMatrix( rank_cofactor, rank_pre ,ring );
-        
-        injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                             HomalgIdentityMatrix( rank_cofactor, ring ) );
-        
-        injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                             HomalgZeroMatrix( rank_cofactor, rank_post, ring ) );
+        injection_of_cofactor := UnionOfColumns( HomalgZeroMatrix( rank_cofactor, rank_pre ,ring ),
+                                                 HomalgIdentityMatrix( rank_cofactor, ring ),
+                                                 HomalgZeroMatrix( rank_cofactor, rank_post, ring )
+                                               );
         
         return CategoryOfRowsMorphism( object_list[ injection_number ], injection_of_cofactor, coproduct );
         
@@ -848,7 +842,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
                 
             elif nr_rows > 1 then
                 
-                underlying_matrix := Iterated( List( [ 1 .. nr_rows ], i -> CertainRows( underlying_matrix, [ i ] ) ), UnionOfColumns );
+                underlying_matrix := UnionOfColumns( List( [ 1 .. nr_rows ], i -> CertainRows( underlying_matrix, [ i ] ) ) );
                 
             fi;
             
@@ -877,7 +871,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
             
             underlying_matrix := UnderlyingMatrix( morphism );
             
-            underlying_matrix := Iterated( List( [ 1 .. nr_rows ], i -> CertainColumns( underlying_matrix, [ ((i - 1) * nr_columns + 1) .. i * nr_columns ] ) ), UnionOfRows );
+            underlying_matrix := UnionOfRows( List( [ 1 .. nr_rows ], i -> CertainColumns( underlying_matrix, [ ((i - 1) * nr_columns + 1) .. i * nr_columns ] ) ) );
             
             return CategoryOfRowsMorphism( A, underlying_matrix, B );
             

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -339,13 +339,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         dim_factor := Dimension( object_list[ projection_number ] );
         
-        projection_in_factor := HomalgZeroMatrix( dim_pre, dim_factor, homalg_field );
-        
-        projection_in_factor := UnionOfRows( projection_in_factor, 
-                                             HomalgIdentityMatrix( dim_factor, homalg_field ) );
-        
-        projection_in_factor := UnionOfRows( projection_in_factor, 
-                                             HomalgZeroMatrix( dim_post, dim_factor, homalg_field ) );
+        projection_in_factor := UnionOfRows( HomalgZeroMatrix( dim_pre, dim_factor, homalg_field ),
+                                             HomalgIdentityMatrix( dim_factor, homalg_field ),
+                                             HomalgZeroMatrix( dim_post, dim_factor, homalg_field )
+                                           );
         
         return VectorSpaceMorphism( direct_sum_object, projection_in_factor, object_list[ projection_number ] );
         
@@ -354,17 +351,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
       function( diagram, sink, direct_sum )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
-        underlying_matrix_of_universal_morphism := UnderlyingMatrix( sink[1] );
-        
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-          
-          underlying_matrix_of_universal_morphism := 
-            UnionOfColumns( underlying_matrix_of_universal_morphism, UnderlyingMatrix( morphism ) );
-          
-        od;
-        
+        underlying_matrix_of_universal_morphism := UnionOfColumns( List( sink, s -> UnderlyingMatrix( s ) ) );
+
         return VectorSpaceMorphism( Source( sink[1] ), underlying_matrix_of_universal_morphism, direct_sum );
       
     end );
@@ -382,13 +372,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         dim_cofactor := Dimension( object_list[ injection_number ] );
         
-        injection_of_cofactor := HomalgZeroMatrix( dim_cofactor, dim_pre ,homalg_field );
-        
-        injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                             HomalgIdentityMatrix( dim_cofactor, homalg_field ) );
-        
-        injection_of_cofactor := UnionOfColumns( injection_of_cofactor, 
-                                             HomalgZeroMatrix( dim_cofactor, dim_post, homalg_field ) );
+        injection_of_cofactor := UnionOfColumns( HomalgZeroMatrix( dim_cofactor, dim_pre ,homalg_field ),
+                                                 HomalgIdentityMatrix( dim_cofactor, homalg_field ),
+                                                 HomalgZeroMatrix( dim_cofactor, dim_post, homalg_field )
+                                               );
         
         return VectorSpaceMorphism( object_list[ injection_number ], injection_of_cofactor, coproduct );
 
@@ -397,16 +384,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
       function( diagram, sink, coproduct )
-        local underlying_matrix_of_universal_morphism, morphism;
+        local underlying_matrix_of_universal_morphism;
         
-        underlying_matrix_of_universal_morphism := UnderlyingMatrix( sink[1] );
-        
-        for morphism in sink{ [ 2 .. Length( sink ) ] } do
-          
-          underlying_matrix_of_universal_morphism := 
-            UnionOfRows( underlying_matrix_of_universal_morphism, UnderlyingMatrix( morphism ) );
-          
-        od;
+        underlying_matrix_of_universal_morphism := UnionOfRows( List( sink, s -> UnderlyingMatrix( s ) ) );
         
         return VectorSpaceMorphism( coproduct, underlying_matrix_of_universal_morphism, Range( sink[1] ) );
         

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -831,7 +831,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
     AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
                                                  
       function( product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix, i;
+        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix;
         
         objects := product_object;
         
@@ -844,13 +844,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
         
         projection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
         
-        projection_matrix := projection[ 1 ];
-        
-        for i in [ 2 .. Length( objects ) ] do
-            
-            projection_matrix := UnionOfRows( projection_matrix, projection[ i ] );
-            
-        od;
+        projection_matrix := UnionOfRows( projection );
         
         return PresentationMorphism( direct_sum_object, projection_matrix, objects[ component_number ] );
         
@@ -859,19 +853,13 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
                                                                  
       function( diagram, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product, i;
+        local components, number_of_components, map_into_product;
         
         components := product_morphism;
         
         number_of_components := Length( components );
         
-        map_into_product := UnderlyingMatrix( components[ 1 ] );
-        
-        for i in [ 2 .. number_of_components ] do
-            
-            map_into_product := UnionOfColumns( map_into_product, UnderlyingMatrix( components[ i ] ) );
-            
-        od;
+        map_into_product := UnionOfColumns( List( components, c -> UnderlyingMatrix( c ) ) );
         
         return PresentationMorphism( Source( components[ 1 ] ), map_into_product, direct_sum );
         
@@ -880,7 +868,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
     AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
                                               
       function( product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix, i;
+        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix;
         
         objects := product_object;
         
@@ -892,13 +880,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
         
         injection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
         
-        injection_matrix := injection[ 1 ];
-        
-        for i in [ 2 .. Length( objects ) ] do
-            
-            injection_matrix := UnionOfColumns( injection_matrix, injection[ i ] );
-            
-        od;
+        injection_matrix := UnionOfColumns( injection );
         
         return PresentationMorphism( objects[ component_number ], injection_matrix, direct_sum_object );
         
@@ -907,19 +889,13 @@ InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
                                                          
       function( diagram, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product, i;
+        local components, number_of_components, map_into_product;
         
         components := product_morphism;
         
         number_of_components := Length( components );
         
-        map_into_product := UnderlyingMatrix( components[ 1 ] );
-        
-        for i in [ 2 .. number_of_components ] do
-            
-            map_into_product := UnionOfRows( map_into_product, UnderlyingMatrix( components[ i ] ) );
-            
-        od;
+        map_into_product := UnionOfRows( List( components, c -> UnderlyingMatrix( c ) ) );
         
         return PresentationMorphism( direct_sum, map_into_product, Range( components[ 1 ] ) );
         
@@ -953,7 +929,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
     AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
                                                  
       function( product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix, i;
+        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix;
         
         objects := product_object;
         
@@ -965,13 +941,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
         
         projection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
         
-        projection_matrix := projection[ 1 ];
-        
-        for i in [ 2 .. Length( objects ) ] do
-            
-            projection_matrix := UnionOfColumns( projection_matrix, projection[ i ] );
-            
-        od;
+        projection_matrix := UnionOfColumns( projection );
         
         return PresentationMorphism( direct_sum_object, projection_matrix, objects[ component_number ] );
         
@@ -980,19 +950,13 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
                                                                  
       function( diagram, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product, i;
+        local components, number_of_components, map_into_product;
         
         components := product_morphism;
         
         number_of_components := Length( components );
         
-        map_into_product := UnderlyingMatrix( components[ 1 ] );
-        
-        for i in [ 2 .. number_of_components ] do
-            
-            map_into_product := UnionOfRows( map_into_product, UnderlyingMatrix( components[ i ] ) );
-            
-        od;
+        map_into_product := UnionOfRows( List( components, c -> UnderlyingMatrix( c ) ) );
         
         return PresentationMorphism( Source( components[ 1 ] ), map_into_product, direct_sum );
         
@@ -1001,7 +965,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
     AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
                                               
       function( product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix, i;
+        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix;
         
         objects := product_object;
         
@@ -1013,13 +977,7 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
         
         injection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
         
-        injection_matrix := injection[ 1 ];
-        
-        for i in [ 2 .. Length( objects ) ] do
-            
-            injection_matrix := UnionOfRows( injection_matrix, injection[ i ] );
-            
-        od;
+        injection_matrix := UnionOfRows( injection );
         
         return PresentationMorphism( objects[ component_number ], injection_matrix, direct_sum_object );
         
@@ -1028,19 +986,13 @@ InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
                                                          
       function( diagram, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product, i;
+        local components, number_of_components, map_into_product;
         
         components := product_morphism;
         
         number_of_components := Length( components );
         
-        map_into_product := UnderlyingMatrix( components[ 1 ] );
-        
-        for i in [ 2 .. number_of_components ] do
-            
-            map_into_product := UnionOfColumns( map_into_product, UnderlyingMatrix( components[ i ] ) );
-            
-        od;
+        map_into_product := UnionOfColumns( List( components, c -> UnderlyingMatrix( c ) ) );
         
         return PresentationMorphism( direct_sum, map_into_product, Range( components[ 1 ] ) );
         
@@ -1828,7 +1780,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
     
     zero_1  := HomalgZeroMatrix( NrRows( A )*NrColumns( A ), NrRows( P )*NrRows( M ), homalg_ring );
     
-    mat1 := UnionOfColumns( UnionOfColumns( B_tr_I, N_tr_I ), zero_1 );
+    mat1 := UnionOfColumns( B_tr_I, N_tr_I, zero_1 );
     
     I_P := KroneckerMat( HomalgIdentityMatrix( NrColumns( M ) ,homalg_ring ), P );
     
@@ -1836,7 +1788,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
     
     M_tr_I := KroneckerMat( TransposedMatrix( M ), HomalgIdentityMatrix( NrRows( P ) ,homalg_ring ) );
     
-    mat2 := UnionOfColumns( UnionOfColumns( I_P, zero_2 ), M_tr_I );
+    mat2 := UnionOfColumns( I_P, zero_2, M_tr_I );
     
     mat := UnionOfRows( mat1, mat2 );
     
@@ -1846,7 +1798,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
        
     else
        
-       vec_A := Iterated( List( [ 1 .. NrColumns( A ) ], i-> CertainColumns( A, [ i ] ) ), UnionOfRows ); 
+       vec_A := UnionOfRows( List( [ 1 .. NrColumns( A ) ], i-> CertainColumns( A, [ i ] ) ) );
        
     fi;
     
@@ -1865,7 +1817,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
        if v <= 1 then
           XX := CertainRows( sol, [ 1.. s ] );
        else
-          XX := Iterated( List( [ 1 .. v ], i-> CertainRows( sol, [ (i-1)*s+1.. i*s ] ) ), UnionOfColumns );
+          XX := UnionOfColumns( List( [ 1 .. v ], i-> CertainRows( sol, [ (i-1)*s+1.. i*s ] ) ) );
        fi;
        
        return PresentationMorphism( Source( morphism_1 ), XX, Source( morphism_2 ) );
@@ -1934,7 +1886,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
     if NrColumns( A ) <= 1 then 
         vec := A_over_zero;
     else
-        vec := Iterated( List( [ 1 .. NrColumns( A ) ], i-> CertainColumns( A_over_zero, [ i ] ) ), UnionOfRows );
+        vec := UnionOfRows( List( [ 1 .. NrColumns( A ) ], i-> CertainColumns( A_over_zero, [ i ] ) ) );
     fi;
 
     sol := LeftDivide( mat, vec );
@@ -1952,7 +1904,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT,
        if s <= 1 then 
           XX := CertainRows( sol, [ 1.. v ] );
        else
-          XX := Iterated( List( [ 1 .. s ], i-> CertainRows( sol, [ (i-1)*v+1.. i*v ] ) ), UnionOfColumns );
+          XX := UnionOfColumns( List( [ 1 .. s ], i-> CertainRows( sol, [ (i-1)*v+1.. i*v ] ) ) );
        fi;
        
        return PresentationMorphism( Range( morphism_1 ), XX, Range( morphism_2 ) );
@@ -2026,7 +1978,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_RIGHT,
     
     zero_1  := HomalgZeroMatrix( NrRows( At )*NrColumns( At ), NrRows( Pt )*NrRows( Mt ), homalg_ring );
     
-    mat1 := UnionOfColumns( UnionOfColumns( B_tr_I, N_tr_I ), zero_1 );
+    mat1 := UnionOfColumns( B_tr_I, N_tr_I, zero_1 );
     
     I_P := KroneckerMat( HomalgIdentityMatrix( NrColumns( Mt ) ,homalg_ring ), Pt );
     
@@ -2034,7 +1986,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_RIGHT,
     
     M_tr_I := KroneckerMat( TransposedMatrix( Mt ), HomalgIdentityMatrix( NrRows( Pt ) ,homalg_ring ) );
     
-    mat2 := UnionOfColumns( UnionOfColumns( I_P, zero_2 ), M_tr_I );
+    mat2 := UnionOfColumns( I_P, zero_2, M_tr_I );
     
     mat := UnionOfRows( mat1, mat2 );
     
@@ -2044,7 +1996,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_RIGHT,
        
     else
        
-       vec_A := Iterated( List( [ 1 .. NrColumns( At ) ], i-> CertainColumns( At, [ i ] ) ), UnionOfRows ); 
+       vec_A := UnionOfRows( List( [ 1 .. NrColumns( At ) ], i-> CertainColumns( At, [ i ] ) ) );
        
     fi;
     
@@ -2063,7 +2015,7 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_RIGHT,
        if v <= 1 then
           XX := TransposedMatrix( CertainRows( sol, [ 1.. s ] ) );
        else
-          XX := TransposedMatrix( Iterated( List( [ 1 .. v ], i-> CertainRows( sol, [ (i-1)*s+1.. i*s ] ) ), UnionOfColumns ) );
+          XX := TransposedMatrix( UnionOfColumns( List( [ 1 .. v ], i-> CertainRows( sol, [ (i-1)*s+1.. i*s ] ) ) ) );
        fi;
        
        return PresentationMorphism( Source( morphism_1 ), XX, Source( morphism_2 ) );
@@ -2114,7 +2066,7 @@ end );
     if NrColumns( At ) <= 1 then 
         vec := A_over_zero;
     else
-        vec := Iterated( List( [ 1 .. NrColumns( At ) ], i-> CertainColumns( A_over_zero, [ i ] ) ), UnionOfRows );
+        vec := UnionOfRows( List( [ 1 .. NrColumns( At ) ], i-> CertainColumns( A_over_zero, [ i ] ) ) );
     fi;
 
     sol := LeftDivide( mat, vec );
@@ -2132,7 +2084,7 @@ end );
        if s <= 1 then 
           XX := TransposedMatrix( CertainRows( sol, [ 1.. v ] ) );
        else
-          XX := TransposedMatrix( Iterated( List( [ 1 .. s ], i-> CertainRows( sol, [ (i-1)*v+1.. i*v ] ) ), UnionOfColumns ) );
+          XX := TransposedMatrix( UnionOfColumns( List( [ 1 .. s ], i-> CertainRows( sol, [ (i-1)*v+1.. i*v ] ) ) ) );
        fi;
        
        return PresentationMorphism( Range( morphism_1 ), XX, Range( morphism_2 ) );

--- a/ToricSheaves/gap/GlobalSectionFunctors.gi
+++ b/ToricSheaves/gap/GlobalSectionFunctors.gi
@@ -12,7 +12,7 @@ InstallMethod( DegreeZeroPartFunctor,
                
   function( graded_module_category, localized_vars )
     local ring, degree_matrix_list, degree_matrix, degree_matrix_as_list_list, module_map, kernel_of_degree_map, localized_degree_zero_ring,
-          range_category, functor, object_function, morphism_function, i;
+          range_category, functor, object_function, morphism_function;
     
     ring := graded_module_category!.ring_for_representation_category;
     
@@ -27,11 +27,7 @@ InstallMethod( DegreeZeroPartFunctor,
         Error( "ring has no indeterminates" );
     fi;
     
-    degree_matrix := degree_matrix_list[ 1 ];
-    
-    for i in [ 2 .. Length( degree_matrix_list ) ] do
-        degree_matrix := UnionOfRows( degree_matrix, degree_matrix_list[ i ] );
-    od;
+    degree_matrix := UnionOfRows( degree_matrix_list );
     
     degree_matrix_as_list_list := EntriesOfHomalgMatrixAsListList( degree_matrix );
     
@@ -46,7 +42,7 @@ InstallMethod( DegreeZeroPartFunctor,
     functor := CapFunctor( Concatenation( "Degree zero functor localized by ", String( localized_vars ) ), graded_module_category, range_category );
     
     object_function := function( module )
-        local range_degrees, module_matrix, non_trivial_degrees, degree_positions, source_degrees, new_module;
+        local range_degrees, module_matrix, non_trivial_degrees, degree_positions, source_degrees, new_module, i;
         
         range_degrees := GeneratorDegrees( module );
         

--- a/ToricSheaves/gap/ToricSheaves.gi
+++ b/ToricSheaves/gap/ToricSheaves.gi
@@ -20,7 +20,7 @@ InstallMethod( CategoryOfToricSheaves,
                [ IsHomalgGradedRing, IsList, IsBool ],
                
   function( graded_ring, irrelevant_ideal_generators, comes_from_smooth_variety )
-    local degree_matrix_list, i, degree_matrix, degree_matrix_as_list_list, test_function, functor_list, presentation_category, serre_quotient_category;
+    local degree_matrix_list, degree_matrix, degree_matrix_as_list_list, test_function, functor_list, presentation_category, serre_quotient_category;
     
     degree_matrix_list := WeightsOfIndeterminates( graded_ring );
     
@@ -30,11 +30,7 @@ InstallMethod( CategoryOfToricSheaves,
         Error( "ring has no indeterminates" );
     fi;
     
-    degree_matrix := degree_matrix_list[ 1 ];
-    
-    for i in [ 2 .. Length( degree_matrix_list ) ] do
-        degree_matrix := UnionOfRows( degree_matrix, degree_matrix_list[ i ] );
-    od;
+    degree_matrix := UnionOfRows( degree_matrix_list );
     
     degree_matrix_as_list_list := EntriesOfHomalgMatrixAsListList( degree_matrix );
     


### PR DESCRIPTION
Applying UnionOfRows/Columns to lists instead of iteratively to pairs gives a small but noticeable performance improvement in case of large lists.

Some notes:
1. I wanted to replace all cases but noticed that lots of them are in examples. To save time I only replaced the cases occurring in actual code (with the exception of VectorSpacesAllMethods.gi because I started with this file).
2. Some occurrences are really weird: UnionOfRows/Columns is applied using `Iterated` to a list with two arguments. Do I miss something or was this unnecessary even before UnionOfRows/Columns was available for lists?
3. I really hope I did not make a mistake somewhere, fingers crossed.... :D