### PR TITLE
Add convenience for Freyd cats

### DIFF
--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -69,7 +69,7 @@ UniversalMorphismIntoDirectSum( [ pr3, pr2 ] );;
 inj1 := InjectionOfCofactorOfDirectSum( [ Z2, Z2, Z2 ], 1 );;
 inj2 := InjectionOfCofactorOfDirectSum( [ Z2, Z2, Z2 ], 2 );;
 UniversalMorphismFromDirectSum( [ inj2, inj1 ] );;
-ZFree := AsFreydCategoryObject( obj1 );;
+ZFree := obj1/freyd;;
 id := IdentityMorphism( ZFree );;
 z := id + id;;
 CokernelProjection( z );;

--- a/FreydCategoriesForCAP/gap/FreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gd
@@ -56,6 +56,9 @@ DeclareAttribute( "EmbeddingFunctorIntoFreydCategory",
                   IsCapCategory );
 
 DeclareOperation( "\/",
+                  [ IsCapCategoryObject, IsFreydCategory ] );
+
+DeclareOperation( "\/",
                   [ IsCapCategoryMorphism, IsFreydCategory ] );
 
 DeclareOperation( "\/",

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -1936,6 +1936,22 @@ InstallMethod( \/,
     
 end );
 
+##
+InstallMethod( \/,
+               [ IsCapCategoryObject, IsFreydCategory ],
+               
+  function( obj, freyd_category )
+    
+    if not IsIdenticalObj( UnderlyingCategory( freyd_category ), CapCategory( obj ) ) then
+      
+      Error( "The underlying category of the given Freyd category has to be equal to the category of the given object" );
+      
+    fi;
+    
+    return AsFreydCategoryObject( obj );
+    
+end );
+
 ####################################
 ##
 ## Down


### PR DESCRIPTION
The case of interpreting a given object as a projective object in the Freyd category was missing, and I didn't see a reason not to install it.