### PR TITLE
d&i CapCategorySwitchLogicPropagationOn/Off

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2020.05.01", ## Mohamed's version
+  "2020.05.02", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2020.04.15", ## Mohamed's version
+  "2020.05.01", ## Mohamed's version
   ## this line prevents merge conflicts
   "2015.04.01", ## Oystein's version
   ## this line prevents merge conflicts

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -257,6 +257,26 @@ DeclareAttribute( "RangeCategoryOfHomomorphismStructure",
 #############################################
 
 #! @Description
+#!  Activates the predicate logic propagation between equal objects for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationForObjectsOn" );
+
+#! @Description
+#!  Deactivates the predicate logic propagation between equal objects for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationForObjectsOff" );
+
+#! @Description
+#!  Activates the predicate logic propagation between equal morphisms for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationForMorphismsOn" );
+
+#! @Description
+#!  Deactivates the predicate logic propagation between equal morphisms for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationForMorphismsOff" );
+
+#! @Description
 #!  Activates the predicate logic propagation between equal cells for the category <A>C</A>.
 #! @Arguments C
 DeclareGlobalFunction( "CapCategorySwitchLogicPropagationOn" );

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -257,6 +257,16 @@ DeclareAttribute( "RangeCategoryOfHomomorphismStructure",
 #############################################
 
 #! @Description
+#!  Activates the predicate logic propagation between equal cells for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationOn" );
+
+#! @Description
+#!  Deactivates the predicate logic propagation between equal cells for the category <A>C</A>.
+#! @Arguments C
+DeclareGlobalFunction( "CapCategorySwitchLogicPropagationOff" );
+
+#! @Description
 #!  Activates the predicate implication logic for the category <A>C</A>.
 #! @Arguments C
 DeclareGlobalFunction( "CapCategorySwitchLogicOn" );
@@ -432,7 +442,7 @@ DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
 #!  In the following some of these are listed.
 #!    * <C>DeactivateCachingOfCategory</C> or <C>DeactivateDefaultCaching</C>: see <Ref Sect="Section_Caching" />.
 #!        This can either improve or degrade the performance depending on the concrete example.
-#!    * <C>CapCategorySwitchLogicOff</C>: see <Ref Sect="Section_Logic_switcher" />.
+#!    * <C>CapCategorySwitchLogicOff</C> (on by default) or <C>CapCategorySwitchLogicPropagationOff</C> (off by default): see <Ref Sect="Section_Logic_switcher" />.
 #!        This can either improve or degrade the performance depending on the concrete example.
 #!    * <C>DisableSanityChecks</C>: see <Ref Sect="Section_Sanity_checks" />.
 #!    * <C>DisableAddForCategoricalOperations</C>: see <Ref Sect="Section_Automatic_adds" />.

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -239,7 +239,8 @@ InstallGlobalFunction( "CREATE_CAP_CATEGORY_OBJECT",
     obj_rec!.input_sanity_check_level := 1;
     obj_rec!.output_sanity_check_level := 1;
     
-    obj_rec!.predicate_logic_propagation := false;
+    obj_rec!.predicate_logic_propagation_for_objects := false;
+    obj_rec!.predicate_logic_propagation_for_morphisms := false;
     
     obj_rec!.predicate_logic := true;
     
@@ -705,11 +706,44 @@ end );
 ##
 #######################################
 
+InstallGlobalFunction( CapCategorySwitchLogicPropagationForObjectsOn,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation_for_objects := true;
+    
+end );
+
+InstallGlobalFunction( CapCategorySwitchLogicPropagationForObjectsOff,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation_for_objects := false;
+    
+end );
+
+InstallGlobalFunction( CapCategorySwitchLogicPropagationForMorphismsOn,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation_for_morphisms := true;
+    
+end );
+
+InstallGlobalFunction( CapCategorySwitchLogicPropagationForMorphismsOff,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation_for_morphisms := false;
+    
+end );
+
 InstallGlobalFunction( CapCategorySwitchLogicPropagationOn,
   
   function( category )
     
-    category!.predicate_logic_propagation := true;
+    CapCategorySwitchLogicPropagationForObjectsOn( category );
+    CapCategorySwitchLogicPropagationForMorphismsOn( category );
     
 end );
 
@@ -717,7 +751,8 @@ InstallGlobalFunction( CapCategorySwitchLogicPropagationOff,
   
   function( category )
     
-    category!.predicate_logic_propagation := false;
+    CapCategorySwitchLogicPropagationForObjectsOff( category );
+    CapCategorySwitchLogicPropagationForMorphismsOff( category );
     
 end );
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -239,6 +239,8 @@ InstallGlobalFunction( "CREATE_CAP_CATEGORY_OBJECT",
     obj_rec!.input_sanity_check_level := 1;
     obj_rec!.output_sanity_check_level := 1;
     
+    obj_rec!.predicate_logic_propagation := false;
+    
     obj_rec!.predicate_logic := true;
     
     obj_rec!.add_primitive_output := false;
@@ -702,6 +704,22 @@ end );
 ## Logic
 ##
 #######################################
+
+InstallGlobalFunction( CapCategorySwitchLogicPropagationOn,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation := true;
+    
+end );
+
+InstallGlobalFunction( CapCategorySwitchLogicPropagationOff,
+  
+  function( category )
+    
+    category!.predicate_logic_propagation := false;
+    
+end );
 
 InstallGlobalFunction( CapCategorySwitchLogicOn,
   

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -994,7 +994,8 @@ IsCongruentForMorphisms := rec(
   
   post_function := function( morphism_1, morphism_2, return_value )
     
-    if CapCategory( morphism_1 )!.predicate_logic and return_value = true then
+    if CapCategory( morphism_1 )!.predicate_logic_propagation and
+       CapCategory( morphism_1 )!.predicate_logic and return_value = true then
           
           INSTALL_TODO_LIST_FOR_EQUAL_MORPHISMS( morphism_1, morphism_2 );
           
@@ -1106,7 +1107,8 @@ IsEqualForObjects := rec(
   
   post_function := function( object_1, object_2, return_value )
     
-    if CapCategory( object_1 )!.predicate_logic and return_value = true and not IsIdenticalObj( object_1, object_2 ) then
+    if CapCategory( object_1 )!.predicate_logic_propagation and
+       CapCategory( object_1 )!.predicate_logic and return_value = true and not IsIdenticalObj( object_1, object_2 ) then
         
         INSTALL_TODO_LIST_FOR_EQUAL_OBJECTS( object_1, object_2 );
         

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -994,7 +994,7 @@ IsCongruentForMorphisms := rec(
   
   post_function := function( morphism_1, morphism_2, return_value )
     
-    if CapCategory( morphism_1 )!.predicate_logic_propagation and
+    if CapCategory( morphism_1 )!.predicate_logic_propagation_for_morphisms and
        CapCategory( morphism_1 )!.predicate_logic and return_value = true then
           
           INSTALL_TODO_LIST_FOR_EQUAL_MORPHISMS( morphism_1, morphism_2 );
@@ -1107,7 +1107,7 @@ IsEqualForObjects := rec(
   
   post_function := function( object_1, object_2, return_value )
     
-    if CapCategory( object_1 )!.predicate_logic_propagation and
+    if CapCategory( object_1 )!.predicate_logic_propagation_for_objects and
        CapCategory( object_1 )!.predicate_logic and return_value = true and not IsIdenticalObj( object_1, object_2 ) then
         
         INSTALL_TODO_LIST_FOR_EQUAL_OBJECTS( object_1, object_2 );


### PR DESCRIPTION
This allows disabling INSTALL_TODO_LIST_FOR_EQUAL_OBJECTS/MORPHISMS
without switching off the logic entirely.