### PR TITLE
use HomalgIdentityMatrix in BasisOfExternalHom

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -15,7 +15,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2019.11.02", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.05.16", ## Mohamed's version
+  "2020.05.17", ## Mohamed's version
   ## this line prevents merge conflicts
   "2019.08.07", ## Fabian's version
   ## this line prevents merge conflicts

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -660,6 +660,31 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
     if is_defined_over_field then
       
       ##
+      AddBasisOfExternalHom( category,
+        function( S, T )
+          local s, t, identity, matrices;
+          
+          s := RankOfObject( S );
+          
+          t := RankOfObject( T );
+          
+          identity := HomalgIdentityMatrix( s * t, UnderlyingRing( CapCategory( S ) ) );
+          
+          matrices := List( [ 1 .. s * t ], i -> ConvertColumnToMatrix( CertainColumns( identity, [ i ] ), t, s ) );
+          
+          return List( matrices, mat -> CategoryOfColumnsMorphism( S, mat, T ) );
+          
+      end );
+      
+      ##
+      AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( category,
+        function( morphism, L )
+          
+          return EntriesOfHomalgMatrix( TransposedMatrix( UnderlyingMatrix( morphism ) ) );
+          
+      end );
+      
+      ##
       AddKernelObject( category,
         function( morphism )
           local homalg_matrix;

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -700,6 +700,31 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
     if is_defined_over_field then
       
       ##
+      AddBasisOfExternalHom( category,
+        function( S, T )
+          local s, t, identity, matrices;
+          
+          s := RankOfObject( S );
+          
+          t := RankOfObject( T );
+          
+          identity := HomalgIdentityMatrix( s * t, UnderlyingRing( CapCategory( S ) ) );
+          
+          matrices := List( [ 1 .. s * t ], i -> ConvertRowToMatrix( CertainRows( identity, [ i ] ), s, t ) );
+          
+          return List( matrices, mat -> CategoryOfRowsMorphism( S, mat, T ) );
+          
+      end );
+      
+      ##
+      AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( category,
+        function( morphism, L )
+          
+          return EntriesOfHomalgMatrix( UnderlyingMatrix( morphism ) );
+          
+      end );
+      
+      ##
       AddKernelObject( category,
         function( morphism )
           local homalg_matrix;

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -13,7 +13,7 @@ PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
 
 Version := Maximum( [
-  "2020.05.16", ## Mohamed's version
+  "2020.05.17", ## Mohamed's version
   ## this line prevents merge conflicts
   "2017.12.30", ## Sebas' version
   ## this line prevents merge conflicts

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -875,18 +875,18 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
    
     ##
     AddBasisOfExternalHom( category,
-      function( object_1, object_2 )
-        local dim_1, dim_2, identity, matrices;
+      function( S, T )
+        local s, t, identity, matrices;
         
-        dim_1 := Dimension( object_1 );
+        s := Dimension( S );
         
-        dim_2 := Dimension( object_2 );
+        t := Dimension( T );
         
-        identity := IdentityMat( dim_1 * dim_2 );
+        identity := HomalgIdentityMatrix( s * t, UnderlyingFieldForHomalg( S ) );
         
-        matrices := List( identity, row -> HomalgMatrix( row, dim_1, dim_2, homalg_field ) );
+        matrices := List( [ 1 .. s * t ], i -> ConvertRowToMatrix( CertainRows( identity, [ i ] ), s, t ) );
         
-        return List( matrices, mat -> VectorSpaceMorphism( object_1, mat, object_2 ) );
+        return List( matrices, mat -> VectorSpaceMorphism( S, mat, T ) );
         
     end );
     


### PR DESCRIPTION
this code
* avoids data transfer when working with external rings
* activates the logic, especially when the source is the distinguished object;
  pre-composing alpha with the i-th basis morphism automatically translates into
  CertainRows( UnderlyingMatrix( alpha ), [ i ] )

This resulted in a measurable speedup in computations of BasisOfExternalHom
in FunctorCategories