### PR TITLE
Implement Down-feature

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -310,6 +310,49 @@ DeclareOperation( "CheckConstructivenessOfCategory",
 DeclareProperty( "IsWellDefined",
                  IsCapCategoryCell );
 
+#############################################
+##
+#! @Section Unpacking data structures
+##
+#############################################
+
+
+#! @Description
+#! The argument is a GAP object $x$.
+#! If $x$ is an object in a CAP category, the output consists of data which are needed to reconstruct $x$
+#! (e.g., by passing them to an appropriate constructor).
+#! If $x$ is a morphism in a CAP category, the output consists of a triple whose first entry is the source of $x$,
+#! the third entry is the range of $x$, and the second entry consists of data which are needed to reconstruct $x$
+#! (e.g., by passing them to an appropriate constructor, possibly together with the source and range of $x$).
+#! @Returns a GAP object
+#! @Arguments x
+DeclareAttribute( "Down",
+                  IsObject );
+
+#! @Description
+#! The argument is a morphism in a CAP category, the output consists of data which are needed to reconstruct $x$
+#! (e.g., by passing it to an appropriate constructor, possibly together with its source and range).
+#! @Returns a GAP object
+#! @Arguments x
+DeclareAttribute( "DownOnlyMorphismData",
+                  IsCapCategoryMorphism );
+
+##
+DeclareAttribute( "Down2",
+                  IsObject );
+
+##
+DeclareAttribute( "Down3",
+                  IsObject );
+
+#! @Description
+#! The argument is a GAP object $x$.
+#! This function iteratively calls <C>Down</C> until it becomes stable.
+#! @Returns a GAP object
+#! @Arguments x
+DeclareAttribute( "DownToBottom",
+                  IsObject );
+
 ####################################
 ##
 #! @Section Caching

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -716,6 +716,76 @@ end );
 
 #######################################
 ##
+## Unpacking data structures
+##
+#######################################
+
+##
+InstallMethod( Down, [ IsObject ], IdFunc );
+
+##
+InstallMethod( Down2, [ IsObject ], x -> Down( Down( x ) ) );
+
+##
+InstallMethod( Down3, [ IsObject ], x -> Down( Down( Down( x ) ) ) );
+
+##
+InstallMethod( DownOnlyMorphismData, [ IsCapCategoryMorphism ], x -> "unknown morphism data" );
+
+##
+InstallMethod( Down,
+               [ IsCapCategoryMorphism ],
+  function( mor )
+    
+    return [ Source( mor ), DownOnlyMorphismData( mor ), Range( mor ) ];
+    
+end );
+
+##
+InstallMethod( Down,
+               [ IsList ],
+               
+  function( obj )
+    
+    return List( obj, Down );
+    
+end );
+
+##
+InstallMethod( DownToBottom,
+               [ IsObject ],
+               
+  function( obj )
+    local objp, equality_func;
+    
+    objp := obj;
+    
+    equality_func := function( a, b )
+      
+      if IsList( a ) and IsList( b ) and Size( a ) = Size( b ) then
+        
+        return ForAll( [ 1 .. Size( a ) ], i -> equality_func(a[i], b[i]) );
+        
+      else
+        
+        return IsIdenticalObj( a, b );
+        
+      fi;
+      
+    end;
+    
+    while not equality_func( objp, Down( objp ) ) do
+      
+      objp := Down( objp );
+      
+    od;
+    
+    return objp;
+    
+end );
+
+#######################################
+##
 ## ViewObj
 ##
 #######################################

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -724,6 +724,9 @@ end );
 InstallMethod( Down, [ IsObject ], IdFunc );
 
 ##
+InstallMethod( Down, [ IsCapCategoryObject ], x -> "unknown object data" );
+
+##
 InstallMethod( Down2, [ IsObject ], x -> Down( Down( x ) ) );
 
 ##

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -1282,3 +1282,19 @@ InstallMethod( Display,
     od;
     
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsAdditiveClosureObject ],
+               ObjectList );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsAdditiveClosureMorphism ],
+               MorphismMatrix );

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -1331,3 +1331,27 @@ InstallMethod( \/,
     return AsAdelmanCategoryMorphism( morphism );
     
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsAdelmanCategoryObject ],
+  function( obj )
+    
+    return [ RelationMorphism( obj ), CorelationMorphism( obj ) ];
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsAdelmanCategoryMorphism ],
+  function( mor )
+    
+    return MorphismDatum( mor );
+    
+end );

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -1194,3 +1194,27 @@ InstallMethod( \/,
 InstallMethod( \/,
                [ IsInt, IsCategoryOfColumns ],
                CategoryOfColumnsObject );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsCategoryOfColumnsObject ],
+  function( obj )
+    
+    return RankOfObject( obj );
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsCategoryOfColumnsMorphism ],
+  function( mor )
+    
+    return UnderlyingMatrix( mor );
+    
+end );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -1231,3 +1231,27 @@ InstallMethod( \/,
 InstallMethod( \/,
                [ IsInt, IsCategoryOfRows ],
                CategoryOfRowsObject );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsCategoryOfRowsObject ],
+  function( obj )
+    
+    return RankOfObject( obj );
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsCategoryOfRowsMorphism ],
+  function( mor )
+    
+    return UnderlyingMatrix( mor );
+    
+end );

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -917,3 +917,28 @@ InstallMethod( NaturalIsomorphismFromFinitePresentationOfCokernelImageClosureObj
     return natural_isomorphism;
     
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsCokernelImageClosureObject ],
+  function( obj )
+    
+    return [ GeneratorMorphism( obj ), RelationMorphism( obj ) ];
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsCokernelImageClosureMorphism ],
+  function( mor )
+    
+    return MorphismDatum( mor );
+    
+end );
+

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -1935,3 +1935,28 @@ InstallMethod( \/,
     return mat/UnderlyingCategory( freyd_category )/freyd_category;
     
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsFreydCategoryObject ],
+  function( obj )
+    
+    return RelationMorphism( obj );
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsFreydCategoryMorphism ],
+  function( mor )
+    
+    return MorphismDatum( mor );
+    
+end );
+

--- a/FreydCategoriesForCAP/gap/GroupsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/GroupsAsCats.gi
@@ -387,3 +387,27 @@ InstallMethod( \=,
 InstallMethod( \/,
                [ IsObject, IsGroupAsCategory ],
                GroupAsCategoryMorphism );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsGroupAsCategoryObject ],
+  function( obj )
+    
+    return "*";
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsGroupAsCategoryMorphism ],
+  function( mor )
+    
+    return UnderlyingGroupElement( mor );
+    
+end );

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -958,3 +958,27 @@ InstallMethod( \/,
         );
         
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsLinearClosureObject ],
+  function( obj )
+    
+    return UnderlyingOriginalObject( obj );
+    
+end );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsLinearClosureMorphism ],
+  function( mor )
+    
+    return [ CoefficientsList( mor ), SupportMorphisms( mor ) ];
+    
+end );

--- a/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
@@ -377,3 +377,23 @@ InstallMethod( ViewObj,
         Print( ViewString( obj ) );
 
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsProSetAsCategoryObject ],
+               UnderlyingInteger );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsProSetAsCategoryMorphism ],
+  function( mor )
+    
+    return "->";
+    
+end );

--- a/FreydCategoriesForCAP/gap/QuiverRows.gi
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gi
@@ -1543,3 +1543,18 @@ InstallMethod( \/,
                [ IsQuiverAlgebraElement, IsQuiverRowsCategory ],
                AsQuiverRowsMorphism );
 
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsQuiverRowsObject ],
+               ListOfQuiverVertices );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsQuiverRowsMorphism ],
+               MorphismMatrix );

--- a/FreydCategoriesForCAP/gap/Relations.gi
+++ b/FreydCategoriesForCAP/gap/Relations.gi
@@ -308,3 +308,23 @@ InstallMethod( \/,
     return PseudoInverse( mor/rel );
     
 end );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsRelCategoryObject ],
+               UnderlyingOriginalObject );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsRelCategoryMorphism ],
+  function( mor )
+    
+    return [ ReversedArrow( mor ), Arrow( mor ) ];
+    
+end );

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -266,3 +266,19 @@ InstallMethod( \=,
 InstallMethod( \/,
                [ IsObject, IsRingAsCategory ],
                RingAsCategoryMorphism );
+
+####################################
+##
+## Down
+##
+####################################
+
+##
+InstallMethod( Down,
+               [ IsRingAsCategoryObject ],
+               UnderlyingRing );
+
+##
+InstallMethod( DownOnlyMorphismData,
+               [ IsRingAsCategoryMorphism ],
+               UnderlyingRingElement );


### PR DESCRIPTION
I often encounter the situation that I have an object/morphism in some category and want to access its underlying defining data. Unfortunately, depending on the category, these data can have different names, e.g. `UnderlyingMatrix`, `UnderlyingOriginalObject`, `MorphismDatum`, etc.

This PR is an attempt to provide a convenience method for such situations.

I have only implemented it in some special cases since the capabilities of this new feature are of course open for discussion.