### PR TITLE
CoclosedMonoidal*

### DIFF
--- a/MonoidalCategories/doc/Doc.autodoc
+++ b/MonoidalCategories/doc/Doc.autodoc
@@ -13,3 +13,5 @@
 @Section Symmetric Closed Monoidal Categories
 
 @Section Rigid Symmetric Closed Monoidal Categories
+
+@Section Coclosed Monoidal Categories

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -534,3 +534,62 @@ DeclareOperation( "AddUniversalPropertyOfCoDual",
 
 DeclareOperation( "AddUniversalPropertyOfCoDual",
                   [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is a morphism $\alpha: a \rightarrow b$.
+#! The output is the corresponding morphism $ \mathrm{\underline{coHom}}(a,b) \rightarrow 1$
+#! under the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), 1 )$.
+#! @Arguments alpha
+DeclareAttribute( "CoLambdaIntroduction",
+                  IsCapCategoryMorphism );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoLambdaIntroduction</C>.
+#! $F: ( \alpha: a \rightarrow b ) \mapsto ( \mathrm{\underline{coHom}}(a,b) \rightarrow 1 )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoLambdaIntroduction",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoLambdaIntroduction",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoLambdaIntroduction",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoLambdaIntroduction",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The arguments are two objects $a,b$,
+#! and a morphism $\alpha: \mathrm{\underline{coHom}}(a,b) \rightarrow 1$.
+#! The output is a morphism $a \rightarrow b$ corresponding to $\alpha$
+#! under the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}(a,b)$.
+#! @Arguments a,b,alpha
+DeclareOperation( "CoLambdaElimination",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoLambdaElimination</C>.
+#! $F: ( a,b,\alpha: \mathrm{\underline{coHom}}(a,b) \rightarrow 1 ) \mapsto ( a \rightarrow b )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoLambdaElimination",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoLambdaElimination",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoLambdaElimination",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoLambdaElimination",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -10,9 +10,11 @@ DeclareGlobalVariable( "CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIO
 
 DeclareGlobalVariable( "COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD" );
 
-CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCoclosedMonoidalCategory  := Concatenation( [ 
+CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCoclosedMonoidalCategory  := Concatenation( [
 "InternalCoHomOnObjects",
 "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+"CoEvaluationMorphismWithGivenRange",
+"DualCoEvaluationMorphismWithGivenSource"
 ], CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsMonoidalCategory );
 
 ##
@@ -26,7 +28,7 @@ DeclareOperation( "InternalCoHomOnObjects",
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
-#! This operations adds the given function $F$ 
+#! This operations adds the given function $F$
 #! to the category for the basic operation <C>InternalCoHomOnObjects</C>.
 #! $F: (a,b) \mapsto \mathrm{\underline{coHom}}(a,b)$.
 #! @Returns nothing
@@ -65,7 +67,7 @@ DeclareOperation( "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
 
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
-#! This operations adds the given function $F$ 
+#! This operations adds the given function $F$
 #! to the category for the basic operation <C>InternalCoHomOnMorphismsWithGivenInternalCoHoms</C>.
 #! $F: (\mathrm{\underline{coHom}}(a,b'), \alpha: a \rightarrow a', \beta: b \rightarrow b', \mathrm{\underline{coHom}}(a',b) ) \mapsto \mathrm{\underline{coHom}}(\alpha,\beta)$.
 #! @Returns nothing
@@ -80,4 +82,82 @@ DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategory, IsList ] );
+
+## TODO: Find a better name!
+#! @Description
+#! The arguments are two objects $a, b$.
+#! The output is the coevaluation morphism $\mathrm{coev}_{a,b}: a \rightarrow b \otimes \mathrm{\underline{coHom}}(a,b)$, i.e.,
+#! the unit of the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( a, b \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! @Arguments a,b
+DeclareOperation( "CoEvaluationMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+## 3rd argument is $b \otimes \mathrm{\underline{coHom}}(a,b)$
+#! @Description
+#! The arguments are two objects $a,b$ and an object $r = b \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! The output is the coevaluation morphism $\mathrm{coev}_{a,b}: a \rightarrow b \otimes \mathrm{\underline{coHom}}(a,b)$, i.e.,
+#! the unit of the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( a, b \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! @Arguments a,b, r
+DeclareOperation( "CoEvaluationMorphismWithGivenRange",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoEvaluationMorphismWithGivenRange</C>.
+#! $F: (a, b, b \otimes \mathrm{\underline{coHom}}(a,b)) \mapsto \mathrm{coev}_{a,b}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoEvaluationMorphismWithGivenRange",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoEvaluationMorphismWithGivenRange",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoEvaluationMorphismWithGivenRange",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoEvaluationMorphismWithGivenRange",
+                  [ IsCapCategory, IsList ] );
+
+## TODO: Find a better name!
+#! @Description
+#! The arguments are two objects $a,b$.
+#! The output is the dual coevaluation morphism $\mathrm{dcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, a) \rightarrow b$, i.e.,
+#! the counit of the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, a), b )$.
+#! @Arguments a,b
+DeclareOperation( "DualCoEvaluationMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+## 3rd argument is $\mathrm{\underline{coHom}}(a \otimes b, a)$
+#! @Description
+#! The arguments are two objects $a,b$ and an object $s = \mathrm{\underline{coHom}(a \otimes b, a)}$.
+#! The output is the dual coevaluation morphism $\mathrm{dcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, a) \rightarrow b$, i.e.,
+#! the unit of the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, a), b )$.
+#! @Arguments a,b,s
+DeclareOperation( "DualCoEvaluationMorphismWithGivenSource",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>DualCoEvaluationMorphismWithGivenSource</C>.
+#! $F: (a, b, \mathrm{\underline{coHom}}(a \otimes b, a)) \mapsto \mathrm{dcoev}_{a,b}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
                   [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -503,3 +503,34 @@ DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
 
 DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
                   [ IsCapCategory, IsList ] );
+
+
+##
+#! @Description
+#! The arguments are two objects $a,t$,
+#! and a morphism $\alpha: 1 \rightarrow a \otimes t$.
+#! The output is the morphism $a_{\vee} \rightarrow t$
+#! given by the universal property of $a_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}(a_{\vee}, t)$.
+#! @Arguments a, t, alpha
+DeclareOperation( "UniversalPropertyOfCoDual",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>UniversalPropertyOfCoDual</C>.
+#! $F: ( a,t,\alpha: 1 \rightarrow a \otimes t ) \mapsto ( a^{\vee} \rightarrow t )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddUniversalPropertyOfCoDual",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddUniversalPropertyOfCoDual",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddUniversalPropertyOfCoDual",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddUniversalPropertyOfCoDual",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -161,3 +161,60 @@ DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
 
 DeclareOperation( "AddDualCoEvaluationMorphismWithGivenSource",
                   [ IsCapCategory, IsList ] );
+
+
+#! @Description
+#! The arguments are objects $a,b$ and a morphism $f: \mathrm{\underline{coHom}}(a,b) \rightarrow c$.
+#! The output is a morphism $g: a \rightarrow b \otimes c$ corresponding to $f$ under the
+#! cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}(a, b \otimes c)$.
+#! @Arguments a, b, f
+DeclareOperation( "InternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>InternalCoHomToTensorProductAdjunctionMap</C>.
+#! $F: (a, b, f: \mathrm{\underline{coHom}}(a,b) \rightarrow c) \mapsto ( g: a \rightarrow b \otimes c )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are objects $b,c$ and a morphism $g: a \rightarrow b \otimes c$.
+#! The output is a morphism $f: \mathrm{\underline{coHom}}(a,b) \rightarrow c$
+#! corresponding to $g$ under the cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), c )$.
+#! @Arguments b, c, g
+DeclareOperation( "TensorProductToInternalCoHomAdjunctionMap",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>TensorProductToInternalCoHomAdjunctionMap</C>.
+#! $F: (a, b, g: a \rightarrow b \otimes c) \mapsto ( f: \mathrm{\underline{coHom}}(a,b) \rightarrow c)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -445,3 +445,61 @@ DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
 
 DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
                   [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is the isomorphism
+#! $\mathrm{IsomorphismFromCoDualToInternalCoHom}_{a}: a_{\vee} \rightarrow \mathrm{\underline{coHom}}(1,a)$.
+#! @Returns a morphism in $\mathrm{Hom}(a_{\vee}, \mathrm{\underline{coHom}}(1,a))$.
+#! @Arguments a
+DeclareAttribute( "IsomorphismFromCoDualToInternalCoHom",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>IsomorphismFromCoDualToInternalCoHom</C>.
+#! $F: a \mapsto \mathrm{IsomorphismFromCoDualToInternalCoHom}_{a}$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsomorphismFromCoDualToInternalCoHom",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromCoDualToInternalCoHom",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromCoDualToInternalCoHom",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromCoDualToInternalCoHom",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is the isomorphism
+#! $\mathrm{IsomorphismFromInternalCoHomToCoDual}_{a}: \mathrm{\underline{coHom}}(1,a) \rightarrow a_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}(\mathrm{\underline{coHom}}(1,a), a_{\vee})$.
+#! @Arguments a
+DeclareAttribute( "IsomorphismFromInternalCoHomToCoDual",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>IsomorphismFromInternalCoHomToCoDual</C>.
+#! $F: a \mapsto \mathrm{IsomorphismFromInternalCoHomToCoDual}_{a}$
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToCoDual",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -448,6 +448,128 @@ DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
 
 ##
 #! @Description
+#! The arguments are four objects $a, a', b, b'$.
+#! The output is the natural morphism
+#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a \otimes a', b \otimes b') \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b')$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes a', b \otimes b'), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b'))$.
+#! @Arguments a,a',b,b'
+DeclareOperation( "InternalCoHomTensorProductCompatibilityMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+##
+## The new_source and new_range arguments are the first and second element of the list.
+## This construction is due to the fact that the maximal number of arguments for an operation is 6,
+## but a basic operation with 6 arguments would install a setter having 7 arguments.
+#! @Description
+#! The arguments are four objects $a, a', b, b'$,
+#! and a list $L = [ \mathrm{\underline{coHom}}(a \otimes a', b \otimes b'), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b') ]$.
+#! The output is the natural morphism
+#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a \otimes a', b \otimes b') \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b')$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes a', b \otimes b'), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b') )$.
+#! @Arguments a,a',b,b',L
+DeclareOperation( "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects</C>.
+#! $F: ( a,a',b,b', [ \mathrm{\underline{coHom}}(a \otimes a', b \otimes b'), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b') ]) \mapsto \mathrm{InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects}_{a,a',b,b'}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The arguments are two objects $a,b$.
+#! The output is the natural morphism
+#! $\mathrm{CoDualityTensorProductCompatibilityMorphismWithGivenObjects}: (a \otimes b)_{\vee} \rightarrow a_{\vee} \otimes b_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( (a \otimes b)_{\vee}, a_{\vee} \otimes b_{\vee} )$.
+#! @Arguments a,b
+DeclareOperation( "CoDualityTensorProductCompatibilityMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are an object $s = (a \otimes b)_{\vee}$,
+#! two objects $a,b$,
+#! and an object $r = a_{\vee} \otimes b_{\vee}$.
+#! The output is the natural morphism
+#! $\mathrm{CoDualityTensorProductCompatibilityMorphismWithGivenObjects}_{a,b}: (a \otimes b)_{\vee} \rightarrow a_{\vee} \otimes b_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( (a \otimes b)_{\vee}, a_{\vee} \otimes b_{\vee} )$.
+#! @Arguments s,a,b,r
+DeclareOperation( "CoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoDualityTensorProductCompatibilityMorphismWithGivenObjects</C>.
+#! $F: ( (a \otimes b)_{\vee}, a, b, a_{\vee} \otimes b_{\vee} ) \mapsto \mathrm{CoDualityTensorProductCompatibilityMorphismWithGivenObjects}_{a,b}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+
+##
+#! @Description
+#! The arguments are two objects $a,b$.
+#! The output is the natural morphism $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow a \otimes b_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), a \otimes b_{\vee} )$.
+#! @Arguments a,b
+DeclareOperation( "MorphismFromInternalCoHomToTensorProduct",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are an object $s = \mathrm{\underline{coHom}}(a,b)$,
+#! two objects $a,b$,
+#! and an object $r = a \otimes b_{\vee}$.
+#! The output is the natural morphism $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow a \otimes b_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), a \otimes b_{\vee} )$.
+#! @Arguments s,a,b,r
+DeclareOperation( "MorphismFromInternalCoHomToTensorProductWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>MorphismFromInternalCoHomToTensorProductWithGivenObjects</C>.
+#! $F: ( \mathrm{\underline{coHom}}(a,b), a, b, a \otimes b_{\vee} ) \mapsto \mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddMorphismFromInternalCoHomToTensorProductWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddMorphismFromInternalCoHomToTensorProductWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddMorphismFromInternalCoHomToTensorProductWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddMorphismFromInternalCoHomToTensorProductWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
 #! The argument is an object $a$.
 #! The output is the isomorphism
 #! $\mathrm{IsomorphismFromCoDualToInternalCoHom}_{a}: a_{\vee} \rightarrow \mathrm{\underline{coHom}}(1,a)$.
@@ -592,4 +714,78 @@ DeclareOperation( "AddCoLambdaElimination",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddCoLambdaElimination",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is the natural isomorphism $a \rightarrow \mathrm{\underline{coHom}}(a,1)$.
+#! @Returns a morphism in $\mathrm{Hom}(a, \mathrm{\underline{coHom}}(a,1))$.
+#! @Arguments a
+DeclareAttribute( "IsomorphismFromObjectToInternalCoHom",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The argument is an object $a$,
+#! and an object $r = \mathrm{\underline{coHom}}(a,1)$.
+#! The output is the natural isomorphism $a \rightarrow \mathrm{\underline{coHom}}(a,1)$.
+#! @Returns a morphism in $\mathrm{Hom}(a, \mathrm{\underline{coHom}}(a,1))$.
+#! @Arguments a,r
+DeclareOperation( "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom</C>.
+#! $F: ( a, \mathrm{\underline{coHom}}(a,1) ) \mapsto ( a \rightarrow \mathrm{\underline{coHom}}(a,1) )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is the natural isomorphism $\mathrm{\underline{coHom}}(a,1) \rightarrow a$.
+#! @Returns a morphism in $\mathrm{Hom}(\mathrm{\underline{coHom}}(a,1), a)$.
+#! @Arguments a
+DeclareAttribute( "IsomorphismFromInternalCoHomToObject",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The argument is an object $a$,
+#! and an object $s = \mathrm{\underline{Hom}}(1,a)$.
+#! The output is the natural isomorphism $\mathrm{\underline{coHom}}(a,1) \rightarrow a$.
+#! @Returns a morphism in $\mathrm{Hom}(\mathrm{\underline{coHom}}(a,1), a)$.
+#! @Arguments a,s
+DeclareOperation( "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom</C>.
+#! $F: ( a, \mathrm{\underline{coHom}}(a,1) ) \mapsto ( \mathrm{\underline{coHom}}(a,1) \rightarrow a )$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
                   [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -1,0 +1,83 @@
+####################################
+##
+#! @Chapter Monoidal Categories
+##
+#! @Section Coclosed Monoidal Categories
+##
+####################################
+
+DeclareGlobalVariable( "CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS" );
+
+DeclareGlobalVariable( "COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD" );
+
+CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCoclosedMonoidalCategory  := Concatenation( [ 
+"InternalCoHomOnObjects",
+"InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+], CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsMonoidalCategory );
+
+##
+#! @Description
+#! The arguments are two objects $a,b$.
+#! The output is the internal cohom object $\mathrm{\underline{coHom}}(a,b)$.
+#! @Returns an object
+#! @Arguments a, b
+DeclareOperation( "InternalCoHomOnObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>InternalCoHomOnObjects</C>.
+#! $F: (a,b) \mapsto \mathrm{\underline{coHom}}(a,b)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInternalCoHomOnObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInternalCoHomOnObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomOnObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomOnObjects",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are two morphisms $\alpha: a \rightarrow a', \beta: b \rightarrow b'$.
+#! The output is the internal cohom morphism
+#! $\mathrm{\underline{coHom}}(\alpha,\beta): \mathrm{\underline{coHom}}(a,b') \rightarrow \mathrm{\underline{coHom}}(a',b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b'), \mathrm{\underline{coHom}}(a',b) )$
+#! @Arguments alpha, beta
+DeclareOperation( "InternalCoHomOnMorphisms",
+                  [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
+
+#! @Description
+#! The arguments are an object $s = \mathrm{\underline{coHom}}(a,b')$,
+#! two morphisms $\alpha: a \rightarrow a', \beta: b \rightarrow b'$,
+#! and an object $r = \mathrm{\underline{coHom}}(a',b)$.
+#! The output is the internal cohom morphism
+#! $\mathrm{\underline{coHom}}(\alpha,\beta): \mathrm{\underline{coHom}}(a,b') \rightarrow \mathrm{\underline{coHom}}(a',b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b'), \mathrm{\underline{coHom}}(a',b) )$
+#! @Arguments s, alpha, beta, r
+DeclareOperation( "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$ 
+#! to the category for the basic operation <C>InternalCoHomOnMorphismsWithGivenInternalCoHoms</C>.
+#! $F: (\mathrm{\underline{coHom}}(a,b'), \alpha: a \rightarrow a', \beta: b \rightarrow b', \mathrm{\underline{coHom}}(a',b) ) \mapsto \mathrm{\underline{coHom}}(\alpha,\beta)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInternalCoHomOnMorphismsWithGivenInternalCoHoms",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -218,3 +218,230 @@ DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
 
 DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
                   [ IsCapCategory, IsList ] );
+
+
+##
+#! @Description
+#! The arguments are three objects $a,b,c$.
+#! The output is the precocomposition morphism
+#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
+#! @Arguments a,b,c
+DeclareOperation( "MonoidalPreCoComposeMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are
+#! an object $s = \mathrm{\underline{coHom}}(a,c)$,
+#! three objects $a,b,c$,
+#! and an object $r = \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
+#! The output is the precocomposition morphism
+#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
+#! @Arguments s,a,b,c,r
+DeclareOperation( "MonoidalPreCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>MonoidalPreCoComposeMorphismWithGivenObjects</C>.
+#! $F: (\mathrm{\underline{coHom}}(a,c),a,b,c,\mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)) \mapsto \mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddMonoidalPreCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddMonoidalPreCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddMonoidalPreCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddMonoidalPreCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+
+##
+#! @Description
+#! The arguments are three objects $a,b,c$.
+#! The output is the postcocomposition morphism
+#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! @Arguments a,b,c
+DeclareOperation( "MonoidalPostCoComposeMorphism",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are
+#! an object $s = \mathrm{\underline{coHom}}(a,c)$,
+#! three objects $a,b,c$,
+#! and an object $r = \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! The output is the postcocomposition morphism
+#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! @Arguments s,a,b,c,r
+DeclareOperation( "MonoidalPostCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>MonoidalPostCoComposeMorphismWithGivenObjects</C>.
+#! $F: (\mathrm{\underline{coHom}}(a,c),a,b,c,\mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)) \mapsto \mathrm{MonoidalPostComposeMorphismWithGivenObjects}_{a,b,c}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddMonoidalPostCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddMonoidalPostCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddMonoidalPostCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddMonoidalPostCoComposeMorphismWithGivenObjects",
+                  [ IsCapCategory, IsList ] );
+
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is its codual object $a_{\vee}$.
+#! @Returns an object
+#! @Arguments a
+DeclareAttribute( "CoDualOnObjects",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoDualOnObjects</C>.
+#! $F: a \mapsto a_{\vee}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoDualOnObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoDualOnObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoDualOnObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoDualOnObjects",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is a morphism $\alpha: a \rightarrow b$.
+#! The output is its codual morphism $\alpha_{\vee}: b_{\vee} \rightarrow a_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( b_{\vee}, a_{\vee} )$.
+#! @Arguments alpha
+DeclareAttribute( "CoDualOnMorphisms",
+                  IsCapCategoryMorphism );
+
+#! @Description
+#! The argument is an object $s = b_{\vee}$,
+#! a morphism $\alpha: a \rightarrow b$,
+#! and an object $r = a_{\vee}$.
+#! The output is the dual morphism $\alpha_{\vee}: b^{\vee} \rightarrow a^{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( b_{\vee}, a_{\vee} )$.
+#! @Arguments s,alpha,r
+DeclareOperation( "CoDualOnMorphismsWithGivenCoDuals",
+                  [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoDualOnMorphismsWithGivenCoDuals</C>.
+#! $F: (b_{\vee},\alpha,a_{\vee}) \mapsto \alpha_{\vee}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoDualOnMorphismsWithGivenCoDuals",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoDualOnMorphismsWithGivenCoDuals",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoDualOnMorphismsWithGivenCoDuals",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoDualOnMorphismsWithGivenCoDuals",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is an object $a$.
+#! The output is the coevaluation morphism $\mathrm{coev}_{a}: 1 \rightarrow a \otimes a_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( 1, a \otimes a_{\vee} )$.
+#! @Arguments a
+DeclareAttribute( "CoEvaluationForCoDual",
+                  IsCapCategoryObject );
+
+
+#! @Description
+#! The arguments are an object $s = 1$,
+#! an object $a$,
+#! and an object $r = a \otimes a_{\vee}$.
+#! The output is the coevaluation morphism $\mathrm{coev}_{a}: 1 \rightarrow a \otimes a_{\vee}$.
+#! @Returns a morphism in $\mathrm{Hom}( 1, a \otimes a_{\vee} )$.
+#! @Arguments s,a,r
+DeclareOperation( "CoEvaluationForCoDualWithGivenTensorProduct",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>CoEvaluationForCoDualWithGivenTensorProduct</C>.
+#! $F: (1, a, a \otimes a_{vee}) \mapsto \mathrm{coev}_{a}$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddCoEvaluationForCoDualWithGivenTensorProduct",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddCoEvaluationForCoDualWithGivenTensorProduct",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddCoEvaluationForCoDualWithGivenTensorProduct",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddCoEvaluationForCoDualWithGivenTensorProduct",
+                  [ IsCapCategory, IsList ] );
+
+##
+#! @Description
+#! The argument is a cobidual object $(a_{\vee})_{\vee}$.
+#! The output is the morphism from the cobidual $(a_{\vee})_{\vee} \rightarrow a$.
+#! @Returns a morphism in $\mathrm{Hom}((a_{\vee})_{\vee}, a)$.
+#! @Arguments avv
+DeclareAttribute( "MorphismFromCoBidual",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The arguments are an object $s = (a_{\vee})_{\vee}$,
+#! and an object $a$.
+#! The output is the morphism from the cobidual $(a_{\vee})_{\vee} \rightarrow a$.
+#! @Returns a morphism in $\mathrm{Hom}((a_{\vee})_{\vee}, a)$.
+#! @Arguments s, a
+DeclareOperation( "MorphismFromCoBidualWithGivenCoBidual",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operations adds the given function $F$
+#! to the category for the basic operation <C>MorphismFromCoBidualWithGivenCoBidual</C>.
+#! $F: ((a_{\vee})_{\vee}, a) \mapsto ((a_{\vee})_{\vee} \rightarrow a)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddMorphismFromCoBidualWithGivenCoBidual",
+                  [ IsCapCategory, IsList ] );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -33,7 +33,7 @@ InstallMethod( CoEvaluationMorphism,
              object_1, object_2,
              TensorProductOnObjects( object_2, InternalCoHomOnObjects( object_1, object_2 ) )
            );
-    
+
 end );
 
 ##

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -1,21 +1,57 @@
 InstallValue( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS, rec( ) );
 
 ##
-CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.InternalCoHomOnMorphisms := 
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.InternalCoHomOnMorphisms :=
   [ [ "InternalCoHomOnMorphismsWithGivenInternalCoHoms", 1 ],
     [ "InternalCoHomOnObjects", 2 ] ];
 ##
 InstallMethod( InternalCoHomOnMorphisms,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
-               
+
   function( morphism_1, morphism_2 )
-    
-    return InternalCoHomOnMorphismsWithGivenInternalCoHoms( 
+
+    return InternalCoHomOnMorphismsWithGivenInternalCoHoms(
              InternalCoHomOnObjects( Source( morphism_1 ), Range( morphism_2 ) ),
              morphism_1, morphism_2,
              InternalCoHomOnObjects( Range( morphism_1 ), Source( morphism_2 ) )
            );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.CoEvaluationMorphism :=
+  [ [ "CoEvaluationMorphismWithGivenRange", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "InternalCoHomOnObjects", 1 ] ];
+##
+InstallMethod( CoEvaluationMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2 )
+
+    return CoEvaluationMorphismWithGivenRange(
+             object_1, object_2,
+             TensorProductOnObjects( object_2, InternalCoHomOnObjects( object_1, object_2 ) )
+           );
     
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.DualCoEvaluationMorphism :=
+  [ [ "DualCoEvaluationMorphismWithGivenSource", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "InternalCoHomOnObjects", 1 ] ];
+##
+InstallMethod( DualCoEvaluationMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2 )
+
+    return DualCoEvaluationMorphismWithGivenSource(
+             object_1, object_2,
+             InternalCoHomOnObjects( TensorProductOnObjects( object_1, object_2 ), object_1 )
+           );
+
 end );
 
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -54,4 +54,97 @@ InstallMethod( DualCoEvaluationMorphism,
 
 end );
 
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.MonoidalPreCoComposeMorphism :=
+  [ [ "MonoidalPreCoComposeMorphismWithGivenObjects", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "InternalCoHomOnObjects", 3 ] ];
+##
+InstallMethod( MonoidalPreCoComposeMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2, object_3 )
+
+    return MonoidalPreCoComposeMorphismWithGivenObjects(
+             InternalCoHomOnObjects( object_1, object_3 ),
+             object_1, object_2, object_3,
+             TensorProductOnObjects( InternalCoHomOnObjects( object_1, object_2 ), InternalCoHomOnObjects( object_2, object_3 ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.MonoidalPostCoComposeMorphism :=
+  [ [ "MonoidalPostCoComposeMorphismWithGivenObjects", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "InternalCoHomOnObjects", 3 ] ];
+##
+InstallMethod( MonoidalPostCoComposeMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2, object_3 )
+
+    return MonoidalPostCoComposeMorphismWithGivenObjects(
+             InternalCoHomOnObjects( object_1, object_3 ),
+             object_1, object_2, object_3,
+             TensorProductOnObjects( InternalCoHomOnObjects( object_2, object_3 ), InternalCoHomOnObjects( object_1, object_2 ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.CoDualOnMorphisms :=
+  [ [ "CoDualOnMorphismsWithGivenCoDuals", 1 ],
+    [ "CoDualOnObjects", 2 ] ];
+##
+InstallMethod( CoDualOnMorphisms,
+               [ IsCapCategoryMorphism ],
+
+  function( morphism )
+
+    return CoDualOnMorphismsWithGivenCoDuals(
+             CoDualOnObjects( Range( morphism ) ),
+             morphism,
+             CoDualOnObjects( Source( morphism ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.CoEvaluationForCoDual :=
+  [ [ "CoEvaluationForCoDualWithGivenTensorProduct", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "CoDualOnObjects", 1 ],
+    [ "TensorUnit", 1 ] ];
+##
+InstallMethod( CoEvaluationForCoDual,
+               [ IsCapCategoryObject ],
+
+  function( object )
+    local category;
+
+    category := CapCategory( object );
+
+    return CoEvaluationForCoDualWithGivenTensorProduct(
+             TensorUnit( category ),
+             object,
+             TensorProductOnObjects( object, CoDualOnObjects( object ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.MorphismFromCoBidual :=
+  [ [ "MorphismFromCoBidualWithGivenCoBidual", 1 ],
+    [ "CoDualOnObjects", 2 ] ];
+##
+InstallMethod( MorphismFromCoBidual,
+               [ IsCapCategoryObject ],
+
+  function( object )
+
+    return MorphismFromCoBidualWithGivenCoBidual( CoDualOnObjects( CoDualOnObjects( object ) ), object );
+
+end );
+
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -147,4 +147,118 @@ InstallMethod( MorphismFromCoBidual,
 
 end );
 
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.InternalCoHomTensorProductCompatibilityMorphism :=
+  [ [ "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects", 1 ],
+    [ "TensorProductOnObjects", 3 ],
+    [ "InternalCoHomOnObjects", 3 ] ];
+##
+InstallMethod( InternalCoHomTensorProductCompatibilityMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1_1, object_1_2, object_2_1, object_2_2 )
+
+    return InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects(
+             object_1_1, object_1_2, object_2_1, object_2_2,
+             [ InternalCoHomOnObjects( TensorProductOnObjects( object_1_1, object_1_2 ), TensorProductOnObjects( object_2_1, object_2_2 ) ),
+               TensorProductOnObjects( InternalCoHomOnObjects( object_1_1, object_2_1 ), InternalCoHomOnObjects( object_1_2, object_2_2 ) ) ]
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.CoDualityTensorProductCompatibilityMorphism :=
+  [ [ "CoDualityTensorProductCompatibilityMorphismWithGivenObjects", 1 ],
+    [ "CoDualOnObjects", 3 ],
+    [ "TensorProductOnObjects", 2 ] ];
+##
+InstallMethod( CoDualityTensorProductCompatibilityMorphism,
+               [ IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2 )
+
+    return CoDualityTensorProductCompatibilityMorphismWithGivenObjects(
+             CoDualOnObjects( TensorProductOnObjects( object_1, object_2 ) ),
+             object_1, object_2,
+             TensorProductOnObjects( CoDualOnObjects( object_1 ), CoDualOnObjects( object_2 ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.MorphismFromInternalCoHomToTensorProduct :=
+  [ [ "MorphismFromInternalCoHomToTensorProductWithGivenObjects", 1 ],
+    [ "CoDualOnObjects", 1 ],
+    [ "TensorProductOnObjects", 1 ],
+    [ "InternalCoHomOnObjects", 1 ] ];
+##
+InstallMethod( MorphismFromInternalCoHomToTensorProduct,
+               [ IsCapCategoryObject, IsCapCategoryObject ],
+
+  function( object_1, object_2 )
+
+    return MorphismFromInternalCoHomToTensorProductWithGivenObjects(
+             InternalCoHomOnObjects( object_1, object_2 ),
+             object_1, object_2,
+             TensorProductOnObjects( object_1, CoDualOnObjects( object_2 ) )
+           );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.IsomorphismFromInternalCoHomToObject :=
+  [ [ "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom", 1 ],
+    [ "TensorUnit", 1 ],
+    [ "InternalCoHomOnObjects", 1 ] ];
+##
+InstallMethod( IsomorphismFromInternalCoHomToObject,
+               [ IsCapCategoryObject ],
+
+  function( object )
+    local category;
+
+    category := CapCategory( object );
+
+    return IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom( object, InternalCoHomOnObjects( object, TensorUnit( category ) ) );
+
+end );
+
+##
+InstallMethod( IsomorphismFromInternalCoHomToObject,
+               [ IsCapCategoryObject and IsCellOfSkeletalCategory ],
+
+  function( object )
+
+    return IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom( object, object );
+
+end );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.IsomorphismFromObjectToInternalCoHom :=
+  [ [ "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom", 1 ],
+    [ "TensorUnit", 1 ],
+    [ "InternalCoHomOnObjects", 1 ] ];
+##
+InstallMethod( IsomorphismFromObjectToInternalCoHom,
+               [ IsCapCategoryObject ],
+
+  function( object )
+    local category;
+
+    category := CapCategory( object );
+
+    return IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom( object, InternalCoHomOnObjects( object, TensorUnit( category ) ) );
+
+end );
+
+##
+InstallMethod( IsomorphismFromObjectToInternalCoHom,
+               [ IsCapCategoryObject and IsCellOfSkeletalCategory ],
+
+  function( object )
+
+    return IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom( object, object );
+
+end );
+
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -1,0 +1,21 @@
+InstallValue( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS, rec( ) );
+
+##
+CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS.InternalCoHomOnMorphisms := 
+  [ [ "InternalCoHomOnMorphismsWithGivenInternalCoHoms", 1 ],
+    [ "InternalCoHomOnObjects", 2 ] ];
+##
+InstallMethod( InternalCoHomOnMorphisms,
+               [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
+               
+  function( morphism_1, morphism_2 )
+    
+    return InternalCoHomOnMorphismsWithGivenInternalCoHoms( 
+             InternalCoHomOnObjects( Source( morphism_1 ), Range( morphism_2 ) ),
+             morphism_1, morphism_2,
+             InternalCoHomOnObjects( Range( morphism_1 ), Source( morphism_2 ) )
+           );
+    
+end );
+
+CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD( CAP_INTERNAL_COCLOSED_MONOIDAL_CATEGORIES_BASIC_OPERATIONS );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
@@ -1,0 +1,53 @@
+####################################
+## Final derived methods
+####################################
+
+## Final methods for CoDual
+AddFinalDerivation( IsomorphismFromCoDualToInternalCoHom,
+                    [ [ IdentityMorphism, 1 ],
+                      [ InternalCoHomOnObjects, 1 ],
+                      [ TensorUnit, 1 ] ],
+                    [ CoDualOnObjects,
+                      CoDualOnMorphismsWithGivenCoDuals,
+                      MorphismFromCoBidualWithGivenCoBidual,
+                      IsomorphismFromCoDualToInternalCoHom,
+                      IsomorphismFromInternalCoHomToCoDual,
+                      UniversalPropertyOfCoDual,
+                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
+                      CoEvaluationForCoDualWithGivenTensorProduct,
+                      MorphismFromInternalCoHomToTensorProductWithGivenObjects
+                      ],
+  function( object )
+    local category;
+
+    category := CapCategory( object );
+
+    return IdentityMorphism( InternalCoHomOnObjects( TensorUnit( category ), object ) );
+
+end : CategoryFilter := IsCoclosedMonoidalCategory,
+      Description := "IsomorphismFromCoDualToInternalCoHom as the identity of coHom(1,a)" );
+
+AddFinalDerivation( IsomorphismFromInternalCoHomToCoDual,
+                    [ [ IdentityMorphism, 1 ],
+                      [ InternalCoHomOnObjects, 1 ],
+                      [ TensorUnit, 1 ] ],
+                    [ CoDualOnObjects,
+                      CoDualOnMorphismsWithGivenCoDuals,
+                      MorphismFromCoBidualWithGivenCoBidual,
+                      IsomorphismFromCoDualToInternalCoHom,
+                      IsomorphismFromInternalCoHomToCoDual,
+                      UniversalPropertyOfCoDual,
+                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
+                      CoEvaluationForCoDualWithGivenTensorProduct,
+                      MorphismFromInternalCoHomToTensorProductWithGivenObjects
+                      ],
+
+  function( object )
+    local category;
+
+    category := CapCategory( object );
+
+    return IdentityMorphism( InternalCoHomOnObjects( TensorUnit( category ), object ) );
+
+end : CategoryFilter := IsCoclosedMonoidalCategory,
+      Description := "IsomorphismFromInternalCoHomToCoDual as the identity of coHom(1,a)" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDoc.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDoc.gd
@@ -1,0 +1,19 @@
+####################################
+##
+#! @Chapter Monoidal Categories
+##
+#! @Section Coclosed Monoidal Categories
+##
+####################################
+
+#! A monoidal category $\mathbf{C}$
+#! which has for each functor $b \otimes -: \mathbf{C} \rightarrow \mathbf{C}$
+#! a left adjoint (denoted by $\mathrm{\underline{coHom}}(-,b)$)
+#! is called a <Emph>coclosed monoidal category</Emph>.
+
+#! The corresponding GAP property is called
+#! <C>IsCoclosedMonoidalCategory</C>.
+
+AddCategoricalProperty( [ "IsCoclosedMonoidalCategory" ] );
+
+InstallTrueMethod( IsMonoidalCategory, IsCoclosedMonoidalCategory );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -28,6 +28,22 @@ DualCoEvaluationMorphismWithGivenSource := rec(
   cache_name := "DualCoEvaluationMorphismWithGivenSource",
   return_type := "morphism" ),
 
+InternalCoHomToTensorProductAdjunctionMap := rec(
+  installation_name := "InternalCoHomToTensorProductAdjunctionMap",
+  filter_list := [ "object", "object", "morphism" ],
+  io_type := [ [ "a", "b", "f" ], [ "a", "t" ] ],
+  cache_name := "InternalCoHomToTensorProductAdjunctionMap",
+  return_type := "morphism",
+  no_with_given := true ),
+
+TensorProductToInternalCoHomAdjunctionMap := rec(
+  installation_name := "TensorProductToInternalCoHomAdjunctionMap",
+  filter_list := [ "object", "object", "morphism" ],
+  io_type := [ [ "b", "c", "g" ], [ "i", "c" ] ],
+  cache_name := "TensorProductToInternalCoHomAdjunctionMap",
+  return_type := "morphism",
+  no_with_given := true ),
+
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -14,6 +14,20 @@ InternalCoHomOnMorphismsWithGivenInternalCoHoms := rec(
   cache_name := "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
   return_type := "morphism" ),
 
+CoEvaluationMorphismWithGivenRange := rec(
+  installation_name := "CoEvaluationMorphismWithGivenRange",
+  filter_list := [ "object", "object", "object" ],
+  io_type := [ [ "a", "b", "r" ], [ "a", "r" ] ],
+  cache_name := "CoEvaluationMorphismWithGivenRange",
+  return_type := "morphism" ),
+
+DualCoEvaluationMorphismWithGivenSource := rec(
+  installation_name := "DualCoEvaluationMorphismWithGivenSource",
+  filter_list := [ "object", "object", "object" ],
+  io_type := [ [ "a", "b", "s" ], [ "s", "b" ] ],
+  cache_name := "DualCoEvaluationMorphismWithGivenSource",
+  return_type := "morphism" ),
+
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -1,0 +1,21 @@
+InstallValue( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD, rec(
+
+InternalCoHomOnObjects := rec(
+  installation_name := "InternalCoHomOnObjects",
+  filter_list := [ "object", "object" ],
+  io_type := [ [ "a", "b" ], [ "i" ] ],
+  cache_name := "InternalCoHomOnObjects",
+  return_type := "object" ),
+
+InternalCoHomOnMorphismsWithGivenInternalCoHoms := rec(
+  installation_name := "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+  filter_list := [ "object", "morphism", "morphism", "object" ],
+  io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
+  cache_name := "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+  return_type := "morphism" ),
+
+) );
+
+CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );
+
+CAP_INTERNAL_INSTALL_ADDS_FROM_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -44,6 +44,47 @@ TensorProductToInternalCoHomAdjunctionMap := rec(
   return_type := "morphism",
   no_with_given := true ),
 
+MonoidalPreCoComposeMorphismWithGivenObjects := rec(
+  installation_name := "MonoidalPreCoComposeMorphismWithGivenObjects",
+  filter_list := [ "object", "object", "object", "object", "object" ],
+  io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
+  cache_name := "MonoidalPreCoComposeMorphismWithGivenObjects",
+  return_type := "morphism" ),
+
+MonoidalPostCoComposeMorphismWithGivenObjects := rec(
+  installation_name := "MonoidalPostCoComposeMorphismWithGivenObjects",
+  filter_list := [ "object", "object", "object", "object", "object" ],
+  io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
+  cache_name := "MonoidalPostCoComposeMorphismWithGivenObjects",
+  return_type := "morphism" ),
+
+CoDualOnObjects := rec(
+  installation_name := "CoDualOnObjects",
+  filter_list := [ "object" ],
+  io_type := [ [ "a" ], [ "acd" ] ],
+  cache_name := "CoDualOnObjects",
+  return_type := "object" ),
+
+CoDualOnMorphismsWithGivenCoDuals := rec(
+  installation_name := "CoDualOnMorphismsWithGivenCoDuals",
+  io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
+  filter_list := [ "object", "morphism", "object" ],
+  cache_name := "CoDualOnMorphismsWithGivenCoDuals",
+  return_type := "morphism" ),
+
+CoEvaluationForCoDualWithGivenTensorProduct := rec(
+  installation_name := "CoEvaluationForCoDualWithGivenTensorProduct",
+  filter_list := [ "object", "object", "object" ],
+  io_type := [ [ "s", "a", "r" ], [ "s", "r" ] ],
+  cache_name := "CoEvaluationForCoDualWithGivenTensorProduct",
+  return_type := "morphism" ),
+
+MorphismFromCoBidualWithGivenCoBidual := rec(
+  installation_name := "MorphismFromCoBidualWithGivenCoBidual",
+  filter_list := [ "object", "object" ],
+  io_type := [ [ "s", "a" ], [ "s", "a" ] ],
+  cache_name := "MorphismFromCoBidualWithGivenCoBidual",
+  return_type := "morphism" ),
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -85,6 +85,22 @@ MorphismFromCoBidualWithGivenCoBidual := rec(
   io_type := [ [ "s", "a" ], [ "s", "a" ] ],
   cache_name := "MorphismFromCoBidualWithGivenCoBidual",
   return_type := "morphism" ),
+
+IsomorphismFromCoDualToInternalCoHom := rec(
+  installation_name := "IsomorphismFromCoDualToInternalCoHom",
+  filter_list := [ "object" ],
+  io_type := [ [ "a" ], [ "i", "d" ] ],
+  cache_name := "IsomorphismFromCoDualToInternalCoHom",
+  return_type := "morphism",
+  no_with_given := true ),
+
+IsomorphismFromInternalCoHomToCoDual := rec(
+  installation_name := "IsomorphismFromInternalCoHomToCoDual",
+  filter_list := [ "object" ],
+  io_type := [ [ "a" ], [ "d", "i" ] ],
+  cache_name := "IsomorphismFromInternalCoHomToCoDual",
+  return_type := "morphism",
+  no_with_given := true ),
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -109,6 +109,22 @@ UniversalPropertyOfCoDual := rec(
   cache_name := "UniversalPropertyOfCoDual",
   return_type := "morphism",
   no_with_given := true ),
+
+CoLambdaIntroduction := rec(
+  installation_name := "CoLambdaIntroduction",
+  filter_list := [ "morphism" ],
+  io_type := [ [ "alpha" ], [ "u", "i" ] ],
+  cache_name := "CoLambdaIntroduction",
+  return_type := "morphism",
+  no_with_given := true ),
+
+CoLambdaElimination := rec(
+  installation_name := "CoLambdaElimination",
+  filter_list := [ "object", "object", "morphism" ],
+  io_type := [ [ "a", "b", "alpha" ], [ "a", "b" ] ],
+  cache_name := "CoLambdaElimination",
+  return_type := "morphism",
+  no_with_given := true ),
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -86,6 +86,27 @@ MorphismFromCoBidualWithGivenCoBidual := rec(
   cache_name := "MorphismFromCoBidualWithGivenCoBidual",
   return_type := "morphism" ),
 
+InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects := rec(
+  installation_name := "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+  filter_list := [ "object", "object", "object", "object", IsList ],
+  io_type := [ [ "a", "ap", "b", "bp", "L" ], [ "L_1", "L_2" ] ],
+  cache_name := "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+  return_type := "morphism" ),
+
+CoDualityTensorProductCompatibilityMorphismWithGivenObjects := rec(
+  installation_name := "CoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+  filter_list := [ "object", "object", "object", "object" ],
+  io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
+  cache_name := "CoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+  return_type := "morphism" ),
+
+MorphismFromInternalCoHomToTensorProductWithGivenObjects := rec(
+  installation_name := "MorphismFromInternalCoHomToTensorProductWithGivenObjects",
+  filter_list := [ "object", "object", "object", "object" ],
+  io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
+  cache_name := "MorphismFromInternalCoHomToTensorProductWithGivenObjects",
+  return_type := "morphism" ),
+
 IsomorphismFromCoDualToInternalCoHom := rec(
   installation_name := "IsomorphismFromCoDualToInternalCoHom",
   filter_list := [ "object" ],
@@ -125,6 +146,21 @@ CoLambdaElimination := rec(
   cache_name := "CoLambdaElimination",
   return_type := "morphism",
   no_with_given := true ),
+
+IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom := rec(
+  installation_name := "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+  filter_list := [ "object", "object" ],
+  io_type := [ [ "a", "r" ], [ "a", "r" ] ],
+  cache_name := "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+  return_type := "morphism" ),
+
+IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom := rec(
+  installation_name := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+  filter_list := [ "object", "object" ],
+  io_type := [ [ "a", "s" ], [ "s", "a" ] ],
+  cache_name := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+  return_type := "morphism" ),
+
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -101,6 +101,14 @@ IsomorphismFromInternalCoHomToCoDual := rec(
   cache_name := "IsomorphismFromInternalCoHomToCoDual",
   return_type := "morphism",
   no_with_given := true ),
+
+UniversalPropertyOfCoDual := rec(
+  installation_name := "UniversalPropertyOfCoDual",
+  filter_list := [ "object", "object", "morphism" ],
+  io_type := [ [ "a", "t", "alpha" ], [ "d", "t" ] ],
+  cache_name := "UniversalPropertyOfCoDual",
+  return_type := "morphism",
+  no_with_given := true ),
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/init.g
+++ b/MonoidalCategories/init.g
@@ -24,3 +24,12 @@ ReadPackage( "MonoidalCategories", "gap/SymmetricClosedMonoidalCategoriesDoc.gd"
 
 ReadPackage( "MonoidalCategories", "gap/RigidSymmetricClosedMonoidalCategoriesDoc.gd" );
 ReadPackage( "MonoidalCategories", "gap/RigidSymmetricClosedMonoidalCategories.gd" );
+
+## Coclosed Monoidal
+ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategoriesDoc.gd" );
+ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategories.gd" );
+
+ReadPackage( "MonoidalCategories", "gap/SymmetricCoclosedMonoidalCategoriesDoc.gd" );
+
+ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategoriesDoc.gd" );
+ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategories.gd" );

--- a/MonoidalCategories/makedoc.g
+++ b/MonoidalCategories/makedoc.g
@@ -29,6 +29,8 @@ AutoDoc(
                                 "gap/SymmetricClosedMonoidalCategoriesDoc.gd",
                                 "gap/RigidSymmetricClosedMonoidalCategoriesDoc.gd",
                                 "gap/RigidSymmetricClosedMonoidalCategories.gd",
+                                "gap/CoclosedMonoidalCategoriesDoc.gd",
+                                "gap/CoclosedMonoidalCategories.gd",
                                 ],
                             scan_dirs := [ ],
                             ),

--- a/MonoidalCategories/read.g
+++ b/MonoidalCategories/read.g
@@ -24,6 +24,13 @@ ReadPackage( "MonoidalCategories", "gap/ClosedMonoidalCategories.gi" );
 ReadPackage( "MonoidalCategories", "gap/RigidSymmetricClosedMonoidalCategoriesMethodRecord.gi" );
 ReadPackage( "MonoidalCategories", "gap/RigidSymmetricClosedMonoidalCategories.gi" );
 
+## Coclosed Monoidal
+ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategoriesMethodRecord.gi" );
+ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategories.gi" );
+
+ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategoriesMethodRecord.gi" );
+ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategories.gi" );
+
 ## Derived Methods
 ReadPackage( "MonoidalCategories", "gap/MonoidalCategoriesDerivedMethods.gi" );
 ReadPackage( "MonoidalCategories", "gap/AdditiveMonoidalCategoriesDerivedMethods.gi" );
@@ -33,3 +40,7 @@ ReadPackage( "MonoidalCategories", "gap/SymmetricMonoidalCategoriesDerivedMethod
 ReadPackage( "MonoidalCategories", "gap/ClosedMonoidalCategoriesDerivedMethods.gi" );
 ReadPackage( "MonoidalCategories", "gap/SymmetricClosedMonoidalCategoriesDerivedMethods.gi" );
 ReadPackage( "MonoidalCategories", "gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi" );
+
+ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategoriesDerivedMethods.gi" );
+ReadPackage( "MonoidalCategories", "gap/SymmetricCoclosedMonoidalCategoriesDerivedMethods.gi" );
+ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi" );


### PR DESCRIPTION
As discussed in https://github.com/homalg-project/CAP_project/pull/510 here is the first part.

- In my thesis the unit and counit of the cohom-tensor adjunctions are called "coclosed evaluation" and "coclosed coevaluation". However, initially I called them `CoEvaluation` and `DualCoEvaluation`, which is certainly bad but I couldn't come up with something better. This will change later via https://github.com/TKuh/CAP_project/commit/316798cd1b0c79f2d71b7a51b0465e952e6e491d. 

- You should probably look closely at `*MethodRecord.gi`, especially the `io_type`. I couldn't find any information about it and mostly guessed its meaning. :/

