### PR TITLE
Add CompilerForCAP

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -13,7 +13,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.04.16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.04.27", ## Fabian's version
+  "2020.06.17", ## Fabian's version
   ## this line prevents merge conflicts
   "2020.01.10", ## Kamal's version
 ] ),
@@ -105,7 +105,9 @@ Dependencies := rec(
                            [ "ToolsForHomalg", ">= 2018.05.22" ],
                            [ "io", ">=0" ],
   ],
-  SuggestedOtherPackages := [ [ "Browse", ">=0" ] ],
+  SuggestedOtherPackages := [ [ "Browse", ">=0" ],
+                              [ "CompilerForCAP", ">= 2020.06.17" ],
+  ],
   ExternalConditions := []
 
 ),

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -500,11 +500,21 @@ InstallMethod( CreateCapCategory,
                [ IsString ],
                
   function( name )
-    local overhead, is_computable, category;
+    local overhead, is_computable, enable_compilation, category;
     
     overhead := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "overhead", true );
     
     is_computable := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "is_computable", true );
+
+    enable_compilation := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "enable_compilation", false );
+
+    if enable_compilation <> false and not IsPackageMarkedForLoading( "CompilerForCAP", ">= 2020.06.17" ) then
+        
+        Display( "WARNING: Package CompilerForCAP is not loaded, so compilation will not be enabled." );
+        
+        enable_compilation := false;
+        
+    fi;
     
     category := rec( );
     
@@ -513,6 +523,10 @@ InstallMethod( CreateCapCategory,
     category!.overhead := overhead;
     
     category!.is_computable := is_computable;
+
+    category!.enable_compilation := enable_compilation;
+
+    category!.compiled_functions := rec( );
     
     CREATE_CAP_CATEGORY_FILTERS( category );
     

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -37,7 +37,7 @@ InstallGlobalFunction( CAP_INTERNAL_CREATE_Cat,
                
   function(  )
     
-    InstallValue( CapCat, rec( caching_info := rec( ), overhead := true, is_computable := true ) );
+    InstallValue( CapCat, rec( caching_info := rec( ), overhead := true, is_computable := true, enable_compilation := false, compiled_functions := rec( ) ) );
     
     CREATE_CAP_CATEGORY_OBJECT( CapCat, [ [ "Name", "Cat" ] ] );
     

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -288,6 +288,7 @@ InstallGlobalFunction( ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes,
                        
   function( morphism, category, source, range, additional_arguments_list... )
     local arg_list, objectified_morphism;
+    #% CAP_JIT_RESOLVE_FUNCTION
     
     arg_list := Concatenation( 
         [ morphism, category!.morphism_type, CapCategory, category, Source, source, Range, range ], additional_arguments_list
@@ -533,6 +534,7 @@ InstallMethod( HomomorphismStructureOnMorphisms,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
                
   function( alpha, beta )
+    #% CAP_JIT_RESOLVE_FUNCTION
     
     return HomomorphismStructureOnMorphismsWithGivenObjects(
              HomomorphismStructureOnObjects( Range( alpha ), Source( beta ) ),

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -231,10 +231,14 @@ InstallMethod( RandomObject, [ IsCapCategory, IsList ], RandomObjectByList );
 
 InstallGlobalFunction( ObjectifyObjectForCAPWithAttributes,
                        
-  function( arg_list... )
+  function( object, category, additional_arguments_list... )
+    local arg_list;
+    #% CAP_JIT_RESOLVE_FUNCTION
     
-    Append( arg_list, [ CapCategory, arg_list[ 2 ] ] );
-    arg_list[ 2 ] := arg_list[ 2 ]!.object_type;
+    arg_list := Concatenation(
+        [ object, category!.object_type, CapCategory, category ], additional_arguments_list
+    );
+    
     return CallFuncList( ObjectifyWithAttributes, arg_list );
     
 end );

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1597,13 +1597,9 @@ AddDerivationToCAP( MorphismBetweenDirectSums,
     
     diagram_direct_sum_range := List( morphism_matrix[1], entry -> Range( entry ) );
     
-    test_diagram_coproduct := [ ];
-    
-    for test_diagram_product in morphism_matrix do
-      
-      Add( test_diagram_coproduct, UniversalMorphismIntoDirectSumWithGivenDirectSum( diagram_direct_sum_range, test_diagram_product, T ) );
-      
-    od;
+    test_diagram_coproduct := List( morphism_matrix,
+        test_diagram_product -> UniversalMorphismIntoDirectSumWithGivenDirectSum( diagram_direct_sum_range, test_diagram_product, T )
+    );
     
     return UniversalMorphismFromDirectSumWithGivenDirectSum( diagram_direct_sum_source, test_diagram_coproduct, S );
     

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -372,6 +372,7 @@ InstallMethod( MorphismBetweenDirectSums,
                
   function( morphism_matrix )
     local nr_rows, nr_cols;
+    #% CAP_JIT_RESOLVE_FUNCTION
     
     nr_rows := Size( morphism_matrix );
     

--- a/CompilerForCAP/.gitignore
+++ b/CompilerForCAP/.gitignore
@@ -1,0 +1,1 @@
+/tst/compilerforcap*.tst

--- a/CompilerForCAP/COPYING
+++ b/CompilerForCAP/COPYING
@@ -1,0 +1,293 @@
+The CompilerForCAP package is free software; you can redistribute and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+The CompilerForCAP package is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+Version 2 of the GNU General Public License follows.
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -1,0 +1,86 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# This file contains package meta data. For additional information on
+# the meaning and correct usage of these fields, please consult the
+# manual of the "Example" package as well as the comments in its
+# PackageInfo.g file.
+#
+SetPackageInfo( rec(
+
+PackageName := "CompilerForCAP",
+Subtitle := "This package allows to \"compile\" the code of CAP categories.",
+Version := Maximum( [
+  "2020.06.17", ## Fabian's version
+  ## this line prevents merge conflicts
+] ),
+Date := ~.Version{[ 1 .. 10 ]},
+Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+License := "GPL-2.0-or-later",
+
+Persons := [
+  rec(
+    FirstNames := "Fabian",
+    LastName := "Zickgraf",
+    WWWHome := "https://github.com/zickgraf/",
+    Email := "fabian.zickgraf@uni-siegen.de",
+    IsAuthor := true,
+    IsMaintainer := true,
+    PostalAddress := Concatenation(
+               "Walter-Flex-Straße 3\n",
+               "57068 Siegen\n",
+               "Germany" ),
+    Place := "Siegen",
+    Institution := "University of Siegen",
+  ),
+],
+
+#SourceRepository := rec( Type := "TODO", URL := "URL" ),
+#IssueTrackerURL := "TODO",
+PackageWWWHome := "http://homalg-project.github.io/CAP_project/",
+PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+README_URL     := Concatenation( ~.PackageWWWHome, "README.md" ),
+ArchiveURL     := Concatenation( ~.PackageWWWHome,
+                                 "/", ~.PackageName, "-", ~.Version ),
+
+ArchiveFormats := ".tar.gz",
+
+##  Status information. Currently the following cases are recognized:
+##    "accepted"      for successfully refereed packages
+##    "submitted"     for packages submitted for the refereeing
+##    "deposited"     for packages for which the GAP developers agreed
+##                    to distribute them with the core GAP system
+##    "dev"           for development versions of packages
+##    "other"         for all other packages
+##
+Status := "dev",
+
+AbstractHTML   :=  "",
+
+PackageDoc := rec(
+  BookName  := "CompilerForCAP",
+  ArchiveURLSubset := ["doc"],
+  HTMLStart := "doc/chap0.html",
+  PDFFile   := "doc/manual.pdf",
+  SixFile   := "doc/manual.six",
+  LongTitle := "This package allows to \"compile\" the code of CAP categories.",
+),
+
+Dependencies := rec(
+  GAP := ">= 4.11",
+  NeededOtherPackages := [
+      [ "CAP", ">= 2020.06.17" ],
+  ],
+  SuggestedOtherPackages := [ ],
+  ExternalConditions := [ ],
+),
+
+AvailabilityTest := ReturnTrue,
+
+TestFile := "tst/testall.g",
+
+#Keywords := [ "TODO" ],
+
+));
+
+

--- a/CompilerForCAP/README.md
+++ b/CompilerForCAP/README.md
@@ -1,0 +1,5 @@
+# The GAP package CompilerForCAP
+
+This package allows to "compile" the code of CAP categories.
+
+**WARNING**: This package is still in alpha and not tested or validated extensively!

--- a/CompilerForCAP/TODO
+++ b/CompilerForCAP/TODO
@@ -1,0 +1,14 @@
+Speed:
+
+* reduce number of calls to `StructuralCopy`
+* get value of all expression from jit args only once
+* logic templates per category?
+* drop unused variables completely (instead of marking them with _UNUSED_)
+
+Features:
+
+* list expressions for logic templates
+* do not inline variables but only a reference to them for the logic to use
+* support for KeyDependentOperation
+* support compilation of operations
+* support assigning a variable multiple times, at least in different if branches

--- a/CompilerForCAP/doc/Doc.autodoc
+++ b/CompilerForCAP/doc/Doc.autodoc
@@ -1,0 +1,174 @@
+@Chapter Using the compiler
+
+**WARNING**: This package is still in alpha and not tested or validated extensively!
+
+@Section Terminology
+
+The compiler is a just-in-time compiler, that is, it needs some arguments to infer types of variables. These arguments
+are refered to as __JIT arguments__. For a given CAP operation, these are usually the arguments of the first
+call of the operation.
+
+The compiler uses GAP's syntax trees for optimizing functions. The term __tree__ always refers to the syntax tree of
+the function to be compiled. Note that a node of the tree always knows its children, so technically it is also a tree.
+That is, the terms __tree__, __subtree__, and __node__ technically describe the same thing but we use them for different
+emphases.
+
+We often replace a node in the tree by another tree representing the "value" of the original node. Examples:
+* Replace a global variable referencing an integer, a string, or a boolean by EXPR_INT, EXPR_STRING, EXPR_TRUE or EXPR_FALSE.
+* Replace a global variable referencing a plain function by the syntax tree of this function.
+* Replace a record access of a global function by the value of this record access.
+* Replace an operation by a concrete method.
+We call this __resolving__ the global variable, operation, etc. Note that this does not change the basic "layout" of the tree.
+
+On the contrary, in the following examples we change the "layout" of the tree:
+* If we have a function call of a resolved function, we can assign the argument values to local variables at the
+    beginning of the function. This way we can avoid passing arguments completely.
+* If a function call of a resolved function occurs in the right hand side of a variable assignment, we can insert the body of the
+    resolved function right before the variable assignment. This way we can avoid the function call.
+* We can replace all references to a local variable by the right hand side of the variable assignment and then drop the assignment.
+We call this __inlining__ the function arguments, functions, or variable assignments.
+
+@Section Capabilities of the compiler
+
+The compilation process has two phases: the resolving phase and the rule phase.
+
+During the resolving phase, operations and global variables are resolved:
+* An operation is resolved by executing the function to be compiled with the JIT arguments to determine the arguments of the operation.
+  These arguments are used to call `ApplicableMethod`, and methods annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION` are resolved.
+* CAP operations are handled separately: instead of using `ApplicableMethod`, the functions added to the category via `Add` functions
+  are considered, and those do not have to be annotated with `CAP_JIT_RESOLVE_FUNCTION`. In particular, caching, pre functions, etc.
+  are bypassed.
+* References to global functions are resolved if the function is annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION`.
+For details see <Ref Func="CapJitResolvedOperations" /> and <Ref Func="CapJitResolvedGlobalVariables" />.
+If no operation or global variable can be resolved anymore, we continue with the rule phase.
+
+In the rule phase, the tree is optimized using several rules and techniques. Function arguments, functions, and assignments to local
+variables are inlined. Unused variables are dropped. Handled edge cases are dropped, that is, if the same edge case is caught multiple times
+via `if condition then return ...; fi;` statements, only the first such statement is kept. Finally, "logic" is applied to the tree.
+For example, calls of `CallFuncList` are replaced by calls to the actual function. The logic can be extended by the user, see chapter
+<Ref Chap="Chapter_ImprovingAndExtendingTheCompiler" />.
+
+For all details, see the list of compilations steps in <Ref Sect="Section_CompilationSteps" />.
+
+@Section Requirements
+
+There are three main requirements for the steps described above to be correct:
+* The code must not depend on side effects (otherwise dropping "unused" variables or inlining variables could change results).
+  See <Ref Func="CapJitThrowErrorOnSideEffects" /> for details.
+* The methods selected for the operations during the resolving phase must be independent of the JIT arguments, that is,
+  they must yield correct results for all allowed arguments of the function to be compiled. Thus, be careful which methods
+  you annotate with `CAP_JIT_RESOLVE_FUNCTION`. In particular, the CAP categories of objects and morphisms appearing during the
+  execution must be independent of the JIT arguments.
+* All results of applications of filters in logic templates must be independent of the JIT arguments.
+  Thus, be careful when adding new logic templates.
+
+There is an additional weak requirement: The compiler mainly optimizes the code paths covered when executing the function with the
+JIT arguments. Thus, the JIT arguments should represent a "generic" call, i.e., they should not run into edge cases which do not happen
+with a "generic" call. Still, the execution using JIT arguments should be fast to improve compilation times.
+
+@Section Activating the compiler
+
+You can activate the compiler by passing the option `enable_compilation` to any category constructor.
+If `enable_compilation` is set to `true`, any basic operation will be compiled when called for the first time.
+If `enable_compilation` is a list of strings, compilation will only happen if the function name
+of the basic operation appears in this list.
+
+@Section Stopping the compiler at a certain level
+
+You can use `StopCompilationAtCategory` to prevent the compiler from inlining and optimizing code of a given category.
+You can revert this decision using `ContinueCompilationAtCategory`.
+
+@Section Getting information about the compilation process
+
+You can increase the info level of `InfoCapJit` to get information about the compilation process.
+
+@Section Compiling a function manually
+
+Use <Ref Func="CapJitCompiledFunction" /> to compile a function `func` with JIT arguments `jit_args`.
+`jit_args` should represent a "generic" call, i.e., they should not run into edge cases which do not happen with a "generic" call.
+Still, the execution using `jit_args` should be fast to improve compilation times.
+
+@Section FAQ
+
+* Q: Why is my function not resolved?
+A: Only functions annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION` are resolved. Additionally, a function can only be resolved
+if it appears as a global variable in the tree during the resolving phase of the compilation. That is, it must be referenced from
+a global variable from the beginning on, or after global variables are resolved by <Ref Func="CapJitResolvedGlobalVariables" />.
+Possibly you have adapt <Ref Func="CapJitResolvedGlobalVariables" /> to your setting.
+
+* Q: Why is my operation not resolved?
+A: The compiler must be able to get the arguments of the call of the operation from the JIT arguments.
+Then the rules in the description of <Ref Func="CapJitResolvedOperations" /> apply.
+
+* Q: Why do I get the error "cannot find iteration key"?
+A: For each syntax tree node type, the tree iterator has to know which record names it should use for continuing the iteration.
+Please add the missing keys to `CAP_INTERNAL_JIT_ITERATION_KEYS`.
+
+* Q: Why do I get the error "tree has no kown type" when calling <Ref Func="CapJitPrettyPrintSyntaxTree" />?
+A: <Ref Func="CapJitPrettyPrintSyntaxTree" /> needs to handle every syntax tree node type separately.
+Please add the missing type to <Ref Func="CapJitPrettyPrintSyntaxTree" />.
+
+* Q: Why is do I get the error "a local variable with name &lt;name&gt; is assigned more than once (not as a part of a rapid reassignment),
+  this is not supported"?
+A: For reasons of correctness, variables cannot be inlined if a variable is assigned more than once in the body of a function
+(this includes function arguments which are assigned at least once, namely when the function is called). An exception is made for
+"rapid reassignments": if the same variable is assigned and then reassigned immediately in the next statement, this only counts
+as a single assignment.
+
+* Q: Why do I get one of the following errors: "tree includes statements or expressions which indicate possible side effects",
+  "tree contains an assignment of a higher variable with initial name &lt;name&gt;, this is not supported", or
+  "tree contains for loop over non-local variable, this is not supported" ?
+A: We can only drop unused variables, inline variables, etc. if we assume that the code contains no side effects. Statements like
+STAT_PROCCALL or assignment to higher variables cause (or at least indicate) side effects, so continuing with the compilation
+would probably not lead to a correct result.
+
+@Chapter Improving and extending the compiler
+@ChapterLabel ImprovingAndExtendingTheCompiler
+
+The easiest way to extend the compiler is by adding more logic to it, see <Ref Sect="Section_Logic" />. For writing logic functions
+you also have to iterate over enhanced syntax trees, see <Ref Sect="Section_EnhancedSyntaxTrees" /> and <Ref Sect="Section_IterateOverTree" />.
+You might also want to use available tools, see <Ref Sect="Section_Tools" />. If you want to improve an existing compilation step or add
+a completely new one, see <Ref Sect="Section_CompilationSteps" />.
+
+For debugging you can:
+* use <Ref Func="CapJitPrettyPrintSyntaxTree" />,
+* set `debug` to `true` in <Ref Func="CapJitCompiledFunction" /> (Note: this causes informational break loops which are not actual errors),
+* use the `debug` and `debug_path` record entries of logic templates (see <Ref Func="CapJitAddLogicTemplate" />).
+
+@Section Logic
+@SectionLabel Logic
+
+@Section Enhanced syntax trees
+@SectionLabel EnhancedSyntaxTrees
+
+To simplify the handling of syntax trees, the CAP compiler enhances syntax trees in the following ways:
+* All node types starting with STAT_SEQ_STAT are replaced by STAT_SEQ_STAT.
+* All node types starting with EXPR_FUNCCALL_ are replaced by EXPR_FUNCCALL.
+* All node types starting with EXPR_PROCCALL_ are replaced by EXPR_PROCCALL.
+* All node types starting with STAT_FOR are replaced by STAT_FOR.
+* Nested STAT_SEQ_STATs are flattened.
+* A final STAT_RETURN_VOID in functions is dropped.
+* Branches of STAT_IF etc. are given the type BRANCH_IF.
+* If the body of a BRANCH_IF is not a STAT_SEQ_STAT, the body is wrapped in a STAT_SEQ_STAT.
+* The key-value pairs of EXPR_RECs are given the type REC_KEY_VALUE_PAIR.
+* A globally unique ID is assigned to each function.
+* The handling of local variables and higher variables is unified by the concept of function variables:
+  function variables (FVARs) reference local variables in functions via the function id (`func_id`) and
+  the position (`pos`) in the list of arguments/local variables of the function.
+  For easier debugging, the name of the local variable is stored in the entry `initial_name` of the FVAR.
+
+@Section Iterating over a syntax tree
+@SectionLabel IterateOverTree
+
+@Section Tools
+@SectionLabel Tools
+
+@Section Compilation steps
+@SectionLabel CompilationSteps
+
+@Chapter Examples and tests
+
+@Section Examples
+
+@Section Tests
+

--- a/CompilerForCAP/doc/clean
+++ b/CompilerForCAP/doc/clean
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f *.{aux,lab,log,dvi,ps,pdf,bbl,ilg,ind,idx,out,html,tex,pnr,txt,blg,toc,six,brf,xml,xml.bib,css,js}

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -1,0 +1,85 @@
+#! @Chapter Examples and tests
+
+#! @Section Examples
+
+#! @Example
+
+package_loading_info_level := InfoLevel( InfoPackageLoading );;
+SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
+LoadPackage( "LinearAlgebraForCAP", false );;
+LoadPackage( "RingsForHomalg", false );;
+SetInfoLevel( InfoPackageLoading, package_loading_info_level );;
+
+Q := HomalgFieldOfRationals();;
+vec := MatrixCategory( Q :
+    enable_compilation := [ "MorphismBetweenDirectSums" ]
+);;
+
+V := VectorSpaceObject( 2, Q );;
+alpha := ZeroMorphism( V, V );;
+beta := IdentityMorphism( V );;
+
+W := DirectSum( V, V );;
+morphism_matrix := [ [ alpha, beta ], [ beta, alpha ] ];;
+
+# compile the primitive installation of MorphismBetweenDirectSums
+MorphismBetweenDirectSums( morphism_matrix );;
+tree1 := SYNTAX_TREE(
+    vec!.compiled_functions.MorphismBetweenDirectSums[3]
+);;
+# fixup nams
+tree1.nams := [ "S", "morphism_matrix", "T" ];;
+tree1.nloc := 0;;
+tree1.stats.statements[1].branches[2].body.statements[1].
+    obj.args[12].args[1].args[2].nams := [ "row" ];;
+tree1.stats.statements[1].branches[2].body.statements[1].
+    obj.args[12].args[1].args[2].nloc := 0;;
+Display( SYNTAX_TREE_CODE( tree1 ) );
+#! function ( S, morphism_matrix, T )
+#!     if morphism_matrix = [  ] or morphism_matrix[1] = [  ] then
+#!         return ZeroMorphism( S, T );
+#!     else
+#!         return ObjectifyWithAttributes( rec(
+#!                ), CAP_JIT_INTERNAL_GLOBAL_VARIABLE_3, CapCategory, 
+#!            CAP_JIT_INTERNAL_GLOBAL_VARIABLE_1, Source, S, Range, T, 
+#!            UnderlyingFieldForHomalg, CAP_JIT_INTERNAL_GLOBAL_VARIABLE_2, 
+#!            UnderlyingMatrix, 
+#!            UnionOfRows( List( morphism_matrix, function ( row )
+#!                     return UnionOfColumns( List( row, UnderlyingMatrix ) );
+#!                 end ) ) );
+#!     fi;
+#!     return;
+#! end
+
+# compile the default derivation of MorphismBetweenDirectSums
+tree2 := SYNTAX_TREE( CapJitCompiledFunction(
+    vec!.added_functions.MorphismBetweenDirectSums[1][1],
+    [ W, morphism_matrix, W  ]
+) );;
+# fixup nams
+tree2.nams := [ "S", "morphism_matrix", "T" ];;
+tree2.nloc := 0;;
+tree2.stats.statements[1].branches[2].body.statements[1].
+    obj.args[12].args[1].args[2].nams := [ "row" ];;
+tree2.stats.statements[1].branches[2].body.statements[1].
+    obj.args[12].args[1].args[2].nloc := 0;;
+Display( SYNTAX_TREE_CODE( tree2 ) );
+#! function ( S, morphism_matrix, T )
+#!     if morphism_matrix = [  ] or morphism_matrix[1] = [  ] then
+#!         return ZeroMorphism( S, T );
+#!     else
+#!         return ObjectifyWithAttributes( rec(
+#!                ), CAP_JIT_INTERNAL_GLOBAL_VARIABLE_3, CapCategory, 
+#!            CAP_JIT_INTERNAL_GLOBAL_VARIABLE_1, Source, S, Range, T, 
+#!            UnderlyingFieldForHomalg, CAP_JIT_INTERNAL_GLOBAL_VARIABLE_2, 
+#!            UnderlyingMatrix, 
+#!            UnionOfRows( List( morphism_matrix, function ( row )
+#!                     return UnionOfColumns( List( row, function ( s )
+#!                               return UnderlyingMatrix( s );
+#!                           end ) );
+#!                 end ) ) );
+#!     fi;
+#!     return;
+#! end
+
+#! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gd
+++ b/CompilerForCAP/gap/CompilerForCAP.gd
@@ -1,0 +1,32 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+
+#! @Chapter Using the compiler
+
+#! @Section Stopping the compiler at a certain level
+
+#! @Description
+#!   Stops the compiler from inlining and optimizing code of <A>category</A>.
+#! @Arguments category
+DeclareGlobalFunction( "StopCompilationAtCategory" );
+
+#! @Description
+#!   Allows the compiler to inline and optimize code of <A>category</A> (this is the default).
+#! @Arguments category
+DeclareGlobalFunction( "ContinueCompilationAtCategory" );
+
+#! @Section Getting information about the compilation process
+
+#! @Description
+#!   Info class used for info messsages of the CAP compiler.
+DeclareInfoClass( "InfoCapJit" );
+
+#! @Section Compiling a function manually
+
+#! @Description
+#!   Returns a compiled version of the function <A>func</A>.
+#!   The arguments <A>jit_args</A> are used to infer the types of variables.
+#! @Returns a function
+#! @Arguments func, jit_args
+DeclareGlobalFunction( "CapJitCompiledFunction" );

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -1,0 +1,205 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# Implementations
+#
+
+InstallGlobalFunction( StopCompilationAtCategory, function( category )
+    
+    Assert( 0, IsCapCategory( category ) );
+    
+    category!.stop_compilation := true;
+    
+end );
+
+InstallGlobalFunction( ContinueCompilationAtCategory, function( category )
+    
+    Assert( 0, IsCapCategory( category ) );
+    
+    category!.stop_compilation := false;
+    
+end );
+
+InstallGlobalFunction( CapJitCompiledFunction, function( func, jit_args )
+  local debug, tree, orig_tree, compiled_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Start compilation." );
+    
+    if IsOperation( func ) or IsKernelFunction( func ) then
+        
+        Info( InfoCapJit, 1, "<func> is a operation or kernel function, this is not supported yet." );
+        return func;
+        
+    fi;
+    
+    debug := false;
+    
+    if debug then
+        Display( func );
+        Error( "start compilation" );
+    fi;
+    
+    tree := ENHANCED_SYNTAX_TREE( func, true );
+    
+    # resolving phase
+    orig_tree := rec();
+    while tree <> orig_tree do
+        
+        orig_tree := tree;
+        
+        Info( InfoCapJit, 1, "####" );
+        Info( InfoCapJit, 1, "Start resolving." );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "start resolving" );
+        fi;
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitResolvedOperations" );
+        fi;
+        
+        tree := CapJitResolvedOperations( tree, jit_args );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitAppliedLogicTemplates" );
+        fi;
+        
+        tree := CapJitAppliedLogicTemplates( tree, jit_args, true );
+        
+        # new functions might be resolved -> test for side effects
+        CapJitThrowErrorOnSideEffects( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedArguments" );
+        fi;
+        
+        tree := CapJitInlinedArguments( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitDroppedUnusedVariables" );
+        fi;
+        
+        tree := CapJitDroppedUnusedVariables( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedVariableAssignments" );
+        fi;
+        
+        tree := CapJitInlinedVariableAssignments( tree, true );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitResolvedGlobalVariables" );
+        fi;
+        
+        tree := CapJitResolvedGlobalVariables( tree );
+        
+    od;
+    
+    # rule phase
+    orig_tree := rec();
+    while tree <> orig_tree do
+        
+        orig_tree := tree;
+        
+        Info( InfoCapJit, 1, "####" );
+        Info( InfoCapJit, 1, "Apply rules." );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply rules" );
+        fi;
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitAppliedLogic" );
+        fi;
+        
+        tree := CapJitAppliedLogic( tree, jit_args );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitDroppedHandledEdgeCases" );
+        fi;
+        
+        tree := CapJitDroppedHandledEdgeCases( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedArguments" );
+        fi;
+        
+        tree := CapJitInlinedArguments( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedSimpleFunctionCalls" );
+        fi;
+        
+        tree := CapJitInlinedSimpleFunctionCalls( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedFunctionCalls" );
+        fi;
+        
+        tree := CapJitInlinedFunctionCalls( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitDroppedUnusedVariables" );
+        fi;
+        
+        tree := CapJitDroppedUnusedVariables( tree );
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display(compiled_func);
+            Error( "apply CapJitInlinedVariableAssignments" );
+        fi;
+        
+        tree := CapJitInlinedVariableAssignments( tree );
+        
+    od;
+    
+    if debug then
+        
+        compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+        
+        Display( compiled_func );
+        
+        Assert( 0, CallFuncList( compiled_func, jit_args ) = CallFuncList( func, jit_args ) );
+        
+        Error( "compilation finished" );
+        
+    fi;
+    
+    compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Compilation finished." );
+    
+    return compiled_func;
+    
+end );

--- a/CompilerForCAP/gap/DropHandledEdgeCases.gd
+++ b/CompilerForCAP/gap/DropHandledEdgeCases.gd
@@ -1,0 +1,16 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION" );
+
+#! @Description
+#!   Idea: If the same edge case is handled multiple times in the tree by checking
+#!   a condition and returning a value, all condition checks except the first can be dropped.
+#!   Details: Keeps a record of conditions which immediately lead to a return,
+#!   i.e., statements of the form `if condition1 then return value; fi;`. If another statement of the
+#!   form `if condition2 then return value; fi;` is found later in the tree and if `condition2 = true`
+#!   implies `condition1 = true`, the second statement is dropped.
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitDroppedHandledEdgeCases" );

--- a/CompilerForCAP/gap/DropHandledEdgeCases.gi
+++ b/CompilerForCAP/gap/DropHandledEdgeCases.gi
@@ -1,0 +1,205 @@
+InstallGlobalFunction( CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION, function( cond1, cond2 )
+    
+    # check if cond1 implies cond2, i.e. if ( cond1 = true => cond2 = true )
+    if cond1 = cond2 then
+        
+        return true;
+
+    elif cond1.type = "EXPR_OR" then
+        
+        if CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION( cond1.left, cond2 ) = true and CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION( cond1.right, cond2 ) = true then
+            
+            return true;
+            
+        fi;
+        
+    elif cond2.type = "EXPR_OR" then
+        
+        if CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION( cond1, cond2.left ) = true then
+            
+            return true;
+            
+        fi;
+        
+        if CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION( cond1, cond2.right ) = true then
+            
+            return true;
+            
+        fi;
+        
+    fi;
+    
+    return fail;
+    
+end );
+
+InstallGlobalFunction( CapJitDroppedHandledEdgeCases, function( tree )
+  local handled_edge_cases, pre_func, result_func, additional_arguments_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Drop handled edge cases." );
+    
+    handled_edge_cases := [];
+
+    pre_func := function( tree, path )
+      local statements, statement, branches, branch, if_path, i, j;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            statements := tree.stats.statements;
+            
+            for i in [ 1 .. Length( statements ) ] do
+                
+                statement := statements[i];
+                
+                if StartsWith( statement.type, "STAT_IF" ) then
+                    
+                    branches := statement.branches;
+                    
+                    for j in [ 1 .. Length( branches ) ] do
+                        
+                        branch := branches[j];
+                        
+                        if Last( branch.body.statements ).type = "STAT_RETURN_OBJ" then
+                            
+                            # we are in the main sequence of statements of a function => we are not inside of a loop
+                            # and this branch ends with a return statement
+                            # => we can only reach the remaining branches if the condition of this branch does not match
+                            if_path := Concatenation( path, [ "stats", "statements", i ] );
+                            Add( handled_edge_cases, rec( if_path := if_path, key := j, condition := branch.condition ) );
+                            
+                        fi;
+                        
+                    od;
+                    
+                fi;
+                
+            od;
+            
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    result_func := function( tree, result, path )
+      local statements, i, statement, positions, key;
+        
+        if IsList( result ) then
+            
+            return result;
+            
+        elif IsRecord( result ) then
+            
+            tree := ShallowCopy( tree );
+
+            for key in RecNames( result ) do
+                
+                tree.(key) := result.(key);
+
+            od;
+
+            if tree.type = "STAT_SEQ_STAT" then
+                
+                tree.statements := Filtered( tree.statements, s -> s.type <> "STAT_EMPTY" );
+
+                statements := tree.statements;
+                
+                i := 1;
+                
+                while i <= Length( statements ) do
+                    
+                    statement := statements[i];
+                    
+                    if statement.type = "STAT_SEQ_STAT" then
+                        
+                        statements := Concatenation( statements{[ 1 .. i-1 ]}, statement.statements, statements{[ i+1 .. Length( statements ) ]} );
+                        
+                    else
+                        
+                        i := i + 1;
+                        
+                    fi;
+                    
+                od;
+                
+                tree.statements := statements;
+            
+            elif StartsWith( tree.type, "STAT_IF" ) then
+                
+                positions := Filtered( [ 1 .. Length( tree.branches ) ], function( j )
+                  local branch, key, handled_edge_case;
+                    
+                    branch := tree.branches[j];
+                    
+                    for handled_edge_case in handled_edge_cases do
+                        
+                        if PositionSublist( path, handled_edge_case.if_path ) = 1 then
+                            
+                            if Length( path ) > Length( handled_edge_case.if_path ) then
+                                
+                                # next entry of path is "branches", then the key
+                                key := path[ Length( handled_edge_case.if_path ) + 2];
+
+                            else
+                                
+                                key := j;
+                                
+                            fi;
+                            
+                            Assert( 0, IsInt( key ) );
+                            
+                            if key > handled_edge_case.key and CAP_JIT_INTERNAL_CONDITION_IMPLIES_CONDITION( branch.condition, handled_edge_case.condition ) = true then
+
+                                Info( InfoCapJit, 1, "####" );
+                                Info( InfoCapJit, 1, "Dropped edge case." );
+    
+                                return false;
+                                
+                            fi;
+                            
+                        fi;
+                        
+                    od;
+                    
+                    return true;
+                    
+                end );
+                
+                if Length( positions ) = 0 then
+                    
+                    return rec( type := "STAT_EMPTY" );
+                    
+                else
+                    
+                    tree.branches := tree.branches{positions};
+                    
+                fi;
+
+                if Length( tree.branches ) = 1 and tree.branches[1].condition.type = "EXPR_TRUE" then
+                    
+                    return tree.branches[1].body;
+                    
+                fi;
+
+            fi;
+            
+            return tree;
+
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    additional_arguments_func := function( tree, key, path )
+        
+        return Concatenation( path, [ key ] );
+        
+    end;
+  
+    return CapJitIterateOverTree( tree, pre_func, result_func, additional_arguments_func, [] );
+
+end );

--- a/CompilerForCAP/gap/DropUnusedVariables.gd
+++ b/CompilerForCAP/gap/DropUnusedVariables.gd
@@ -1,0 +1,13 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Drops assignments to local variables which are never referenced. If a path to a function
+#!   is given as the second argument, only variables in this function are considered. Otherwise,
+#!   all functions in <A>tree</A> are considered.
+#!   Marks unused variables with the prefix _UNUSED_. Assumes that arguments of function calls
+#!   are inlined (i.e., you should use <Ref Func="CapJitInlinedArguments" /> first).
+#! @Returns a record
+#! @Arguments tree[, func_path]
+DeclareGlobalFunction( "CapJitDroppedUnusedVariables" );

--- a/CompilerForCAP/gap/DropUnusedVariables.gi
+++ b/CompilerForCAP/gap/DropUnusedVariables.gi
@@ -1,0 +1,171 @@
+InstallGlobalFunction( CapJitDroppedUnusedVariables, function( tree, args... )
+  local single_pass, func_path, condition_func, path, pre_func, func, used_nams, used_positions, unused_positions, pos;
+    
+    if not Length( args ) in [ 0, 1 ] then
+        
+        Error( "CapJitDroppedUnusedVariables cannot be called with more than two arguments" );
+        
+    fi;
+
+    if Length( args ) = 1 then
+        
+        Assert( 0, IsList( args[1] ) );
+        
+        func_path := args[1];
+        
+        single_pass := true;
+        
+    else
+        
+        func_path := fail;
+        
+        single_pass := false;
+        
+    fi;
+    
+    tree := StructuralCopy( tree );
+    
+    if func_path = fail then
+        
+        # find EXPR_FUNC
+        condition_func := function( tree, path )
+            
+            if tree.type = "EXPR_FUNC" and not (IsBound( tree.CAP_JIT_NO_UNUSED_VARIABLES ) and tree.CAP_JIT_NO_UNUSED_VARIABLES) then
+                
+                return true;
+
+            fi;
+            
+            return false;
+            
+        end;
+        
+        func_path := CapJitFindNodeDeep( tree, condition_func );
+        
+        if func_path = fail then
+            
+            # reset CAP_JIT_NO_UNUSED_VARIABLES
+            pre_func := function( tree, additional_arguments )
+              local level, pos;
+                
+                if IsRecord( tree ) and IsBound( tree.CAP_JIT_NO_UNUSED_VARIABLES ) then
+                    
+                    Unbind( tree.CAP_JIT_NO_UNUSED_VARIABLES );
+                    
+                fi;
+                    
+                return tree;
+                
+            end;
+            
+            CapJitIterateOverTree( tree, pre_func, ReturnTrue, ReturnTrue, true );
+            
+            return tree;
+            
+        fi;
+
+    fi;
+
+    func := CapJitGetNodeByPath( tree, func_path );
+
+    if Last( func_path ) = "funcref" and func.narg <> 0 then
+        
+        Error( "please inline arguments first" );
+        
+    fi;
+
+    # find unused variables
+    # we can ignore args: if this function is part of a function call, all arguments have been inlined anyway
+    #                     if this function is not part of a function call, we cannot optimize unused arguments
+
+    # modified inplace
+    used_nams := Concatenation( ListWithIdenticalEntries( func.narg, true ), ListWithIdenticalEntries( func.nloc, false ) );
+    
+    pre_func := function( tree, additional_arguments )
+      local level;
+        
+        if IsRecord( tree ) then
+            
+            level := fail;
+            
+            # STAT_ASS_FVAR does not count as using the variable and EXPR_ISB_FVAR and STAT_UNB_FVAR are forbidden
+            if tree.type = "EXPR_REF_FVAR" and tree.func_id = func.id then
+                
+                used_nams[tree.pos] := true;
+                    
+            fi;
+            
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    CapJitIterateOverTree( func, pre_func, ReturnTrue, ReturnTrue, true );
+    
+    used_positions := PositionsProperty( used_nams, x -> x = true );
+    unused_positions := PositionsProperty( used_nams, x -> x = false );
+    
+    if ForAny( func.nams{used_positions}, n -> StartsWith( n, "_UNUSED_" ) ) then
+        
+        Error( "a variable marked as _UNUSED_ is used" );
+        
+    fi;
+
+    # do not consider variables already marked as _UNUSED_
+    unused_positions := Filtered( unused_positions, i -> not StartsWith( func.nams[i], "_UNUSED_" ) );
+    
+    if Length( unused_positions ) = 0 then
+    
+        func.CAP_JIT_NO_UNUSED_VARIABLES := true;
+    
+    else
+        
+        Info( InfoCapJit, 1, "####" );
+        Info( InfoCapJit, 1, "Dropping the following unused variables:" );
+        Info( InfoCapJit, 1, func.nams{unused_positions} );
+        
+        for pos in unused_positions do
+            
+            func.nams[pos] := Concatenation( "_UNUSED_", func.nams[pos] );
+            
+        od;
+        
+        # remove STAT_ASS_FVAR
+        pre_func := function( tree, additional_arguments )
+            
+            if IsRecord( tree ) and tree.type = "STAT_SEQ_STAT" then
+                
+                tree.statements := Filtered( tree.statements, function( statement )
+                    
+                    if statement.type = "STAT_ASS_FVAR" and statement.func_id = func.id and statement.pos in unused_positions then
+                        
+                        return false;
+                        
+                    fi;
+
+                    return true;
+                
+                end );
+                
+            fi;
+                
+            return tree;
+            
+        end;
+        
+        CapJitIterateOverTree( func, pre_func, ReturnTrue, ReturnTrue, true );
+        
+    fi;
+    
+    if single_pass then
+        
+        Unbind( func.CAP_JIT_NO_UNUSED_VARIABLES );
+        
+        return tree;
+        
+    fi;
+    
+    return CapJitDroppedUnusedVariables( tree );
+    
+end );

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gd
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gd
@@ -1,0 +1,17 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Enhanced syntax trees
+
+#! @Description
+#!   Returns an enhanced syntax tree of the plain function <A>func</A> (see above). If the second argument is set to `true`,
+#!   higher variables pointing to variables in the environment of <A>func</A> are assigned to global variables
+#!   and referenced via these global variables in the tree. Otherwise, an error is thrown if such higher variables exist.
+#! @Returns a record
+#! @Arguments func[, globalize_hvars ]
+DeclareGlobalFunction( "ENHANCED_SYNTAX_TREE" );
+
+#! @Description
+#!   Converts the enhanced syntax tree <A>tree</A> to a function.
+#! @Returns a function
+#! @Arguments tree
+DeclareGlobalFunction( "ENHANCED_SYNTAX_TREE_CODE" );

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -1,0 +1,429 @@
+BindGlobal( "CAP_JIT_INTERNAL_FUNCTION_ID", 1 );
+MakeReadWriteGlobal( "CAP_JIT_INTERNAL_FUNCTION_ID" );
+InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function( func, args... )
+  local globalize_hvars, tree, pre_func, additional_arguments_func;
+    
+    Assert( 0, Length( args ) = 0 or Length( args ) = 1 );
+    
+    if Length( args ) = 1 then
+        
+        Assert( 0, IsBool( args[1] ) );
+        
+        globalize_hvars := args[1];
+        
+    else
+        
+        globalize_hvars := false;
+        
+    fi;
+  
+    tree := SYNTAX_TREE( func );
+    
+    # some references to the original function are kept, e.g. tree.nams -> make a copy
+    tree := StructuralCopy( tree );
+
+    pre_func := function( tree, additional_arguments )
+      local path, func_stack, statements, i, statement, level, pos, lvars, value, branch, keyvalue;
+        
+        path := additional_arguments[1];
+        func_stack := additional_arguments[2];
+        
+        if IsRecord( tree ) then
+            
+            Assert( 0, IsBound( tree.type ) );
+            
+            # replace verbose types by short types
+            if StartsWith( tree.type, "STAT_SEQ_STAT" ) then
+                
+                tree.type := "STAT_SEQ_STAT";
+            
+            elif StartsWith( tree.type, "EXPR_FUNCCALL_" ) then
+                
+                tree.type := "EXPR_FUNCCALL";
+            
+            elif StartsWith( tree.type, "STAT_PROCCALL_" ) then
+                
+                tree.type := "STAT_PROCCALL";
+            
+            elif StartsWith( tree.type, "STAT_FOR" ) then
+                
+                tree.type := "STAT_FOR";
+            
+            fi;
+            
+            # flatten statements
+            if tree.type = "STAT_SEQ_STAT" then
+                
+                statements := tree.statements;
+                
+                i := 1;
+                
+                while i <= Length( statements ) do
+                    
+                    statement := statements[i];
+                    
+                    if StartsWith( statement.type, "STAT_SEQ_STAT" ) then
+                        
+                        statements := Concatenation( statements{[ 1 .. i-1 ]}, statement.statements, statements{[ i+1 .. Length( statements ) ]} );
+                        
+                    else
+                        
+                        i := i + 1;
+                        
+                    fi;
+                    
+                od;
+                
+                # drop final STAT_RETURN_VOID in a function (it will automatically be added again by SYNTAX_TREE_CODE)
+                if Last( path ) = "stats" and Last( statements ).type = "STAT_RETURN_VOID" then
+                    
+                    statements := statements{[ 1 .. Length( statements ) - 1 ]};
+                    
+                fi;
+                
+                tree.statements := statements;
+                
+            fi;
+
+            # give if branches a type
+            if tree.type in [ "STAT_IF", "STAT_IF_ELSE", "STAT_IF_ELIF", "STAT_IF_ELIF_ELSE" ] then
+                
+                for branch in tree.branches do
+                    
+                    branch.type := "BRANCH_IF";
+                    
+                od;
+                
+            fi;
+
+            # make sure the body of an if branch is a STAT_SEQ_STAT
+            if tree.type = "BRANCH_IF" then
+                
+                if not StartsWith( tree.body.type, "STAT_SEQ_STAT" ) then
+                    
+                    tree.body := rec(
+                        type := "STAT_SEQ_STAT",
+                        statements := [
+                            tree.body,
+                        ],
+                    );
+                    
+                fi;
+                
+            fi;
+
+            # give rec key-values a type
+            if tree.type = "EXPR_REC" then
+                
+                for keyvalue in tree.keyvalue do
+                    
+                    keyvalue.type := "REC_KEY_VALUE_PAIR";
+                    
+                od;
+                
+            fi;
+
+            # assign IDs to functions
+            if tree.type = "EXPR_FUNC" then
+                
+                # id might already have been set during inlining of global vars
+                if not IsBound( tree.id ) then
+                
+                    tree.id := CAP_JIT_INTERNAL_FUNCTION_ID;
+                    
+                    CAP_JIT_INTERNAL_FUNCTION_ID := CAP_JIT_INTERNAL_FUNCTION_ID + 1;
+                
+                fi;
+                    
+            fi;
+
+            # unify lvar and hvar handling
+            if PositionSublist( tree.type, "LVAR" ) <> fail then
+                
+                tree.type := ReplacedString( tree.type, "LVAR", "FVAR" );
+                tree.func_id := func_stack[Length( func_stack )].id;
+                tree.pos := tree.lvar;
+                tree.initial_name := func_stack[Length( func_stack )].nams[tree.lvar];
+                Unbind( tree.lvar );
+                
+            fi;
+            
+            if PositionSublist( tree.type, "HVAR" ) <> fail then
+                
+                level := Int( tree.hvar / 2^16 );
+                pos := tree.hvar mod 2^16;
+                
+                if level >= Length( func_stack ) then
+                    
+                    # only EPXR_REF_HVAR can be globalized
+                    if globalize_hvars and tree.type = "EXPR_REF_HVAR" then
+                        
+                        lvars := ContentsLVars( ENVI_FUNC( func ) );
+                        i := level - Length( func_stack );
+                        while i > 0 do
+                            
+                            Assert( 0, IsBound( lvars.higher ) );
+                            lvars := ContentsLVars( lvars.higher );
+                            i := i - 1;
+                            
+                        od;
+
+                        Assert( 0, IsBound( lvars.values[pos] ) );
+
+                        value := lvars.values[pos];
+                        
+                        tree.type := "EXPR_REF_GVAR";
+                        tree.gvar := CapJitGetOrCreateGlobalVariable( lvars.values[pos] );
+                        Unbind( tree.hvar );
+                        
+                    else
+                        
+                        Error( "tree contains hvar ref outside of stack" );
+                        
+                    fi;
+                    
+                else
+
+                    tree.type := ReplacedString( tree.type, "HVAR", "FVAR" );
+                    tree.func_id := func_stack[Length( func_stack ) - level].id;
+                    tree.pos := pos;
+                    tree.initial_name := func_stack[Length( func_stack ) - level].nams[pos];
+                    Unbind( tree.hvar );
+
+                fi;
+                
+            fi;
+            
+        fi;
+
+        return tree;
+        
+    end;
+    
+    additional_arguments_func := function( tree, key, additional_arguments )
+      local path, func_stack;
+        
+        path := additional_arguments[1];
+        func_stack := additional_arguments[2];
+        
+        path := Concatenation( path, [ key ] );
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            Assert( 0, IsBound( tree.id ) );
+            
+            func_stack := Concatenation( func_stack, [ tree ] );
+            
+        fi;
+        
+        return [ path, func_stack ];
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, additional_arguments_func, [[],[]] );
+    
+end );
+
+InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function( tree )
+  local pre_func, additional_arguments_func, func;
+    
+    tree := StructuralCopy( tree );
+    
+    pre_func := function( tree, additional_arguments )
+      local path, func_stack, statements, first_six_statements, new_statements, func_pos, level;
+        
+        path := additional_arguments[1];
+        func_stack := additional_arguments[2];
+      
+        if IsRecord( tree ) then
+            
+            Assert( 0, IsBound( tree.type ) );
+
+            # sanity check that every function has an ID
+            if tree.type = "EXPR_FUNC" then
+                
+                Assert( 0, IsBound( tree.id ) );
+                
+            fi;
+            
+            # assert that short types are used and replace by verbose types
+            if StartsWith( tree.type, "STAT_SEQ_STAT" ) then
+                
+                if tree.type <> "STAT_SEQ_STAT" then
+                    
+                    Error( "enhanced syntax trees can only be used with short types" );
+                    
+                fi;
+
+                # handled below
+            
+            elif StartsWith( tree.type, "EXPR_FUNCCALL" ) then
+                
+                if tree.type <> "EXPR_FUNCCALL" then
+                    
+                    Error( "enhanced syntax trees can only be used with short types" );
+                    
+                fi;
+
+                if Length( tree.args ) > 6 then
+                    
+                    tree.type := "EXPR_FUNCCALL_XARGS";
+                    
+                else
+                    
+                    tree.type := Concatenation( "EXPR_FUNCCALL_", String( Length( tree.args ) ), "ARGS" );
+                    
+                fi;
+            
+            elif StartsWith( tree.type, "STAT_PROCCALL" ) then
+                
+                if tree.type <> "STAT_PROCCALL" then
+                    
+                    Error( "enhanced syntax trees can only be used with short types" );
+                    
+                fi;
+
+                if Length( tree.args ) > 6 then
+                    
+                    tree.type := "STAT_PROCCALL_XARGS";
+                    
+                else
+                    
+                    tree.type := Concatenation( "STAT_PROCCALL_", String( Length( tree.args ) ), "ARGS" );
+                    
+                fi;
+                
+            elif StartsWith( tree.type, "STAT_FOR" ) then
+                
+                if tree.type <> "STAT_FOR" then
+                    
+                    Error( "enhanced syntax trees can only be used with short types" );
+                    
+                fi;
+                
+                # check if we range over a local variable
+                if tree.collection.type = "EXPR_RANGE" and tree.variable.type = "EXPR_REF_FVAR" and tree.variable.func_id = Last( func_stack ).id then
+                    
+                    tree.type := "STAT_FOR_RANGE";
+                    
+                fi;
+                
+                if Length( tree.body ) = 2 or Length( tree.body ) = 3 then
+                    
+                    tree.type := Concatenation( tree.type, [ String( Length( tree.body ) ) ] );
+                    
+                fi;
+                
+            fi;
+            
+            # nest statements
+            if tree.type = "STAT_SEQ_STAT" then
+                
+                statements := tree.statements;
+                
+                # assert that statements are flat
+                Assert( 0, Length( statements ) > 0 );
+                Assert( 0, ForAll( statements, s -> not StartsWith( s.type, "STAT_SEQ_STAT" ) ) );
+                
+                first_six_statements := fail;
+                
+                if Last( path ) = "stats" and Length( statements ) > 7 then
+                    
+                    first_six_statements := statements{[ 1 .. 6 ]};
+                    statements := statements{[ 7 .. Length( statements ) ]};
+                    
+                fi;
+                
+                new_statements := rec(
+                    type := "STAT_SEQ_STAT",
+                    statements := statements,
+                );
+                    
+                if first_six_statements <> fail then
+                    
+                    # new_statements.type will be handled by the recursion
+                    return rec(
+                        type := "STAT_SEQ_STAT7",
+                        statements := Concatenation( first_six_statements, [ new_statements ] ),
+                    );
+                    
+                else
+
+                    if Length( statements ) >= 2 and Length( statements ) <= 7 then
+                        
+                        new_statements.type := Concatenation( "STAT_SEQ_STAT", String( Length( statements ) ) );
+                        
+                    fi;
+                    
+                    return new_statements;
+                    
+                fi;
+                
+            fi;
+
+            # convert FVAR to LVAR and HVAR
+            if PositionSublist( tree.type, "FVAR" ) <> fail then
+                
+                func_pos := PositionProperty( func_stack, f -> f.id = tree.func_id );
+                
+                if func_pos = fail then
+                    
+                    Error( "FVAR reference outside of function stack" );
+                    
+                fi;
+                
+                level := Length( func_stack ) - func_pos;
+                
+                if tree.pos > Length( func_stack[func_pos].nams ) then
+                    
+                    Error( "FVAR references a non-existing position" );
+
+                fi;
+                
+                if level = 0 then
+                    
+                    tree.type := ReplacedString( tree.type, "FVAR", "LVAR" );
+                    tree.lvar := tree.pos;
+                    
+                else
+                    
+                    tree.type := ReplacedString( tree.type, "FVAR", "HVAR" );
+                    tree.hvar := 2^16 * level + tree.pos;
+                    
+                fi;
+                
+            fi;
+
+        fi;
+
+        return tree;
+        
+    end;
+    
+    additional_arguments_func := function( tree, key, additional_arguments )
+      local path, func_stack;
+        
+        path := additional_arguments[1];
+        func_stack := additional_arguments[2];
+        
+        path := Concatenation( path, [ key ] );
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            Assert( 0, IsBound( tree.id ) );
+            
+            func_stack := Concatenation( func_stack, [ tree ] );
+            
+        fi;
+        
+        return [ path, func_stack ];
+        
+    end;
+    
+    tree := CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, additional_arguments_func, [[],[]] );
+    
+    func := SYNTAX_TREE_CODE( tree );
+    
+    return func;
+    
+end );

--- a/CompilerForCAP/gap/GetValuesFromJitArgs.gd
+++ b/CompilerForCAP/gap/GetValuesFromJitArgs.gd
@@ -1,0 +1,23 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Tools
+
+#! @Description
+#!   Computes the arguments of the function call at the given <A>path</A> in <A>tree</A>
+#!   when executing the function defined by <A>tree</A> with arguments <A>jit_args</A>.
+#!   If the arguments cannot be determined, a list with first entry `false` is returned.
+#!   Otherwise, a list with `true` as the first value and the computed arguments
+#!   as the second value is returned.
+#! @Returns a list
+#! @Arguments tree, path, jit_args
+DeclareGlobalFunction( "CapJitGetFunctionCallArgumentsFromJitArgs" );
+
+#! @Description
+#!   Computes the value of the expression at the given <A>path</A> in <A>tree</A>
+#!   when executing the function defined by <A>tree</A> with arguments <A>jit_args</A>.
+#!   If the value cannot be determined, a list with first entry `false` is returned.
+#!   Otherwise, a list with `true` as the first value and the computed value
+#!   as the second value is returned.
+#! @Returns a list
+#! @Arguments tree, path, jit_args
+DeclareGlobalFunction( "CapJitGetExpressionValueFromJitArgs" );

--- a/CompilerForCAP/gap/GetValuesFromJitArgs.gi
+++ b/CompilerForCAP/gap/GetValuesFromJitArgs.gi
@@ -1,0 +1,129 @@
+BindGlobal( "CAP_JIT_INTERNAL_STORED_VALUES", [] );
+BindGlobal( "CAP_JIT_INTERNAL_STORED_VALUES_COUNTER", 1 );
+MakeReadWriteGlobal( "CAP_JIT_INTERNAL_STORED_VALUES_COUNTER" );
+
+BindGlobal( "CAP_JIT_INTERNAL_STORE_ARGUMENTS", function( counter, func, args... )
+  local result;
+    
+    CAP_JIT_INTERNAL_STORED_VALUES[counter] := args;
+    
+    result := CallFuncListWrap( func, args );
+    
+    if Length( result ) > 0 then
+        
+        return result[1];
+        
+    else
+    
+        return;
+    
+    fi;
+
+end );
+
+BindGlobal( "CAP_JIT_INTERNAL_STORE_VALUE", function( counter, value )
+  
+    CAP_JIT_INTERNAL_STORED_VALUES[counter] := value;
+    
+    return value;
+
+end );
+
+InstallGlobalFunction( CapJitGetFunctionCallArgumentsFromJitArgs, function( tree, path, jit_args )
+  local jit_tree, jit_record, counter, jit_func;
+
+    jit_tree := StructuralCopy( tree );
+    
+    jit_record := CapJitGetNodeByPath( jit_tree, path );
+
+    Assert( 0, jit_record.type = "EXPR_FUNCCALL" and jit_record.funcref.type = "EXPR_REF_GVAR" );
+    
+    counter := CAP_JIT_INTERNAL_STORED_VALUES_COUNTER;
+    CAP_JIT_INTERNAL_STORED_VALUES_COUNTER := CAP_JIT_INTERNAL_STORED_VALUES_COUNTER + 1;
+    
+    jit_record.args := Concatenation( [ rec( type := "EXPR_INT", value := counter ), jit_record.funcref ], jit_record.args );
+
+    jit_record.funcref := rec(
+        type := "EXPR_REF_GVAR",
+        gvar := "CAP_JIT_INTERNAL_STORE_ARGUMENTS",
+    );
+
+    jit_func := ENHANCED_SYNTAX_TREE_CODE( jit_tree );
+    
+    CallFuncList( jit_func, jit_args );
+
+    if IsBound( CAP_JIT_INTERNAL_STORED_VALUES[counter] ) then
+
+        return [ true, CAP_JIT_INTERNAL_STORED_VALUES[counter] ];
+
+    else
+        
+        return [ false ];
+
+    fi;
+    
+end );
+
+InstallGlobalFunction( CapJitGetExpressionValueFromJitArgs, function( tree, path, jit_args )
+  local jit_tree, jit_record, parent, counter, new_record, args, jit_func;
+
+    jit_tree := StructuralCopy( tree );
+    
+    jit_record := CapJitGetNodeByPath( jit_tree, path );
+    
+    Assert( 0, StartsWith( jit_record.type, "EXPR_" ) );
+    Assert( 0, Length( path ) >= 1 );
+
+    parent := CapJitGetNodeByPath( jit_tree, path{[ 1 .. Length( path )-1 ]});
+    
+    counter := CAP_JIT_INTERNAL_STORED_VALUES_COUNTER;
+    CAP_JIT_INTERNAL_STORED_VALUES_COUNTER := CAP_JIT_INTERNAL_STORED_VALUES_COUNTER + 1;
+    
+    new_record := rec(
+        type := "EXPR_FUNCCALL",
+        funcref := rec(
+            type := "EXPR_REF_GVAR",
+            gvar := "CAP_JIT_INTERNAL_STORE_VALUE",
+        ),
+        args := [
+            rec(
+                type := "EXPR_INT",
+                value := counter,
+            ),
+            jit_record,
+        ],
+    );
+
+    if IsList( parent ) then
+        
+        Assert( 0, IsInt( Last( path ) ) );
+
+        parent[Last( path )] := new_record;
+    
+    elif IsRecord( parent ) then
+        
+        Assert( 0, IsString( Last( path ) ) );
+
+        parent.(Last( path )) := new_record;
+        
+    else
+        
+        Error( "this should never happen" );
+        
+    fi;
+
+    jit_func := ENHANCED_SYNTAX_TREE_CODE( jit_tree );
+    
+    CallFuncList( jit_func, jit_args );
+    
+    if IsBound( CAP_JIT_INTERNAL_STORED_VALUES[counter] ) then
+
+        return [ true, CAP_JIT_INTERNAL_STORED_VALUES[counter] ];
+
+    else
+        
+        return [ false ];
+
+    fi;
+    
+end );

--- a/CompilerForCAP/gap/InlineArguments.gd
+++ b/CompilerForCAP/gap/InlineArguments.gd
@@ -1,0 +1,11 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Example: transforms `(function(x) return x; end)(1)` into `(function() local x; x := 1; return x; end)()`.
+#!   Details: Searches for function calls of resolved functions. Assigns the argument values to local variables
+#!   at the beginning of the function, and drops the arguments (i.e., makes the function a 0-ary function).
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitInlinedArguments" );

--- a/CompilerForCAP/gap/InlineArguments.gi
+++ b/CompilerForCAP/gap/InlineArguments.gi
@@ -1,0 +1,72 @@
+InstallGlobalFunction( CapJitInlinedArguments, function( tree )
+  local pre_func, additional_arguments_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Inlining function arguments." );
+    
+    pre_func := function( tree, additional_arguments )
+      local func, args, arg_statements, i;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNCCALL" and Length( tree.args ) > 0 and tree.funcref.type = "EXPR_FUNC" then
+            
+            tree := ShallowCopy( tree );
+            func := ShallowCopy( tree.funcref );
+            
+            if func.variadic then
+                
+                Assert( 0, Length( tree.args ) >= func.narg - 1 );
+                
+            else
+                
+                Assert( 0, Length( tree.args ) = func.narg );
+                
+            fi;
+
+            func.nams := ShallowCopy( func.nams );
+
+            for i in [ 1 .. func.narg ] do
+                
+                func.nams[i] := Concatenation( "inline_arg_", func.nams[i] );
+                
+            od;
+            
+            args := ShallowCopy( tree.args );
+            
+            if func.variadic then
+                
+                args[func.narg] := rec(
+                    type := "EXPR_LIST",
+                    list := args{[ func.narg .. Length( args ) ]},
+                );
+                
+            fi;
+            
+            arg_statements := List( [ 1 .. func.narg ], j -> rec(
+                type := "STAT_ASS_FVAR",
+                func_id := func.id,
+                pos := j,
+                initial_name := func.nams[j],
+                rhs := args[j],
+            ) );
+            
+            func.nloc := func.nloc + func.narg;
+            func.narg := 0;
+            func.variadic := false;
+            func.stats := ShallowCopy( func.stats );
+            func.stats.statements := Concatenation( arg_statements, func.stats.statements );
+            
+            tree.funcref := func;
+            tree.args := [];
+            
+            Info( InfoCapJit, 1, "####" );
+            Info( InfoCapJit, 1, "Inlined arguments of a single function." );
+            
+        fi;
+
+        return tree;
+        
+    end;
+
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );

--- a/CompilerForCAP/gap/InlineFunctionCalls.gd
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gd
@@ -1,0 +1,23 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_FUNCTION_CAN_BE_INLINED" );
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID" );
+
+#! @Description
+#!   Example: transforms `function() local x; x := (y -> y + 2)(1); return x; end` into
+#!            `function() local x, y, r; y := 1; r := y + 2; x := r; return x; end`.
+#!   Details: Searches for function calls of a resolved function in the right hand side of a variable assignment
+#!   or a return statement. Inserts the body of the function right before the variable assignment / return statement
+#!   to avoid the function call.
+#!   Assumes that arguments of function calls are inlined (i.e., you should use <Ref Func="CapJitInlinedArguments" /> first).
+#!   Due to the nature of a `return` statement breaking the execution and having no `goto` keyword in GAP, only
+#!   functions
+#!   * ending with a `return` statement, or
+#!   * ending with an if-(elif)-else-statement with `return` statements at the end of all branches
+#!
+#!   and not containing other `return` statements can be inlined.
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitInlinedFunctionCalls" );

--- a/CompilerForCAP/gap/InlineFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gi
@@ -1,0 +1,319 @@
+InstallGlobalFunction( CAP_JIT_INTERNAL_FUNCTION_CAN_BE_INLINED, function( tree )
+  local statements, statements_to_check, branch_statements, branch, result_func;
+    
+    # currently only functions
+    # a) ending with a return statement, or
+    # b) ending with an if-(elif)-else-statement with return statements at the end of all branches
+    # and not containing other return statements can be inlined
+    
+    statements := tree.stats.statements;
+
+    statements_to_check := fail;
+    
+    if Last( statements ).type = "STAT_RETURN_OBJ" then
+        
+        statements_to_check := statements{[ 1 .. Length( statements ) - 1 ]};
+
+    elif Last( statements ).type in [ "STAT_IF_ELSE", "STAT_IF_ELIF_ELSE" ] and ForAll( Last( statements ).branches, b -> Last( b.body.statements ).type = "STAT_RETURN_OBJ" ) then
+        
+        Assert( 0, Last( Last( statements ).branches ).condition.type = "EXPR_TRUE" );
+        
+        statements_to_check := statements{[ 1 .. Length( statements ) - 1 ]};
+
+        for branch in Last( statements ).branches do
+            
+            branch_statements := branch.body.statements;
+            statements_to_check := Concatenation( statements_to_check, branch_statements{[ 1 .. Length( branch_statements ) - 1 ]} );
+            
+        od;
+        
+    fi;
+    
+    if statements_to_check = fail then
+        
+        Info( InfoCapJit, 1, "Function does neither end with a return statement nor an if-(elif)-else-statement" );
+        
+        return false;
+        
+    fi;
+    
+    # check if another return statement occurs
+    result_func := function( tree, result, additional_arguments )
+        
+        if IsList( tree ) then
+            
+            return true in result;
+            
+        elif IsRecord( tree ) then
+            
+            if tree.type = "EXPR_FUNC" then
+                
+                # return statements inside of another function do not matter
+                return false;
+                
+            elif tree.type = "STAT_RETURN_OBJ" then
+                
+                return true;
+                
+            fi;
+            
+            return ForAny( RecNames( result ), key -> result.(key) );
+            
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    if CapJitIterateOverTree( statements_to_check, ReturnFirst, result_func, ReturnTrue, true ) then
+        
+        Info( InfoCapJit, 1, "Function contains another return statement." );
+        
+        return false;
+        
+    fi;
+    
+    return true;
+    
+end );
+
+InstallGlobalFunction( CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID, function( tree, source_func_id, target_func_id, offset )
+  local result_func, additional_arguments_func;
+  
+    result_func := function( tree, result, additional_arguments )
+      local key, level;
+        
+        if IsList( result ) then
+            
+            return result;
+
+        elif IsRecord( result ) then
+            
+            tree := ShallowCopy( tree );
+            
+            for key in RecNames( result ) do
+                
+                tree.(key) := result.(key);
+
+            od;
+
+            if PositionSublist( tree.type, "FVAR" ) <> fail then
+                
+                if tree.func_id = source_func_id then
+                    
+                    tree.func_id := target_func_id;
+                    tree.pos := tree.pos + offset;
+                    
+                fi;
+                
+            fi;
+            
+            return tree;
+            
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    return CapJitIterateOverTree( tree, ReturnFirst, result_func, ReturnTrue, true );
+    
+end );
+
+BindGlobal( "CAP_JIT_INTERNAL_INLINED_FUNCTION_COUNTER", 1 );
+MakeReadWriteGlobal( "CAP_JIT_INTERNAL_INLINED_FUNCTION_COUNTER" );
+InstallGlobalFunction( CapJitInlinedFunctionCalls, function( tree )
+  local pre_func, additional_arguments_func;
+    
+    pre_func := function( tree, current_func )
+      local statements, i, statement, search_key, search_tree, condition_func, found_path, path, func_call, inline_func, counter, new_nams, inline_func_stats, offset, inline_return_statement, return_value_lvar, inline_return_statements, inlined_original_statement, ref_return_value_lvar, parent;
+        
+        tree := StructuralCopy( tree );
+        
+        if IsRecord( tree ) and tree.type = "STAT_SEQ_STAT" then
+            
+            statements := tree.statements;
+            
+            i := 1;
+            
+            while i <= Length( statements ) do
+                
+                statement := statements[i];
+                
+                if statement.type = "STAT_ASS_FVAR" then
+                    
+                    search_key := "rhs";
+                    
+                elif statement.type = "STAT_RETURN_OBJ" then
+                    
+                    search_key := "obj";
+                    
+                else
+                    
+                    i := i + 1;
+                    continue;
+                    
+                fi;
+                
+                search_tree := statement.(search_key);
+                
+                condition_func := function( tree, path )
+                    
+                    if tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_FUNC" then
+                        
+                        # we only want to find function calls inside of the current function, not other functions
+                        return not "stats" in path;
+                        
+                    fi;
+                    
+                    return false;
+                    
+                end;
+                
+                found_path := CapJitFindNodeDeep( search_tree, condition_func );
+                
+                if found_path = fail then
+                    
+                    i := i + 1;
+                    continue;
+                    
+                fi;
+
+                path := Concatenation( [ search_key ], found_path );
+                
+                func_call := CapJitGetNodeByPath( statement, path );
+                inline_func := func_call.funcref;
+                
+                if not ( Length( func_call.args ) = 0 and inline_func.narg = 0 ) then
+                    
+                    Error( "found function call with arguments, please inline arguments first" );
+                    
+                fi;
+                
+                if IsBound( inline_func.name ) then
+                    
+                    Info( InfoCapJit, 1, "####" );
+                    Info( InfoCapJit, 1, Concatenation( "Try to inline ", inline_func.name ) );
+                    
+                else
+                    
+                    Info( InfoCapJit, 1, "####" );
+                    Info( InfoCapJit, 1, "Try to inline function with the following arguments:" );
+                    Info( InfoCapJit, 1, inline_func.nams );
+                    
+                fi;
+
+                if CAP_JIT_INTERNAL_FUNCTION_CAN_BE_INLINED( func_call.funcref ) then
+                    
+                    counter := CAP_JIT_INTERNAL_INLINED_FUNCTION_COUNTER;
+                    
+                    # create new local variables
+                    new_nams := List( [ 1 .. inline_func.nloc ], i -> Concatenation( "inline_", String( counter ), "_", inline_func.nams[i] ) );
+                    Add( new_nams, Concatenation( "inline_", String( counter ), "_return_value" ) );
+
+                    Assert( 0, IsDuplicateFree( new_nams ) );
+                    
+                    # prepare function statements for inlining
+                    inline_func_stats := StructuralCopy( inline_func.stats );
+
+                    offset := current_func.narg + current_func.nloc;
+
+                    inline_func_stats := CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID( inline_func_stats, inline_func.id, current_func.id, offset );
+
+                    # find and modify the return statements
+                    return_value_lvar := offset + inline_func.nloc + 1;
+                    
+                    Assert( 0, return_value_lvar = Length( current_func.nams ) + Length( new_nams ) );
+                    
+                    if Last( inline_func_stats.statements ).type = "STAT_RETURN_OBJ" then
+                        
+                        inline_return_statements := [ Last( inline_func_stats.statements ) ];
+                    
+                    elif Last( inline_func_stats.statements ).type in [ "STAT_IF_ELSE", "STAT_IF_ELIF_ELSE" ] then
+                        
+                        inline_return_statements := List( Last( inline_func_stats.statements ).branches, b -> Last( b.body.statements ) );
+                        
+                    else
+                        
+                        Error( "this should never happen" );
+                        
+                    fi;
+                    
+                    for inline_return_statement in inline_return_statements do
+                    
+                        inline_return_statement.type := "STAT_ASS_FVAR";
+                        inline_return_statement.func_id := current_func.id;
+                        inline_return_statement.pos := return_value_lvar;
+                        inline_return_statement.initial_name := Last( new_nams );
+                        inline_return_statement.rhs := inline_return_statement.obj;
+                        Unbind( inline_return_statement.obj );
+
+                    od;
+                    
+                    # modify original statement
+                    inlined_original_statement := StructuralCopy( statement );
+                    ref_return_value_lvar := rec(
+                        type := "EXPR_REF_FVAR",
+                        func_id := current_func.id,
+                        pos := return_value_lvar,
+                        initial_name := Last( new_nams ),
+                    );
+                    
+                    parent := CapJitGetNodeByPath( inlined_original_statement, path{[ 1 .. (Length( path ) - 1) ]} );
+                    if IsList( parent ) then
+                        parent[Last( path )] := ref_return_value_lvar;
+                    else
+                        parent.(Last( path )) := ref_return_value_lvar;
+                    fi;
+                    
+                    statements := Concatenation( statements{[ 1 .. i-1 ]}, inline_func_stats.statements, [ inlined_original_statement ], statements{[ i+1 .. Length( statements ) ]} );
+                    
+                    current_func.nloc := current_func.nloc + inline_func.nloc + 1;
+                    
+                    current_func.nams := Concatenation( current_func.nams, new_nams );
+
+                    Assert( 0, Length( current_func.nams ) = current_func.narg + current_func.nloc );
+
+                    Assert( 0, IsDuplicateFreeList( current_func.nams ) );
+                    
+                    CAP_JIT_INTERNAL_INLINED_FUNCTION_COUNTER := CAP_JIT_INTERNAL_INLINED_FUNCTION_COUNTER + 1;
+
+                    Info( InfoCapJit, 1, "Successfully inlined." );
+    
+                else
+                    
+                    i := i + 1;
+                    
+                fi;
+                
+            od;
+            
+            tree.statements := statements;
+            
+        fi;
+
+        return tree;
+        
+    end;
+
+    additional_arguments_func := function( tree, key, current_func )
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            return tree;
+        
+        else
+            
+            return current_func;
+            
+        fi;
+        
+    end;
+
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, additional_arguments_func, fail );
+    
+end );

--- a/CompilerForCAP/gap/InlineSimpleFunctionCalls.gd
+++ b/CompilerForCAP/gap/InlineSimpleFunctionCalls.gd
@@ -1,0 +1,10 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Replaces function calls of the form `(function() return value; end)()` by `value`.
+#!   Assumes that arguments of function calls are inlined (i.e., you should use <Ref Func="CapJitInlinedArguments" /> first).
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitInlinedSimpleFunctionCalls" );

--- a/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
@@ -1,0 +1,31 @@
+InstallGlobalFunction( CapJitInlinedSimpleFunctionCalls, function( tree )
+  local pre_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Inline simple function calls." );
+    
+    pre_func := function( tree, additional_arguments )
+      local statements, statement, search_paths, condition_func, func_call, search_tree, found_path, path, inline_func, counter, new_nams, inline_func_stats, offset, inline_return_statement, return_value_lvar, inlined_original_statement, ref_return_value_lvar, parent, i, search_path;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_FUNC" and Length( tree.funcref.stats.statements ) = 1 and tree.funcref.stats.statements[1].type = "STAT_RETURN_OBJ" then
+            
+            if not ( Length( tree.args ) = 0 and tree.funcref.narg = 0 ) then
+                
+                Error( "found function call with arguments, please inline arguments first" );
+                
+            fi;
+
+            Info( InfoCapJit, 1, "####" );
+            Info( InfoCapJit, 1, "Inlined simple function call." );
+    
+            return tree.funcref.stats.statements[1].obj;
+            
+        fi;
+
+        return tree;
+        
+    end;
+
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );

--- a/CompilerForCAP/gap/InlineVariableAssignments.gd
+++ b/CompilerForCAP/gap/InlineVariableAssignments.gd
@@ -1,0 +1,18 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Example: transforms `function() local x; x := 1; return x^2; end` into `function() return 1^2; end()`.
+#!   Details: Searches for local variable assigments. Replace all references to the local variable in the same
+#!   STAT_SEQ_STAT as the assignment by the right-hand side of the assignment.
+#!   If the second argument is set to `true`, this is only done if the right-hand side is a reference to a global variable.
+#!   Assumes that any local variable is assigned at most once (this includes function arguments, which are assigned at least once,
+#!   namely when the function is called). An exception is made for "rapid reassignments": if the same variable is assigned
+#!   and then reassigned immediately in the next statement, the right-hand side of the first assignment is inserted
+#!   into the right-hand side of the second assignment.
+#!   Assumes that unused variables are dropped (i.e., you should use <Ref Func="CapJitDroppedUnusedVariables" /> first).
+#!   Drops the variables assignment after inlining if possible.
+#! @Returns a record
+#! @Arguments tree[, inline_gvars_only]
+DeclareGlobalFunction( "CapJitInlinedVariableAssignments" );

--- a/CompilerForCAP/gap/InlineVariableAssignments.gi
+++ b/CompilerForCAP/gap/InlineVariableAssignments.gi
@@ -1,0 +1,188 @@
+InstallGlobalFunction( CapJitInlinedVariableAssignments, function( tree, args... )
+  local inline_gvars_only, condition_func, path, lvar_path, lvar_assignment, parent_path, parent, inline_tree, subsequent_child, inline_tree_path, inline_tree_parent, func_path, func, func_id, number_of_assignments, pre_func, rhs, number_of_uses, modified_inline_tree;
+    
+    if not Length( args ) in [ 0, 1 ] then
+        
+        Error( "CapJitInlinedVariableAssignments cannot be called with more than two arguments" );
+        
+    fi;
+
+    if Length( args ) = 1 then
+        
+        Assert( 0, IsBool( args[1] ) );
+        
+        inline_gvars_only := args[1];
+        
+    else
+        
+        inline_gvars_only := false;
+        
+    fi;
+  
+    tree := StructuralCopy( tree );
+    
+    # find STAT_ASS_FVAR
+    condition_func := function( tree, path )
+        
+        if tree.type = "STAT_ASS_FVAR" and ( not inline_gvars_only or tree.rhs.type = "EXPR_REF_GVAR" ) then
+            
+            if IsBound( tree.CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT ) and tree.CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT then
+                
+                return false;
+                
+            fi;
+            
+            return true;
+            
+        fi;
+        
+        return false;
+        
+    end;
+    
+    lvar_path := CapJitFindNodeDeep( tree, condition_func );
+    
+    if lvar_path = fail then
+        
+        Info( InfoCapJit, 1, "####" );
+        Info( InfoCapJit, 1, "Inlined all variables, finished." );
+
+        # reset CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT
+        pre_func := function( tree, additional_arguments )
+          local level, pos;
+            
+            if IsRecord( tree ) and IsBound( tree.CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT ) then
+                
+                Unbind( tree.CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT );
+                
+            fi;
+                
+            return tree;
+            
+        end;
+        
+        CapJitIterateOverTree( tree, pre_func, ReturnTrue, ReturnTrue, true );
+        
+        return tree;
+        
+    fi;
+
+    lvar_assignment := CapJitGetNodeByPath( tree, lvar_path );
+    parent_path := lvar_path{[ 1 .. Length( lvar_path ) - 1 ]};
+    parent := CapJitGetNodeByPath( tree, parent_path );
+
+    # assert that parent is a STAT_SEQ_STAT
+    Assert( 0, IsInt( Last( lvar_path ) ) and Last( parent_path ) = "statements" and IsList( parent ) );
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, Concatenation( "Try to inline variable with initial name ", lvar_assignment.initial_name ), "." );
+    
+    # we want to ignore the variable in the next iteration in any case
+    lvar_assignment.CAP_JIT_IGNORE_VARIABLE_ASSIGNMENT := true;
+    
+    inline_tree := fail;
+    
+    if Length( parent ) >= Last( lvar_path ) + 1 then
+        
+        subsequent_child := parent[Last( lvar_path ) + 1];
+
+        # detect "rapid reassignment"
+        if subsequent_child.type = "STAT_ASS_FVAR" and subsequent_child.func_id = lvar_assignment.func_id and subsequent_child.pos = lvar_assignment.pos then
+            
+            Info( InfoCapJit, 1, "Found rapid reassignment." );
+            
+            inline_tree := subsequent_child.rhs;
+            inline_tree_path := Concatenation( parent_path, [ Last( lvar_path ) + 1, "rhs" ] );
+            inline_tree_parent := subsequent_child;
+            
+        else
+            
+            inline_tree_path := parent_path;
+            inline_tree := parent;
+            inline_tree_parent := CapJitGetNodeByPath( tree, parent_path{[ 1 .. Length( parent_path ) - 1 ]} );
+            
+        fi;
+        
+    else
+        
+        Info( InfoCapJit, 1, "Variable assignment is the last statement in STAT_SEQ_STAT. Skip inlining..." );
+        
+        return CapJitInlinedVariableAssignments( tree, inline_gvars_only );
+        
+    fi;
+
+    # replace all references to lvar by rhs
+    rhs := lvar_assignment.rhs;
+    number_of_uses := 0;
+    
+    pre_func := function( tree, additional_arguments )
+        
+        if IsRecord( tree ) then
+            
+            if PositionSublist( tree.type, "FVAR" ) <> fail and tree.func_id = lvar_assignment.func_id and tree.pos = lvar_assignment.pos then
+                
+                if tree.type = "EXPR_REF_FVAR" then
+                    
+                    number_of_uses := number_of_uses + 1;
+
+                    return StructuralCopy( rhs );
+                
+                fi;
+                
+            fi;
+
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    modified_inline_tree := CapJitIterateOverTree( inline_tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+
+    if number_of_uses = 0 then
+
+        Info( InfoCapJit, 1, "Variable is unused." );
+        
+    else
+        
+        Info( InfoCapJit, 1, "Success." );
+        
+        # replace inline_tree
+        if IsInt( Last( inline_tree_path ) ) then
+            
+            Assert( 0, IsList( inline_tree_parent ) );
+            
+            inline_tree_parent[Last( inline_tree_path )] := modified_inline_tree;
+            
+        else
+            
+            Assert( 0, IsRecord( inline_tree_parent ) );
+            
+            inline_tree_parent.(Last( inline_tree_path )) := modified_inline_tree;
+            
+        fi; 
+        
+    fi;
+
+    # drop lvar assignment if possible
+
+    # get func containing lvar assignment
+    func_path := ShallowCopy( lvar_path );
+    
+    # find "stats"
+    while Last( func_path ) <> "stats" do
+        
+        Remove( func_path );
+        
+    od;
+    
+    # remove "stats"
+    Remove( func_path );
+    
+    Info( InfoCapJit, 1, "Try to drop variable assignment:" );
+        
+    tree := CapJitDroppedUnusedVariables( tree, func_path );
+    
+    return CapJitInlinedVariableAssignments( tree, inline_gvars_only );
+    
+end );

--- a/CompilerForCAP/gap/IterateOverTree.gd
+++ b/CompilerForCAP/gap/IterateOverTree.gd
@@ -1,0 +1,48 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Iterating over a syntax tree
+
+#! @Description
+#!   Iterates recursively over a syntax tree and calls <A>pre_func</A> and <A>result_func</A> for each node.
+#!   Overview:
+#!     * <A>pre_func</A> allows to modify a (sub-)tree before the recursion over its children. For example, you could
+#!         detect occurrences of `if true then &lt;body&gt; fi;` and simply return the body to simplify the tree.
+#!     * <A>result_func</A> allows to construct the return value of a (sub-)tree from the return values of its children.
+#!         For example, if you want to check if a node of a certain type occurs in the tree, return `true`
+#!         if <A>tree</A> has the type or any of the children returned `true`, otherwise return `false`.
+#!     * <A>additional_arguments[_func]</A> allows to create and pass additional data to the children of <A>tree</A>,
+#!         for example the path or the function stack.
+#!
+#!   Details:
+#!     * First, <A>pre_func</A> is called with the following arguments:
+#!         <A>tree</A> and <A>additional_arguments</A>.
+#!       If it returns `fail`, the recursion is skipped and <A>result_func</A> is called immediately
+#!       with `result` set to `fail` (see below).
+#!       Otherwise it must return a syntax tree, which is then used as the value of <A>tree</A> for the remaining computation.
+#!       If you do not need this function, use `ReturnFirst`.
+#!     * Secondly, for each child of <A>tree</A>, <A>additional_arguments_func</A> is called with the following arguments:
+#!         <A>tree</A>, the key of the child, and <A>additional_arguments</A>.
+#!       If <A>tree</A> is a list, the key of a child is its list index.
+#!       If <A>tree</A> is a record, the key of a child is the corresponding record name of <A>tree</A>.
+#!       The return value is used in the next step.
+#!     * Next, the recursion starts: for each child, <Ref Func="CapJitIterateOverTree" /> is called again with the following arguments:
+#!         the child, <A>pre_func</A>, <A>result_func</A>, <A>additional_arguments_func</A>, and the return value of the
+#!         call of <A>additional_arguments_func</A> in the step above.
+#!     * The results of the recursive calls are stored in the variable `result`:
+#!       If <A>tree</A> is a list, `result` is also a list
+#!         and the `i`-th entry of this list is the return value of the `result_func` of the `i`-th child.
+#!       If <A>tree</A> is a record, `result` is also a record
+#!         and `result.(key)` is the return value of the `result_func` of the child named `key`.
+#!     * Next, <A>result_func</A> is called with the following arguments:
+#!         <A>tree</A>, `result`, and <A>additional_arguments</A>.
+#!       The return value should be the result of the current tree formed by combining the results of the children.
+#!       For an example see <Ref Func="CapJitResultFuncCombineChildren" />.
+#!     * Finally, the return value of <A>result_func</A> is returned.
+#!
+#!   Note: This function on its own does not modify the tree.
+#!   However, you can make modifications in <A>pre_func</A>, <A>result_func</A>, and <A>additional_arguments_func</A>.
+#!   If you do not want to make these modifcations in-place, you can replace a (sub-)tree by a modified version in <A>pre_func</A>
+#!   and combine the modified (sub-)trees again using <Ref Func="CapJitResultFuncCombineChildren" /> as <A>result_func</A>.
+#! @Returns see description
+#! @Arguments tree, pre_func, result_func, additional_arguments_func, additional_arguments
+DeclareGlobalFunction( "CapJitIterateOverTree" );

--- a/CompilerForCAP/gap/IterateOverTree.gi
+++ b/CompilerForCAP/gap/IterateOverTree.gi
@@ -1,0 +1,174 @@
+BindGlobal( "CAP_JIT_INTERNAL_ITERATION_KEYS", rec(
+    EXPR_FUNC := "stats",
+    STAT_SEQ_STAT := "statements",
+    STAT_SEQ_STAT2 := "statements",
+    STAT_SEQ_STAT3 := "statements",
+    STAT_SEQ_STAT4 := "statements",
+    STAT_SEQ_STAT5 := "statements",
+    STAT_SEQ_STAT6 := "statements",
+    STAT_SEQ_STAT7 := "statements",
+    STAT_ASS_LVAR := "rhs",
+    STAT_ASS_FVAR := "rhs",
+    EXPR_FUNCCALL := [ "funcref", "args" ],
+    EXPR_FUNCCALL_0ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_1ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_2ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_3ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_4ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_5ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_6ARGS := [ "funcref", "args" ],
+    EXPR_FUNCCALL_XARGS := [ "funcref", "args" ],
+    STAT_PROCCALL := [ "funcref", "args" ],
+    STAT_PROCCALL_0ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_1ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_2ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_3ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_4ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_5ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_6ARGS := [ "funcref", "args" ],
+    STAT_PROCCALL_XARGS := [ "funcref", "args" ],
+    EXPR_REF_LVAR := fail,
+    EXPR_REF_HVAR := fail,
+    EXPR_REF_FVAR := fail,
+    EXPR_REF_GVAR := fail,
+    STAT_RETURN_VOID := fail,
+    STAT_IF := [ "branches" ],
+    STAT_IF_ELSE := [ "branches" ],
+    STAT_IF_ELIF := [ "branches" ],
+    STAT_IF_ELIF_ELSE := [ "branches" ],
+    STAT_FOR := [ "variable", "collection", "body" ],
+    STAT_ASS_LIST := [ "list", "pos", "rhs" ],
+    EXPR_ELM_LIST := [ "list", "pos" ],
+    EXPR_ELMS_LIST := [ "list", "poss" ],
+    EXPR_ISB_LIST := [ "list", "pos" ],
+    EXPR_ELM_REC_NAME := [ "record" ],
+    EXPR_ELM_REC_EXPR := [ "record", "expression" ],
+    EXPR_ISB_REC_EXPR := [ "record", "expression" ],
+    EXPR_ELM_COMOBJ_NAME := [ "comobj" ],
+    EXPR_ISB_COMOBJ_NAME := [ "comobj" ],
+    EXPR_ELM_MAT := [ "list", "row", "col" ],
+    EXPR_LIST := "list",
+    STAT_RETURN_OBJ := "obj",
+    EXPR_RANGE := [ "first", "last" ],
+    EXPR_INT := fail,
+    EXPR_STRING := fail,
+    EXPR_TRUE := fail,
+    EXPR_FALSE := fail,
+    STAT_EMPTY := fail,
+    STAT_PRAGMA := fail,
+    STAT_CONTINUE := fail,
+    STAT_BREAK := fail,
+    EXPR_PROD := [ "left", "right" ],
+    EXPR_QUO := [ "left", "right" ],
+    EXPR_SUM := [ "left", "right" ],
+    EXPR_AINV := [ "op" ],
+    EXPR_DIFF := [ "left", "right" ],
+    EXPR_EQ := [ "left", "right" ],
+    EXPR_NE := [ "left", "right" ],
+    EXPR_LE := [ "left", "right" ],
+    EXPR_GE := [ "left", "right" ],
+    EXPR_LT := [ "left", "right" ],
+    EXPR_GT := [ "left", "right" ],
+    EXPR_AND := [ "left", "right" ],
+    EXPR_OR := [ "left", "right" ],
+    EXPR_IN := [ "left", "right" ],
+    EXPR_NOT := [ "op" ],
+    EXPR_REC := [ "keyvalue" ],
+    STAT_ASSERT_2ARGS := [ "level", "condition" ],
+    STAT_ASSERT_3ARGS := [ "level", "condition", "message" ],
+    STAT_INFO := [ "sel", "lev", "args" ],
+    BRANCH_IF := [ "condition", "body" ],
+    REC_KEY_VALUE_PAIR := [ "value" ],
+) );
+
+InstallGlobalFunction( CapJitIterateOverTree, function( tree, pre_func, result_func, additional_arguments_func, additional_arguments )
+  local pre_func_result, result, type, keys, key;
+    
+    pre_func_result := pre_func( tree, additional_arguments );
+    
+    # check if we should stop iteration
+    if pre_func_result = fail then
+        
+        return result_func( tree, fail, additional_arguments );
+        
+    fi;
+    
+    # continue iteration
+    tree := pre_func_result;
+    
+    if IsList( tree ) then
+       
+        result := [];
+        
+        for key in [ 1 .. Length( tree ) ] do
+            
+            result[key] := CapJitIterateOverTree( tree[key], pre_func, result_func, additional_arguments_func, additional_arguments_func( tree, key, additional_arguments ) );
+            
+        od;
+
+        return result_func( tree, result, additional_arguments );
+
+    fi;
+    
+    if not IsRecord( tree ) then
+        
+        Display( tree );
+        
+        Error( "tree is neither a list nor a record" );
+        
+    fi;
+    
+    if IsBound(tree.type) then
+        
+        type := tree.type; 
+    
+    elif SortedList( RecNames( tree ) ) = [ "body", "condition" ] then
+        
+        type := "BRANCH_IF";
+        
+    else
+        
+        Display( tree );
+        
+        Error( "cannot determine type of tree" );
+        
+    fi;
+    
+    if not IsBound(CAP_JIT_INTERNAL_ITERATION_KEYS.(type)) then
+        
+        Display( tree );
+        
+        Error( "cannot find iteration key" );
+
+    fi;
+    
+    result := rec();
+
+    keys := CAP_JIT_INTERNAL_ITERATION_KEYS.(type);
+    if keys <> fail then
+       
+        if IsString( keys ) then
+            
+            keys := [ keys ];
+            
+        fi;
+
+        for key in keys do
+           
+            if not IsBound(tree.(key)) then
+                
+                Display( tree );
+        
+                Error( "invalid iteration key" );
+            
+            fi;
+            
+            result.(key) := CapJitIterateOverTree( tree.(key), pre_func, result_func, additional_arguments_func, additional_arguments_func( tree, key, additional_arguments ) );
+
+        od;
+        
+    fi;
+
+    return result_func( tree, result, additional_arguments );
+    
+end );

--- a/CompilerForCAP/gap/Logic.gd
+++ b/CompilerForCAP/gap/Logic.gd
@@ -1,0 +1,22 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Logic
+
+#! @Description
+#!   Adds the function <A>func</A> to the list of logic functions.
+#!   For a list of pre-installed logic functions, which can be used as guiding examples, see `CompilerForCAP/gap/Logic.gi`.
+#!   Technically, <A>func</A> should accept an (enhanced) syntax tree and some JIT arguments and return an (enhanced) syntax tree.
+#!   Semantically, <A>func</A> should use some kind of "logic" to transform the tree.
+#!   For example, <A>func</A> could look for calls of `CallFuncList` and replace them by calls to the actual function.
+#!   Note: Often it is easier to use a logic template (see <Ref Func="CapJitAddLogicTemplate" />) than a logic function.
+#! @Arguments func
+DeclareGlobalFunction( "CapJitAddLogicFunction" );
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Applies all logic functions (see <Ref Func="CapJitAddLogicFunction" />) and logic templates
+#!   (see <Ref Func="CapJitAppliedLogicTemplates" />) to <A>tree</A>.
+#! @Returns a record
+#! @Arguments tree, jit_args
+DeclareGlobalFunction( "CapJitAppliedLogic" );

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -1,0 +1,219 @@
+BindGlobal( "CAP_JIT_LOGIC_FUNCTIONS", [ ] );
+
+InstallGlobalFunction( CapJitAddLogicFunction, function( func )
+    
+    if not IsFunction( func ) then
+        
+        Error( "a logic function must be a function" );
+        
+    fi;
+    
+    if not NumberArgumentsFunction( func ) in [ -2, -1, 2 ] then
+        
+        Error( "a logic function must be callable with two arguments" );
+        
+    fi;
+    
+    Add( CAP_JIT_LOGIC_FUNCTIONS, func );
+    
+end );
+
+InstallGlobalFunction( CapJitAppliedLogic, function( tree, jit_args )
+  local logic_function;
+    
+    for logic_function in CAP_JIT_LOGIC_FUNCTIONS do
+        
+        tree := CallFuncList( logic_function, [ tree, jit_args ] );
+        
+    od;
+    
+    tree := CapJitAppliedLogicTemplates( tree, jit_args );
+    
+    return tree;
+    
+end );
+
+# Concatenation( [ a, b, ... ], [ c, d, ... ], ... ) => [ a, b, ..., c, d, ... ]
+CapJitAddLogicFunction( function( tree, jit_args )
+  local pre_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic for concatenation of lists." );
+    
+    pre_func := function( tree, additional_arguments )
+      local args;
+        
+        if CapJitIsCallToGlobalFunction( tree, "Concatenation" ) then
+            
+            args := tree.args;
+            
+            if ForAll( args, a -> a.type = "EXPR_LIST" ) then
+                
+                return rec(
+                    type := "EXPR_LIST",
+                    list := Concatenation( List( args, a -> a.list ) ),
+                );
+                
+            fi;
+
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );
+
+# CallFuncList( func, [ a, b, ... ] ) => func( a, b, ... )
+CapJitAddLogicFunction( function( tree, jit_args )
+  local pre_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic for CallFuncList." );
+    
+    pre_func := function( tree, additional_arguments )
+      local args;
+        
+        if CapJitIsCallToGlobalFunction( tree, "CallFuncList" ) then
+            
+            args := tree.args;
+            
+            if args[2].type = "EXPR_LIST" then
+                
+                return rec(
+                    type := "EXPR_FUNCCALL",
+                    funcref := args[1],
+                    args := args[2].list,
+                );
+                
+            fi;
+            
+        fi;
+        
+        return tree;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );
+
+# AttributeGetter( ObjectifyWithAttributes( ..., Attribute, value, ... ) ) => value
+CapJitAddLogicFunction( function( tree, jit_args )
+  local pre_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic for attribute getters." );
+    
+    pre_func := function( tree, additional_arguments )
+      local args, object, value, pos;
+        
+        if CapJitIsCallToGlobalFunction( tree, gvar -> IsAttribute( ValueGlobal( gvar ) ) ) then
+            
+            args := tree.args;
+            
+            # an attribute getter only has a single argument
+            Assert( 0, Length( args ) = 1 );
+            
+            object := args[1];
+
+            if CapJitIsCallToGlobalFunction( object, "ObjectifyWithAttributes" ) then
+                
+                pos := PositionProperty( object.args, a -> a.type = "EXPR_REF_GVAR" and a.gvar = tree.funcref.gvar );
+                
+                if pos <> fail then
+                    
+                    Assert( 0, IsBound( object.args[pos + 1] ) );
+                    
+                    return object.args[pos + 1];
+                    
+                fi;
+                
+            fi;
+
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );
+
+# if <condition> then <body>; return <value>; fi; <more statements>
+# =>
+# if <condition> then <body>; return <value>; else <more statements>; fi
+CapJitAddLogicFunction( function( tree, jit_args )
+  local pre_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic for ifs." );
+    
+    pre_func := function( tree, additional_arguments )
+      local statements, i, statement, new_branch;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            statements := tree.stats.statements;
+
+            # find if ... then ...; return ...; elif ...; return ...; fi; (excluding the last statement)
+            i := 1;
+            while i <= Length( statements ) - 1 do
+                
+                statement := statements[i];
+                
+                if StartsWith( statement.type, "STAT_IF" ) and ForAll( statement.branches, b -> Last( b.body.statements ).type = "STAT_RETURN_OBJ" ) then
+                    # we are in the main sequence of statements of a function => we are not inside of a loop
+                    # and all branches end with a return statement
+                    # => we reach the remaining statements iff none of the conditions of the branches match
+
+                    if Last( statement.branches ).condition.type = "EXPR_TRUE" then
+                        
+                        Error( "found unreachable code, this is not yet handled" );
+
+                    else
+                        
+                        Assert( 0, not EndsWith( statement.type, "_ELSE" ) );
+                        
+                        # put remaining statements into an else branch
+                        statement.type := Concatenation( statement.type, "_ELSE" );
+                        
+                        new_branch := rec(
+                            type := "BRANCH_IF",
+                            condition := rec(
+                                type := "EXPR_TRUE",
+                            ),
+                            body := rec(
+                                type := "STAT_SEQ_STAT",
+                                statements := statements{[ i+1 .. Length( statements ) ]},
+                            ),
+                        );
+                        
+                        Add( statement.branches, new_branch );
+                        
+                        statements := statements{[ 1 .. i ]};
+
+                        tree := ShallowCopy( tree );
+                        tree.stats := ShallowCopy( tree.stats );
+                        tree.stats.statements := statements;
+                        
+                    fi;
+                    
+                fi;
+                
+                i := i + 1;
+                
+            od;
+            
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );

--- a/CompilerForCAP/gap/LogicTemplates.gd
+++ b/CompilerForCAP/gap/LogicTemplates.gd
@@ -1,0 +1,60 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Logic
+
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE" );
+
+#! @Description
+#!   Adds the logic template <A>template</A> to the list of logic templates.
+#!   For a list of pre-installed logic templates, which can be used as guiding examples, see `CompilerForCAP/gap/LogicTemplates.gi`.
+#!   Logic templates are records with the following entries:
+#!     * `src_template` and `dst_template` (required): strings containing valid GAP code
+#!     * `variable_names` (required): a list of strings
+#!     * `variable_filters` (optional): a list of filters with the same length as `variable_names`, defaults to a list of `IsObject`
+#!     * `returns_value` (required): a boolean
+#!     * `new_funcs` (optional): a list of lists of strings, defaults to the empty list
+#!     * `needed_packages` (optional): a list of pairs (i.e. lists with two entries) of strings, defaults to the empty list
+#!     * `debug` (optional): a boolean
+#!     * `debug_path` (optional): a path
+#!
+#!   Semantics: `src_template` is a piece of code which should be replaced by `dst_template`:
+#!     * The function <Ref Func="CapJitAppliedLogicTemplates" /> tries to find occurences of `src_template` in a tree and
+#!       potentially replaces them by `dst_template`.
+#!     * When trying to find an occurence of `src_template` in a tree, all strings occuring in the list `variable_names`
+#!       are considered as variables, i.e., they match any value in the tree. If a variable occurs
+#!       multiple times, the corresponding parts of the tree must be equal.
+#!     * <Ref Func="CapJitAppliedLogicTemplates" /> uses <A>jit_args</A> to compute a concrete value of each variable.
+#!       The template is only applied if all values match the corresponding filters in `variable_filters`.
+#!     * For each function in `dst_template`, <Ref Func="CapJitAppliedLogicTemplates" /> tries to find a corresponding function in
+#!       `src_template`. The functions are matched by comparing the lists of names of local variables. If for a function in
+#!       `dst_template` no corresponding function in `src_template` exists, you have to add the list of names of local variables
+#!       of this function to `new_funcs`.
+#!     * `returns_value` must be `true` if `src_template` defines an expression, `false` if it defines a statement.
+#!     * `needed_packages` has the same format as `NeededOtherPackages` in `PackageInfo.g`. The template is only evaluated if
+#!       the packages in `needed_packages` are loaded in the correct versions.
+#!     * `debug` can be set to `true` to print more information while <Ref Func="CapJitAppliedLogicTemplates" /> tries to apply the template.
+#!       (Note: this causes informational break loops which are not actual errors).
+#!     * `debug_path` can be set to a specific path to get exact information why the subtree at this path does or does not match
+#!       `src_template`.
+#!
+#!    Technical note: `src_template` is only replaced by `dst_template` if the result is well-defined, i.e., if all function variables
+#!    reference only functions in their function stack. This can be used to move "static" variables (i.e. variables not depending
+#!    on local variables) outside of functions. Example: consider a template with `src_template` given by
+#!    `Sum( List( L, x -> x^2 * value ) )` and `dst_template` given by `Sum( List( L, x -> x^2 ) ) * value` (assuming distributivity).
+#!    This replacement is only valid if `value` is independent of `x`. However, we do not need to make this explicit at any point,
+#!    because if `value` depends on `x`, the result `Sum( List( L, x -> x^2 ) ) * value` is not well-defined,
+#!    so the template is not applied anyway.
+#! @Arguments template
+DeclareGlobalFunction( "CapJitAddLogicTemplate" );
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Applies all logic templates (see <Ref Func="CapJitAddLogicTemplate" />) to <A>tree</A>.
+#!   The arguments <A>jit_args</A> are used to infer the types of variables.
+#!   If the third argument is set to `true`, only templates with empty `dst_template` are applied.
+#!   This can be used to quickly drop unwanted statements from the tree without applying all
+#!   (possibly expensive) logic templates.
+#! @Returns a record
+#! @Arguments tree, jit_args[, cleanup_only]
+DeclareGlobalFunction( "CapJitAppliedLogicTemplates" );

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -1,0 +1,780 @@
+BindGlobal( "CAP_JIT_LOGIC_TEMPLATES", [
+    # if ... then Error( ... ); fi;
+    rec(
+        variable_names := [ "condition", "message" ],
+        src_template := "if condition then Error( message ); fi;",
+        dst_template := "",
+        returns_value := false,
+    ),
+    # INSTALL_TODO_FOR_LOGICAL_THEOREMS
+    rec(
+        variable_names := [ "condition", "objectified_morphism", "source", "range", "category" ],
+        src_template := """
+            if condition then
+                INSTALL_TODO_FOR_LOGICAL_THEOREMS( "Source", [ objectified_morphism ], source, category );
+                INSTALL_TODO_FOR_LOGICAL_THEOREMS( "Range", [ objectified_morphism ], range, category );
+            fi;
+        """,
+        dst_template := "",
+        returns_value := false,
+    ),
+    # Assert( level, condition )
+    rec(
+        variable_names := [ "level", "condition" ],
+        src_template := "Assert( level, condition )",
+        dst_template := "",
+        returns_value := false,
+    ),
+    # Assert( level, condition, message )
+    rec(
+        variable_names := [ "level", "condition", "message" ],
+        src_template := "Assert( level, condition, message )",
+        dst_template := "",
+        returns_value := false,
+    ),
+    # List( List( L, f ), g ) => List( L, x -> g( f( x ) ) )
+    rec(
+        variable_names := [ "list", "outer_func", "inner_func" ],
+        src_template := "List( List( list, inner_func ), outer_func )",
+        dst_template := "List( list, x -> outer_func( inner_func( x ) ) )",
+        new_funcs := [ [ "x" ] ],
+        returns_value := true,
+    ),
+    # List( L, f )[index] => f( L[index] )
+    rec(
+        variable_names := [ "list", "func", "index" ],
+        src_template := "List( list, func )[index]",
+        dst_template := "func( list[index] )",
+        returns_value := true,
+    ),
+] );
+
+InstallGlobalFunction( CapJitAddLogicTemplate, function( template )
+    
+    # some basic sanity checks
+    if not IsRecord( template ) then
+        
+        Error( "a logic template must be a record" );
+        
+    fi;
+    
+    if not IsSubset( RecNames( template ), [ "variable_names", "src_template", "dst_template", "returns_value" ] ) then
+        
+        Error( "a logic template must have the following required record entries: variable_names, src_template, dst_template, returns_value" );
+        
+    fi;
+
+    if IsBound( template.variable_filters ) and Length( template.variable_names ) <> Length( template.variable_filters ) then
+        
+        Error( "the length of the record entries variable_names and variable_filters of a logic template must be equal" );
+        
+    fi;
+
+    if IsBound( template.needed_packages ) and ( not IsList( template.needed_packages ) or ForAny( template.needed_packages, p -> not IsList( p ) or Length( p ) <> 2 ) ) then
+        
+        Error( "the record entry needed_packages of a logic template must be a list of pairs" );
+        
+    fi;
+    
+    Add( CAP_JIT_LOGIC_TEMPLATES, template );
+    
+end );
+
+InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function( tree, template_tree, args... )
+  local debug, variables, pre_func, result_func, additional_arguments_func, result;
+    
+    if not Length( args ) in [ 0, 1 ] then
+        
+        Error( "CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE cannot be called with more than three arguments" );
+        
+    fi;
+
+    if Length( args ) = 1 then
+        
+        Assert( 0, IsBool( args[1] ) );
+        
+        debug := args[1];
+        
+    else
+        
+        debug := false;
+        
+    fi;
+  
+    variables := [];
+
+    pre_func := function( tree, additional_arguments )
+      local template_tree;
+        
+        template_tree := additional_arguments[1];
+
+        if template_tree = fail then
+
+            return fail;
+            
+        fi;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" and template_tree.type = "EXPR_FUNC" then
+            
+            template_tree.stats := CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID( template_tree.stats, template_tree.id, tree.id, 0 );
+            template_tree.id := tree.id;
+            template_tree.real_nloc := tree.nloc;
+            template_tree.real_nams := tree.nams;
+            
+        fi;
+        
+        return tree;
+        
+    end;
+    
+    result_func := function( tree, result, additional_arguments )
+      local template_tree, path, var_number, r, key;
+        
+        template_tree := additional_arguments[1];
+        path := additional_arguments[2];
+      
+        if debug then
+            Display( "now matching against" );
+            Display( template_tree );
+            Display( "result" );
+            Display( result );
+        fi;
+            
+        if template_tree = fail then
+            
+            Assert( 0, result = fail );
+            
+            return false;
+      
+        elif IsList( result ) then
+            
+            for r in result do
+                
+                if r = false then
+                    
+                    if debug then
+                        Display( "child mismatch" );
+                    fi;
+                    
+                    return false;
+                    
+                fi;
+                
+            od;
+
+            if debug then
+                Display( "list length match" );
+                Display( Length( tree ) = Length( template_tree ) );
+            fi;
+            
+            return Length( tree ) = Length( template_tree );
+            
+        elif IsRecord( result ) then
+
+            if template_tree.type = "EXPR_REF_GVAR" and StartsWith( template_tree.gvar, "CAP_INTERNAL_JIT_TEMPLATE_VAR_" ) then
+                
+                var_number := Int( ReplacedString( template_tree.gvar, "CAP_INTERNAL_JIT_TEMPLATE_VAR_", "" ) );
+                
+                Assert( 0, var_number <> fail );
+
+                if not IsBound( variables[var_number] ) then
+                    
+                    variables[var_number] := rec(
+                        path := path,
+                        tree := tree,
+                    );
+
+                    if debug then
+                        Display( "matched via variable1" );
+                        Display( true );
+                    fi;
+                    
+                    return true;
+                    
+                else
+
+                    if debug then
+                        Display( "matched via variable2" );
+                        Display( variables[var_number].tree = tree );
+                    fi;
+                    
+                    return variables[var_number].tree = tree;
+                    
+                fi;
+                
+            fi;
+
+            if template_tree.type <> tree.type then
+                
+                if debug then
+                    Display( "type mismatch" );
+                fi;
+                
+                return false;
+                
+            fi;
+            
+            for key in RecNames( template_tree ) do
+
+                if debug then
+                    Display( "checking" );
+                    Display( key );
+                fi;
+                
+                # ignore these keys
+                if key in [ "nams", "nloc", "real_nams", "real_nloc", "initial_name" ] then
+                    
+                    continue;
+                    
+                fi;
+
+                Assert( 0, IsBound( tree.(key) ) );
+
+                # different gvars might point to the same value
+                if key = "gvar" then
+                    
+                    if IsIdenticalObj( ValueGlobal( template_tree.gvar ), ValueGlobal( tree.gvar ) ) then
+                        
+                        if debug then
+                            Display( "match: gvars point to identical values" );
+                        fi;
+                
+                        continue;
+                        
+                    else
+                        
+                        if debug then
+                            Display( "mismatch: gvars point to non-identical values" );
+                        fi;
+
+                        return false;
+                        
+                    fi;
+                        
+                fi;
+                
+                # check if children match
+                if IsBound( result.(key) ) then
+                    
+                    if result.(key) = false then
+                        
+                        if debug then
+                            Display( "result mismatch" );
+                            Display( key );
+                        fi;
+                        
+                        return false;
+                        
+                    else
+                        
+                        continue;
+                        
+                    fi;
+                    
+                fi;
+                
+                # now there should only remain integers, booleans or strings
+                Assert( 0, IsInt( template_tree.(key) ) or IsBool( template_tree.(key) ) or IsString( template_tree.(key) ) );
+                
+                if template_tree.(key) <> tree.(key) then
+                    
+                    if debug then
+                        Display( "tree mismatch" );
+                        Display( key );
+                    fi;
+                    
+                    return false;
+                    
+                else
+                    
+                    continue;
+                    
+                fi;
+
+                Error( "should never get here" );
+                
+            od;
+
+            if debug then
+                Display( "everything matched" );
+            fi;
+            
+            return true;
+
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    additional_arguments_func := function( tree, key, additional_arguments )
+      local template_tree, path;
+        
+        template_tree := additional_arguments[1];
+        path := additional_arguments[2];
+      
+        if template_tree = fail then
+            
+            # do nothing
+            
+        elif IsList( tree ) then
+            
+            Assert( 0, IsList( template_tree ) );
+            
+            if IsBound( template_tree[key] ) then
+                
+                template_tree := template_tree[key];
+                
+            else
+                
+                template_tree := fail;
+                
+            fi;
+
+        elif IsRecord( tree ) then
+            
+            Assert( 0, IsRecord( template_tree ) );
+            
+            if tree.type = template_tree.type then
+                
+                Assert( 0, IsBound( template_tree.(key) ) );
+                
+                template_tree := template_tree.(key);
+                
+            else
+                
+                template_tree := fail;
+                
+            fi;
+
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+
+        path := Concatenation( path, [ key ] );
+
+        return [ template_tree, path ];
+        
+    end;
+    
+    result := CapJitIterateOverTree( tree, pre_func, result_func, additional_arguments_func, [ template_tree, [] ] );
+
+    if result then
+    
+        return variables;
+    
+    else
+        
+        return fail;
+        
+    fi;
+    
+end );
+
+InstallGlobalFunction( CapJitAppliedLogicTemplates, function( tree, jit_args, args... )
+  local cleanup_only, template, variable_names, variable_filters, src_template, dst_template, new_funcs, i, template_var_name, src_template_tree, dst_template_tree, variables, matched_src_template_tree, condition_func, path, match, new_tree, parent, variable_path, filter, result, value, dst_tree, pre_func;
+    
+    if not Length( args ) in [ 0, 1 ] then
+        
+        Error( "CapJitAppliedLogicTemplates cannot be called with more than three arguments" );
+        
+    fi;
+
+    if Length( args ) = 1 then
+        
+        Assert( 0, IsBool( args[1] ) );
+        
+        cleanup_only := args[1];
+        
+    else
+        
+        cleanup_only := false;
+        
+    fi;
+  
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic templates." );
+    
+    tree := StructuralCopy( tree );
+  
+    for template in CAP_JIT_LOGIC_TEMPLATES do
+        
+        variable_names := template.variable_names;
+        
+        if IsBound( template.variable_filters ) then
+            
+            # replace strings with actual filters
+            variable_filters := List( template.variable_filters, function( f )
+                
+                if IsString( f ) then
+                    
+                    return ValueGlobal( f );
+                    
+                else
+                    
+                    return f;
+                    
+                fi;
+                
+            end );
+            
+        else
+            
+            variable_filters := ListWithIdenticalEntries( Length( variable_names ), IsObject );
+            
+        fi;
+        
+        Assert( 0, Length( variable_names ) = Length( variable_filters ) );
+
+        if IsBound( template.needed_packages ) then
+            
+            # check if all needed packages are loaded
+            if not ForAll( template.needed_packages, p -> IsPackageMarkedForLoading( p[1], p[2] ) ) then
+                
+                continue;
+                
+            fi;
+            
+        fi;
+        
+        src_template := template.src_template;
+        dst_template := template.dst_template;
+
+        if cleanup_only and dst_template <> "" then
+            
+            continue;
+            
+        fi;
+        
+        if IsBound( template.new_funcs ) then
+            
+            new_funcs := template.new_funcs;
+            
+        else
+            
+            new_funcs := [];
+            
+        fi;
+        
+        for i in [ 1 .. Length( variable_names ) ] do
+            
+            template_var_name := Concatenation( "CAP_INTERNAL_JIT_TEMPLATE_VAR_", String( i ) );
+
+            if not template_var_name in NamesGVars() then
+            
+                DeclareGlobalVariable( template_var_name );
+
+            fi;
+            
+            src_template := ReplacedString( src_template, variable_names[i], template_var_name );
+            dst_template := ReplacedString( dst_template, variable_names[i], template_var_name );
+            
+        od;
+        
+        # to get a syntax tree we have to wrap the template in a function
+        
+        if template.returns_value then
+
+            src_template_tree := ENHANCED_SYNTAX_TREE( EvalString( Concatenation( "x -> ", src_template ) ) ).stats.statements[1].obj;
+            dst_template_tree := ENHANCED_SYNTAX_TREE( EvalString( Concatenation( "x -> ", dst_template ) ) ).stats.statements[1].obj;
+        
+        else
+            
+            src_template_tree := ENHANCED_SYNTAX_TREE( EvalString( Concatenation( "function() ", src_template, " ; return; end;" ) ) ).stats.statements[1];
+            dst_template_tree := ENHANCED_SYNTAX_TREE( EvalString( Concatenation( "function() ", dst_template, " ; return; end;" ) ) ).stats.statements[1];
+
+        fi;
+
+        while true do
+            
+            if IsBound( template.debug ) and template.debug then
+                
+                Display( "try to match template:" );
+                Display( src_template );
+                
+            fi;
+            
+            # will be modified inplace
+            variables := fail;
+            matched_src_template_tree := StructuralCopy( src_template_tree );
+            
+            condition_func := function( tree, path )
+                
+                # check if we know that the template does not match
+                if IsBound( tree.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE ) and tree.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE then
+                    
+                    return false;
+                    
+                fi;
+                
+                # check if we already have a match
+                if variables <> fail then
+                    
+                    return false;
+                    
+                fi;
+                
+                # matched_src_template_tree is modified inplace 
+                if IsBound( template.debug_path ) and template.debug_path = path then
+                    
+                    variables := CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE( tree, matched_src_template_tree, true );
+                    
+                else
+                    
+                    variables := CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE( tree, matched_src_template_tree );
+                    
+                fi;
+
+                if variables = fail then
+                    
+                    tree.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE := true;
+
+                fi;
+                
+                return variables <> fail;
+                
+            end;
+            
+            path := CapJitFindNodeDeep( tree, condition_func );
+
+            if path = fail then
+                
+                Assert( 0, variables = fail );
+                
+                if IsBound( template.debug ) and template.debug then
+                    
+                    Display( "could not find a match" );
+                    
+                fi;
+            
+                # no further occurrences -> done
+                break;
+                
+            fi;
+            
+            if IsBound( template.debug ) and template.debug then
+                
+                Error( "found match" );
+                
+            fi;
+            
+            # not handled yet
+            Assert( 0, Length( path ) >= 1 );
+
+            match := CapJitGetNodeByPath( tree, path );
+
+            new_tree := StructuralCopy( tree );
+            parent := CapJitGetNodeByPath( new_tree, path{[ 1 .. Length( path )-1 ]} );
+
+            if not IsDenseList( variables ) or Length( variables ) <> Length( variable_names ) then
+                
+                Error( "matched wrong number of variables" );
+                
+            fi;
+            
+            if dst_template = "" then
+                
+                # can only drop expression if it is in a list of statements
+                Assert( 0, IsList( parent ) );
+                Assert( 0, IsInt( Last( path ) ) );
+                
+                Remove( parent, Last( path ) );
+
+                tree := new_tree;
+
+                continue;
+                
+            fi;
+            
+            # type check
+            for i in [ 1 .. Length( variable_names ) ] do
+                
+                variable_path := Concatenation( path, variables[i].path );
+                filter := variable_filters[i];
+
+                if IsIdenticalObj( filter, IsObject ) then
+                    
+                    continue;
+                    
+                fi;
+                
+                result := CapJitGetExpressionValueFromJitArgs( tree, variable_path, jit_args );
+
+                if result[1] = false then
+                    
+                    match.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE := true;
+                    
+                    break;
+                    
+                fi;
+
+                value := result[2];
+
+                if not filter( value ) then
+                    
+                    match.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE := true;
+                    
+                    break;
+                    
+                fi;
+                
+            od;
+            
+            if IsBound( match.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE ) and match.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE then
+                
+                if IsBound( template.debug ) and template.debug then
+                    
+                    Error( "type check did not succeed" );
+                    
+                fi;
+                
+                continue;
+                
+            fi;
+            
+            dst_tree := StructuralCopy( dst_template_tree );
+
+            # set correct function IDs in dst_tree
+            pre_func := function( tree, additional_arguments )
+              local current_func, condition_func, path, func;
+
+                if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+                    
+                    current_func := ShallowCopy( tree );
+
+                    if current_func.nams in new_funcs then
+                        
+                        current_func.stats := CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID( current_func.stats, current_func.id, CAP_JIT_INTERNAL_FUNCTION_ID, 0 );
+                        current_func.id := CAP_JIT_INTERNAL_FUNCTION_ID;
+                        CAP_JIT_INTERNAL_FUNCTION_ID := CAP_JIT_INTERNAL_FUNCTION_ID + 1;
+
+                        current_func.nams := List( current_func.nams, nam -> Concatenation( "logic_new_func_", String( current_func.id ), "_", nam ) );
+                        
+                    else
+                        
+                        condition_func := function( tree, path )
+                            
+                            return tree.type = "EXPR_FUNC" and tree.nams = current_func.nams;
+                            
+                        end;
+                        
+                        path := CapJitFindNodeDeep( matched_src_template_tree, condition_func );
+                        
+                        if path = fail then
+                            
+                            Error( "could not find matching func in src_template" );
+
+                        fi;
+
+                        func := CapJitGetNodeByPath( matched_src_template_tree, path );
+
+                        current_func.stats := CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID( current_func.stats, current_func.id, func.id, 0 );
+                        current_func.id := func.id;
+                        current_func.nloc := func.real_nloc;
+                        current_func.nams := func.real_nams;
+                        
+                    fi;
+
+                    return current_func;
+                    
+                fi;
+                
+                return tree;
+                
+            end;
+            
+            dst_tree := CapJitIterateOverTree( dst_tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+            
+            # insert variables in dst_tree (this has to happen after function IDs are set, since otherwise functions in replaced variables are considered)
+            pre_func := function( tree, additional_arguments )
+              local var_number;
+
+                if IsRecord( tree ) and tree.type = "EXPR_REF_GVAR" and StartsWith( tree.gvar, "CAP_INTERNAL_JIT_TEMPLATE_VAR_" ) then
+                    
+                    var_number := Int( ReplacedString( tree.gvar, "CAP_INTERNAL_JIT_TEMPLATE_VAR_", "" ) );
+        
+                    Assert( 0, var_number <> fail );
+
+                    return variables[var_number].tree;
+
+                fi;
+                
+                return tree;
+                
+            end;
+            
+            dst_tree := CapJitIterateOverTree( dst_tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+
+            if IsList( parent ) then
+                
+                Assert( 0, IsInt( Last( path ) ) );
+
+                parent[Last( path )] := dst_tree;
+                
+            elif IsRecord( parent ) then
+                
+                Assert( 0, IsString( Last( path ) ) );
+
+                parent.(Last( path )) := dst_tree;
+                
+            else
+                
+                Error( "this should never happen" );
+                
+            fi;
+            
+            # if new_tree is well-defined, take it
+            if not CapJitContainsRefToFVAROutsideOfFuncStack( new_tree ) then
+                
+                if IsBound( template.debug ) and template.debug then
+                    
+                    Error( "success, new_tree is well-defined" );
+                    
+                fi;
+                
+                tree := new_tree;
+
+                Info( InfoCapJit, 1, "####" );
+                Info( InfoCapJit, 1, "Applied the following template:" );
+                Info( InfoCapJit, 1, src_template );
+                Info( InfoCapJit, 1, dst_template );
+            
+            else
+                
+                if IsBound( template.debug ) and template.debug then
+                    
+                    Error( "new_tree is not well-defined" );
+                    
+                fi;
+                
+                match.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE := true;
+                
+            fi;
+
+        od;
+        
+        # reset CAP_INTERNAL_JIT_NO_UNUSED_VARIABLES
+        pre_func := function( tree, additional_arguments )
+          local level, pos;
+            
+            if IsRecord( tree ) and IsBound( tree.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE ) then
+                
+                Unbind( tree.CAP_INTERNAL_JIT_DOES_NOT_MATCH_TEMPLATE );
+                
+            fi;
+            
+            return tree;
+            
+        end;
+        
+        CapJitIterateOverTree( tree, pre_func, ReturnTrue, ReturnTrue, true );
+        
+    od;
+    
+    return tree;
+    
+end );

--- a/CompilerForCAP/gap/PrettyPrintSyntaxTree.gd
+++ b/CompilerForCAP/gap/PrettyPrintSyntaxTree.gd
@@ -1,0 +1,11 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Tools
+
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT" );
+
+#! @Description
+#!   Displays an enhanced syntax tree in a more useful way. For example, prints the
+#!   type of a node on top.
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitPrettyPrintSyntaxTree" );

--- a/CompilerForCAP/gap/PrettyPrintSyntaxTree.gi
+++ b/CompilerForCAP/gap/PrettyPrintSyntaxTree.gi
@@ -1,0 +1,227 @@
+InstallGlobalFunction( CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT, function( tree, func_stack )
+  local type, statements, lvars, level, hvars, func;
+
+    if IsList( tree ) then
+        
+        return List( tree, t -> CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( t, func_stack ) );
+        
+    fi;
+    
+    tree := ShallowCopy( tree );
+    
+    if not IsBound( tree.type ) then
+        Error( "record is not a syntax tree" );
+    fi;
+    
+    type := tree.type;
+    
+    if type = "EXPR_FUNC" then
+        
+        return rec( 0_type := tree.type,
+                    1_id := tree.id,
+                    2_nams := tree.nams,
+                    3_narg := tree.narg,
+                    4_nloc := tree.nloc,
+                    5_variadic := tree.variadic,
+                    6_stats := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.stats, Concatenation( func_stack, [ tree ] ) ),
+                  );
+
+    elif StartsWith( type, "STAT_SEQ_STAT" ) then
+        
+        return rec(
+            0_type := tree.type,
+            1_statements := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.statements, func_stack ),
+        );
+        
+    elif type = "STAT_ASS_LVAR" then
+        
+        lvars := Last( func_stack ).nams;
+
+        Assert( 0, tree.lvar <= Length( lvars ) );
+        
+        return rec( 0_type := tree.type,
+                    1_lvar := tree.lvar,
+                    2_nvar := lvars[tree.lvar],
+                    3_rhs := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.rhs, func_stack ),
+                  );
+        
+    elif type = "STAT_ASS_FVAR" then
+
+        func := First( func_stack, f -> f.id = tree.func_id );
+        
+        Assert( 0, func <> fail );
+        Assert( 0, tree.pos <= Length( func.nams ) );
+        
+        return rec( 0_type := tree.type,
+                    1_func_id := tree.func_id,
+                    2_pos := tree.pos,
+                    3_current_name := func.nams[tree.pos],
+                    4_initial_name := tree.initial_name,
+                    5_rhs := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.rhs, func_stack ),
+                  );
+        
+    elif StartsWith( type, "EXPR_FUNCCALL" ) or StartsWith( type, "STAT_PROCCALL" ) then
+        
+        return rec( 0_type := tree.type,
+                    1_funcref := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.funcref, func_stack ),
+                    2_args := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.args, func_stack ),
+                  );
+        
+    elif type = "EXPR_REF_GVAR" then
+        
+        return rec( 0_type := tree.type,
+                    1_gvar := tree.gvar,
+                  );
+        
+    elif type = "EXPR_REF_LVAR" then
+        
+        lvars := Last( func_stack ).nams;
+
+        Assert( 0, tree.lvar <= Length( lvars ) );
+        
+        return rec( 0_type := tree.type,
+                    1_lvar := tree.lvar,
+                    2_nvar := lvars[tree.lvar],
+                  );
+        
+    elif type = "EXPR_REF_FVAR" then
+
+        func := First( func_stack, f -> f.id = tree.func_id );
+        
+        Assert( 0, func <> fail );
+        Assert( 0, tree.pos <= Length( func.nams ) );
+        
+        return rec( 0_type := tree.type,
+                    1_func_id := tree.func_id,
+                    2_pos := tree.pos,
+                    3_current_name := func.nams[tree.pos],
+                    4_initial_name := tree.initial_name,
+                  );
+        
+    elif type = "STAT_IF" or type = "STAT_IF_ELSE" then
+        
+        return rec( 0_type := tree.type,
+                    1_branches := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.branches, func_stack ),
+                  );
+        
+    elif type = "BRANCH_IF" then
+        
+        return rec( 0_type := tree.type,
+                    1_condition := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.condition, func_stack ),
+                    2_body := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.body, func_stack ),
+                  );
+        
+    elif type = "EXPR_REC" then
+        
+        Assert( 0, Length( tree.keyvalue ) = 0 );
+        
+        return rec( 0_type := tree.type,
+                    1_keyvalue := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.keyvalue, func_stack ),
+                  );
+        
+    elif type = "EXPR_LIST" then
+        
+        return rec( 0_type := tree.type,
+                    1_list := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.list, func_stack ),
+                  );
+        
+    elif type = "STAT_RETURN_OBJ" then
+        
+        return rec( 0_type := tree.type,
+                    1_obj := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.obj, func_stack ),
+                  );
+        
+    elif type = "EXPR_RANGE" then
+        
+        return rec( 0_type := tree.type,
+                    1_first := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.first, func_stack ),
+                    2_last := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.last, func_stack ),
+                  );
+        
+    elif type = "EXPR_INT" or type = "EXPR_STRING" then
+        
+        return rec( 0_type := tree.type,
+                    1_value := tree.value,
+                  );
+        
+    elif type = "EXPR_TRUE" or type = "EXPR_FALSE" then
+        
+        return rec( 0_type := tree.type,
+                  );
+        
+    elif type = "EXPR_OR" or type = "EXPR_AND" or type = "EXPR_EQ" or type = "EXPR_NE" or type = "EXPR_PROD" or type = "EXPR_SUM" or type = "EXPR_DIFF" or type = "EXPR_LE" or type = "EXPR_LT" or type = "EXPR_GE" or type = "EXPR_GT" then
+        
+        return rec( 0_type := tree.type,
+                    1_left := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.left, func_stack ),
+                    2_right := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.right, func_stack ),
+                  );
+        
+    elif type = "EXPR_NOT" then
+        
+        return rec( 0_type := tree.type,
+                    1_op := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.op, func_stack ),
+                  );
+        
+    elif type = "EXPR_ELM_COMOBJ_NAME" then
+        
+        return rec( 0_type := tree.type,
+                    1_name := tree.name,
+                    2_comobj := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.comobj, func_stack ),
+                  );
+        
+    elif type = "EXPR_ELM_REC_NAME" then
+        
+        return rec( 0_type := tree.type,
+                    1_name := tree.name,
+                    2_record := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.record, func_stack ),
+                  );
+        
+    elif type = "EXPR_REF_HVAR" then
+        
+        level := Int(tree.hvar / 2^16);
+        
+        if not Length( func_stack ) - level > 0 then
+            
+            Error( "cannot reference an hvar outside of the stack" );
+            
+        fi;
+        
+        hvars := func_stack[Length( func_stack ) - level];
+        
+        Assert( 0, tree.hvar mod 2^16 <= Length( hvars ) );
+        
+        return rec( 0_type := tree.type,
+                    1_hvar := tree.hvar,
+                    2_nvar := hvars[tree.hvar mod 2^16],
+                  );
+        
+    elif type = "EXPR_ELM_LIST" then
+        
+        return rec( 0_type := tree.type,
+                    1_pos := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.pos, func_stack ),
+                    2_list := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.list, func_stack ),
+                  );
+        
+    elif type = "EXPR_ELM_MAT" then
+        
+        return rec( 0_type := tree.type,
+                    1_row := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.row, func_stack ),
+                    2_col := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.col, func_stack ),
+                    3_list := CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree.list, func_stack ),
+                  );
+        
+    else
+        
+        Display( tree );
+        
+        Error( "tree has no kown type" );
+        
+    fi;
+    
+end );
+
+InstallGlobalFunction( CapJitPrettyPrintSyntaxTree, function( tree )
+    
+    Display( CAP_JIT_INTERNAL_PREPARE_SYNTAX_TREE_FOR_PRETTY_PRINT( tree, [] ) );
+    
+end );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gd
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gd
@@ -1,0 +1,12 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Resolves global variables:
+#!   * Replaces a global variable referencing an integer, a string, or a boolean by EXPR_INT, EXPR_STRING, EXPR_TRUE or EXPR_FALSE.
+#!   * Replaces a global variable referencing a plain function by the syntax tree of this function.
+#!   * Replaces a record access of a global function by the value of this record access.
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitResolvedGlobalVariables" );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -1,0 +1,148 @@
+InstallGlobalFunction( "CapJitResolvedGlobalVariables", function( tree )
+  local pre_func;    
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Resolving global variables." );
+    
+    pre_func := function( tree, additional_arguments )
+      local value, inline_tree, name, global_variable_name;
+        
+        if IsRecord( tree ) and not ( IsBound( tree.CAP_JIT_NOT_RESOLVABLE ) and tree.CAP_JIT_NOT_RESOLVABLE ) then
+            
+            if tree.type = "EXPR_REF_GVAR" then
+                
+                value := ValueGlobal( tree.gvar );
+
+            elif tree.type = "EXPR_ELM_COMOBJ_NAME" and tree.comobj.type = "EXPR_REF_GVAR" then
+                
+                value := ValueGlobal( tree.comobj.gvar )!.(tree.name);
+                
+            elif tree.type = "EXPR_ELM_REC_NAME" and tree.record.type = "EXPR_REF_GVAR" then
+                
+                value := ValueGlobal( tree.record.gvar ).(tree.name);
+                
+            elif tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_REF_GVAR" and ForAll( tree.args, a -> a.type in [ "EXPR_REF_GVAR", "EXPR_INT", "EXPR_STRING", "EXPR_TRUE", "EXPR_FALSE" ] ) then
+                
+                value := CallFuncList( ValueGlobal( tree.funcref.gvar ), List( tree.args, function( a )
+                    
+                    if a.type = "EXPR_REF_GVAR" then
+                        
+                        return ValueGlobal( a.gvar );
+                        
+                    elif a.type = "EXPR_INT" or a.type = "EXPR_STRING" then
+                        
+                        return a.value;
+                        
+                    elif a.type = "EXPR_TRUE" then
+                        
+                        return true;
+                        
+                    elif a.type = "EXPR_FALSE" then
+                        
+                        return false;
+                        
+                    else
+                        
+                        Error( "this should never happen" );
+                        
+                    fi;
+                
+                end ) );
+                
+            fi;
+                
+            if IsBound( value ) then
+                
+                if IsInt( value ) then
+                    
+                    return rec(
+                        type := "EXPR_INT",
+                        value := value,
+                    );
+                    
+                elif IsString( value ) then
+                    
+                    return rec(
+                        type := "EXPR_STRING",
+                        value := value,
+                    );
+                
+                elif value = true then
+                    
+                    return rec(
+                        type := "EXPR_TRUE",
+                    );
+                
+                elif value = false then
+                    
+                    return rec(
+                        type := "EXPR_FALSE",
+                    );
+                
+                elif IsFunction( value ) then
+                    
+                    if not IsKernelFunction( value ) and not IsOperation( value ) then
+                        
+                        inline_tree := ENHANCED_SYNTAX_TREE( value, true );
+                        
+                        if Length( inline_tree.stats.statements ) >= 1 and inline_tree.stats.statements[1].type = "STAT_PRAGMA" and inline_tree.stats.statements[1].value = "% CAP_JIT_RESOLVE_FUNCTION" then
+                            
+                            inline_tree.stats.statements := inline_tree.stats.statements{[ 2 .. Length( inline_tree.stats.statements ) ]};
+                            
+                            return inline_tree;
+                            
+                        fi;
+                        
+                    fi;
+        
+                    name := NameFunction( value );
+                    
+                    if name in NamesGVars() and IsIdenticalObj( value, ValueGlobal( name ) ) then
+                        
+                        tree := rec(
+                            type := "EXPR_REF_GVAR",
+                            gvar := name,
+                        );
+                        
+                    fi;
+                    
+                fi;
+                
+                # could not resolve to a another value
+                if tree.type = "EXPR_REF_GVAR" then
+                    
+                    # this was already a gvar and we could not simplify it
+                    tree := ShallowCopy( tree );
+
+                    tree.CAP_JIT_NOT_RESOLVABLE := true;
+
+                    return tree;
+                    
+                else
+                    
+                    global_variable_name := CapJitGetOrCreateGlobalVariable( value );
+                    
+                    tree := rec(
+                        type := "EXPR_REF_GVAR",
+                        gvar := global_variable_name,
+                        CAP_JIT_NOT_RESOLVABLE := true,
+                    );
+                    
+                    Info( InfoCapJit, 1, "####" );
+                    Info( InfoCapJit, 1, "Resolved a global variable." );
+    
+                    return tree;
+                    
+                fi;
+
+            fi;
+                
+        fi;
+        
+        return tree;
+        
+    end;
+
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+  
+end );

--- a/CompilerForCAP/gap/ResolveOperations.gd
+++ b/CompilerForCAP/gap/ResolveOperations.gd
@@ -1,0 +1,18 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+# helper function
+DeclareGlobalFunction( "CapJitGetCapCategoryFromArguments" );
+
+#! @Description
+#!   Tries to resolve operations in <A>tree</A>:
+#!   * The attribute `CapCategory` is resolved by computing the category using <A>jit_args</A> and storing it in a global variable.
+#!   * Operations of CAP categories are resolved by taking one of the functions added to the category via an `Add` function.
+#!   * Other operations are resolved by considering applicable methods of the operation with regard to arguments infered
+#!     from <A>jit_args</A>. Only methods annotated with the pragma CAP_JIT_RESOLVE_FUNCTION are resolved.
+#!
+#!   If the arguments of the operation cannot be infered from <A>jit_args</A>, the operation is not resolved.
+#! @Returns a record
+#! @Arguments tree, jit_args
+DeclareGlobalFunction( "CapJitResolvedOperations" );

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -1,0 +1,242 @@
+InstallGlobalFunction( CapJitGetCapCategoryFromArguments, function( arguments )
+  local result;
+    
+    if IsList( arguments ) then
+        
+        result := List( arguments, arg -> CapJitGetCapCategoryFromArguments( arg ) );
+        
+        return First( result, r -> r <> fail );
+        
+    elif IsCapCategory( arguments ) then
+        
+        return arguments;
+        
+    elif HasCapCategory( arguments ) then
+        
+        return CapCategory( arguments );
+    
+    else
+        
+        return fail;
+
+    fi;
+    
+end );
+
+InstallGlobalFunction( CapJitResolvedOperations, function( tree, jit_args )
+  local condition_func, path, record, operation, operation_name, arguments, result, new_tree, category, global_variable_name, operation_name_record_entry, installation_name, filter_list, replaced_filter_list, positions, index, func_to_resolve, applicable_methods, resolved_tree, parent, method;
+    
+    tree := StructuralCopy( tree );
+  
+    # find resolvable operation
+    condition_func := function( tree, path )
+        
+        if tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_REF_GVAR" and not (IsBound(tree.CAP_JIT_IGNORE_OPERATION) and tree.CAP_JIT_IGNORE_OPERATION) then
+            
+            # not all CAP operations are operations in the GAP sense
+            return tree.funcref.gvar in RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ) or IsOperation( ValueGlobal( tree.funcref.gvar ) );
+            
+        fi;
+        
+        return false;
+        
+    end;
+    
+    path := CapJitFindNodeDeep( tree, condition_func );
+    
+    if path = fail then
+        
+        return tree;
+        
+    fi;
+
+    record := CapJitGetNodeByPath( tree, path );
+    operation := ValueGlobal( record.funcref.gvar );
+    operation_name := NameFunction( operation );
+
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, Concatenation( "Try to resolve ", operation_name, "." ) );
+    
+    result := CapJitGetFunctionCallArgumentsFromJitArgs( tree, path, jit_args );
+    
+    if result[1] = false then
+        
+        Info( InfoCapJit, 1, "Could not get arguments. Skip resolving..." );
+
+        record.CAP_JIT_IGNORE_OPERATION := true;
+        
+    else
+
+        arguments := result[2];
+        
+        new_tree := fail;
+        
+        # special case: CapCategory
+        if IsIdenticalObj( operation, CapCategory ) then
+            
+            Info( InfoCapJit, 1, "Determine category." );
+            
+            Assert( 0, Length( arguments ) = 1 and HasCapCategory( arguments[1] ) );
+            
+            category := CapCategory( arguments[1] );
+            
+            global_variable_name := CapJitGetOrCreateGlobalVariable( category );
+            
+            new_tree := rec(
+                type := "EXPR_REF_GVAR",
+                gvar := global_variable_name,
+            );
+            
+        # special case: this is a CAP operation
+        elif operation_name in RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ) then
+            
+            Info( InfoCapJit, 1, "This is a CAP operation, try to determine category and take the added function." );
+
+            operation_name_record_entry := CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name);
+            
+            installation_name := operation_name_record_entry.installation_name;
+            filter_list := operation_name_record_entry.filter_list;
+            replaced_filter_list := CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS( filter_list );
+            
+            # prepare Op
+            if Concatenation( operation_name, "Op" ) = installation_name then
+                
+                filter_list := filter_list{ [ 1 .. Length( filter_list ) - 1 ] };
+                
+            fi;
+
+            Assert( 0, not IsBound(operation_name_record_entry.argument_list) or operation_name_record_entry.argument_list = [ 1 .. Length( filter_list ) ] );
+            
+            # check that arguments lie in filter
+            if Length( filter_list ) = Length( arguments ) and ForAll( [ 1 .. Length( filter_list ) ], i -> replaced_filter_list[i](arguments[i]) ) then
+                
+                # do not infer category from other_object et al.
+                positions := PositionsProperty( filter_list, x -> x in [ "object", "morphism", "twocell", "list_of_objects", "list_of_morphisms" ] );
+                category := CapJitGetCapCategoryFromArguments( arguments{ positions } );
+                
+                if category = fail then
+                    
+                    Error( "could not get category from arguments" );
+                    
+                fi;
+
+                Assert( 0, CanCompute( category, operation_name ) );
+                
+                # find the last added function with no additional filters
+                index := Last( PositionsProperty( category!.added_functions.(operation_name), f -> Length( f[2] ) = 0 ) );
+                
+                if IsBound( category!.stop_compilation ) and category!.stop_compilation = true then
+                    
+                    Info( InfoCapJit, 1, "Compilation stops at this category." );
+                    
+                elif index = fail then
+                    
+                    Info( InfoCapJit, 1, "All added functions have additional filters." );
+                    
+                else
+                    
+                    if IsBound( category!.compiled_functions.(operation_name)[index] ) then
+                        
+                        Info( InfoCapJit, 1, Concatenation( "Taking compiled function with index ", String( index ), "." ) );
+                        
+                        func_to_resolve := category!.compiled_functions.(operation_name)[index];
+                        
+                    else
+                        
+                        Info( InfoCapJit, 1, Concatenation( "Taking added function with index ", String( index ), "." ) );
+                        
+                        func_to_resolve := category!.added_functions.(operation_name)[index][1];
+                        
+                    fi;
+                    
+                    if IsOperation( func_to_resolve ) or IsKernelFunction( func_to_resolve ) then
+                        
+                        # will be handled in the next iteration
+                        global_variable_name := CapJitGetOrCreateGlobalVariable( func_to_resolve );
+                        
+                        new_tree := rec(
+                            type := "EXPR_REF_GVAR",
+                            gvar := global_variable_name,
+                        );
+                        
+                    else
+                    
+                        new_tree := rec(
+                            type := "EXPR_FUNCCALL",
+                            funcref := ENHANCED_SYNTAX_TREE( func_to_resolve, true ),
+                            args := record.args,
+                        );
+
+                    fi;
+                    
+                fi;
+            
+            fi;
+            
+        fi;
+        
+        if new_tree = fail and IsOperation( operation ) then
+            
+            Info( InfoCapJit, 1, "Try applicable methods." );
+
+            applicable_methods := ApplicableMethod( operation, arguments, 0, "all" );
+            
+            for method in applicable_methods do
+                
+                if not IsKernelFunction( method ) then
+                
+                    resolved_tree := ENHANCED_SYNTAX_TREE( method );
+                    
+                    if Length( resolved_tree.stats.statements ) >= 1 and resolved_tree.stats.statements[1].type = "STAT_PRAGMA" and resolved_tree.stats.statements[1].value = "% CAP_JIT_RESOLVE_FUNCTION" then
+                        
+                        Info( InfoCapJit, 1, "Found suitable applicable method." );
+                        
+                        # remove pragma
+                        resolved_tree.stats.statements := resolved_tree.stats.statements{[ 2 .. Length( resolved_tree.stats.statements ) ]};
+                        
+                        new_tree := rec(
+                            type := "EXPR_FUNCCALL",
+                            funcref := resolved_tree,
+                            args := record.args,
+                        );
+
+                        break;
+                        
+                    fi;
+                    
+                fi;
+                
+            od;
+            
+        fi;
+
+        if new_tree <> fail then
+            
+            parent := CapJitGetNodeByPath( tree, path{[ 1 .. Length( path ) - 1 ]} );
+
+            if IsList( parent ) then
+                
+                parent[Last( path )] := new_tree;
+                
+            else
+                
+                parent.(Last( path )) := new_tree;
+                
+            fi;
+            
+            Info( InfoCapJit, 1, "Successfully resolved operation." );
+            
+        else
+            
+            Info( InfoCapJit, 1, "Could not find suitable function. Skip resolving..." );
+            
+            record.CAP_JIT_IGNORE_OPERATION := true;
+            
+        fi;
+                
+    fi;
+
+    # resolve next operation
+    return CapJitResolvedOperations( tree, jit_args );
+    
+end );

--- a/CompilerForCAP/gap/Tools.gd
+++ b/CompilerForCAP/gap/Tools.gd
@@ -1,0 +1,62 @@
+#! @Chapter Improving and extending the compiler
+
+#! @Section Tools
+
+#! @Description
+#!   Checks if <A>tree</A> is an EXPR_FUNCCALL with `funcref` EXPR_GVAR such that `gvar` fulfills <A>condition</A>.
+#!   If <A>condition</A> is a string, `gvar` must be equal to the string.
+#!   Othwerwise, <A>condition</A> must be a function returning a boolean when applied to `gvar`.
+#! @Returns a boolean
+#! @Arguments tree, condition
+DeclareGlobalFunction( "CapJitIsCallToGlobalFunction" );
+
+#! @Description
+#!   Can be used as a `result_func` for <Ref Func="CapJitIterateOverTree" />.
+#!   Replaces <A>tree</A>`.(key)` (resp. <A>tree</A>`[key]`) by <A>result</A>`.(key)` (resp. <A>result</A>`[key]`) for all
+#!   keys of children of <A>tree</A> and returns the result. See <Ref Func="CapJitIterateOverTree" /> for more details.
+#! @Returns a list or a record
+#! @Arguments tree, result, additional_arguments
+DeclareGlobalFunction( "CapJitResultFuncCombineChildren" );
+
+#! @Description
+#!  Checks if <A>tree</A> contains an FVAR which references a function outside of its function stack.
+#!  Such a tree is not well-defined.
+#! @Returns a boolean
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitContainsRefToFVAROutsideOfFuncStack" );
+
+#! @Description
+#!   Assigns <A>value</A> to a global variable and returns the name of the global variable.
+#!   If <A>value</A> has already been assigned to a global variable by this function before,
+#!   simply returns the name of that global variable.
+#! @Returns a string
+#! @Arguments value
+DeclareGlobalFunction( "CapJitGetOrCreateGlobalVariable" );
+
+#! @Description
+#!   Checks if <A>tree</A> contains statements or expressions indicating side effects. If yes, it throws an error.
+#!   The following checks are performed:
+#!     * <A>tree</A> must be an enhanced syntax tree. In particular, it may not contain LVARs or HVARs.
+#!     * The following statements and expressions are forbidden: STAT_ASS_GVAR, EXPR_ISB_GVAR, STAT_UNB_GVAR,
+#!         EXPR_ISB_FVAR, EXPR_UNB_FVAR, STAT_PROCCALL.
+#!     * An FVAR must not reference functions outside of its function stack (see also <Ref Func="CapJitContainsRefToFVAROutsideOfFuncStack" />).
+#!     * An FVAR must be assigned at most once (this includes function arguments, which are assigned at least once,
+#!         namely when the function is called). An exception is made for "rapid reassignments": if the same variable
+#!         is assigned and then reassigned immediately in the next statement, this only counts as a single assignment.
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitThrowErrorOnSideEffects" );
+
+#! @Description
+#!   Finds a node in <A>tree</A> for which <A>condition_func</A> returns `true`.
+#!   For each node, <A>condition_func</A> is called with the node and current path as arguments, and must return a boolean.
+#!   If multiple nodes are found, children are preferred over their parents (i.e. a "deep" node is returned).
+#!   If no node can be found, `fail` is returned.
+#! @Returns a record or fail
+#! @Arguments tree, condition_func
+DeclareGlobalFunction( "CapJitFindNodeDeep" );
+
+#! @Description
+#!   Gets the node of <A>tree</A> with path <A>path</A>. Throws an error if no such node exists.
+#! @Returns a record
+#! @Arguments tree, path
+DeclareGlobalFunction( "CapJitGetNodeByPath" );

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -1,0 +1,342 @@
+InstallGlobalFunction( CapJitIsCallToGlobalFunction, function( tree, condition )
+  local condition_func;
+    
+    if IsString( condition ) then
+        
+        condition_func := gvar -> gvar = condition;
+        
+    elif IsFunction( condition ) then
+        
+        condition_func := condition;
+        
+    else
+        
+        Error( "<condition> must be a string or a function" );
+        
+    fi;
+    
+    return IsRecord( tree ) and tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_REF_GVAR" and condition_func( tree.funcref.gvar );
+    
+end );
+
+InstallGlobalFunction( CapJitResultFuncCombineChildren, function( tree, result, additional_arguments )
+  local key;
+    
+    if IsList( result ) then
+        
+        return result;
+        
+    elif IsRecord( result ) then
+        
+        tree := ShallowCopy( tree );
+
+        for key in RecNames( result ) do
+            
+            tree.(key) := result.(key);
+
+        od;
+        
+        return tree;
+
+    else
+        
+        Error( "this should never happen" );
+        
+    fi;
+    
+end );
+
+InstallGlobalFunction( CapJitContainsRefToFVAROutsideOfFuncStack, function( tree )
+  local result_func, additional_arguments_func;
+  
+    result_func := function( tree, result, func_id_stack )
+      local type, level;
+        
+        if IsList( result ) then
+            
+            return true in result;
+
+        elif IsRecord( result ) then
+            
+            if PositionSublist( tree.type, "FVAR" ) <> fail then
+                
+                if not tree.func_id in func_id_stack then
+                    
+                    return true;
+                    
+                fi;
+                
+            fi;
+            
+            return ForAny( RecNames( result ), key -> result.(key) = true );
+            
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    additional_arguments_func := function( tree, key, func_id_stack )
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            Assert( 0, IsBound( tree.id ) );
+            
+            return Concatenation( func_id_stack, [ tree.id ] );
+            
+        else
+            
+            return func_id_stack;
+            
+        fi;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, ReturnFirst, result_func, additional_arguments_func, [] );
+    
+end );
+
+BindGlobal( "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER", 1 );
+MakeReadWriteGlobal( "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER" );
+InstallGlobalFunction( CapJitGetOrCreateGlobalVariable, function( value )
+  local gvar, i;
+    
+    # check if value is already bound to a global variable
+    for i in [ 1 .. CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER - 1 ] do
+        
+        gvar := Concatenation( "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_", String( i ) );
+
+        if IsIdenticalObj( value, ValueGlobal( gvar ) ) then
+            
+            return gvar;
+            
+        fi;
+        
+    od;
+    
+    # create new global variable
+    gvar := Concatenation( "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_", String( CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER ) );
+    
+    BindGlobal( gvar, value );
+
+    CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER := CAP_JIT_INTERNAL_GLOBAL_VARIABLE_COUNTER + 1;
+    
+    return gvar;
+    
+end );
+
+InstallGlobalFunction( CapJitThrowErrorOnSideEffects, function( tree )
+  local number_of_assignments, nams, pre_func, additional_arguments_func, i, j;
+    
+    # modified inplace
+    number_of_assignments := [];
+    nams := [];
+    
+    pre_func := function( tree, func_id_stack )
+      local statement, next_statement, i;
+        
+        if IsRecord( tree ) then
+            
+            # make sure we deal with an enhanced syntax tree
+            if PositionSublist( tree.type, "HVAR" ) <> fail or PositionSublist( tree.type, "LVAR" ) <> fail then
+                
+                Error( "tree contains reference to HVAR or LVAR, this is not supported. Please use an enhanced syntax tree" );
+                
+            fi;
+            
+            # exclude most common statements and expression indicating possible side effects
+            if tree.type in [ "STAT_ASS_GVAR", "EXPR_ISB_GVAR", "STAT_UNB_GVAR", "EXPR_ISB_FVAR", "EXPR_UNB_FVAR", "STAT_PROCCALL" ] then
+
+                Error( Concatenation( "tree includes statements or expressions which indicate possible side effects: ", tree.type ) );
+
+            fi;
+            
+            # make sure that fvars reference only functions in the current function stack
+            if PositionSublist( tree.type, "FVAR" ) <> fail then
+                
+                Assert( 0, IsBound( tree.func_id ) );
+                
+                if not tree.func_id in func_id_stack then
+                    
+                    Error( Concatenation( "tree contains reference to an fvar with inital name ", tree.initial_name, " outside of the current function stack, this is not well-defined" ) );
+                    
+                fi;
+                
+            fi;
+
+            # make sure for loop only loops over local variables
+            if tree.type = "STAT_FOR" then
+                
+                if tree.variable.type <> "EXPR_REF_FVAR" or tree.variable.func_id <> Last( func_id_stack ) then
+                    
+                    Error( "tree contains for loop over non-local variable, this is not supported" );
+                    
+                fi;
+                
+            fi;
+            
+            # initialize number_of_assignments and nams per function
+            if tree.type = "EXPR_FUNC" and not IsBound( number_of_assignments[tree.id] ) then
+                
+                number_of_assignments[tree.id] := Concatenation( ListWithIdenticalEntries( tree.narg, 1 ), ListWithIdenticalEntries( tree.nloc, 0 ) );
+                nams[tree.id] := tree.nams;
+                
+            fi;
+            
+            # make sure that only local variables are assigned, increase number_of_assignments
+            if tree.type = "STAT_ASS_FVAR" then
+                
+                if tree.func_id <> Last( func_id_stack ) then
+                    
+                    Error( Concatenation( "tree contains an assignment of a higher variable with initial name ", tree.initial_name, ", this is not supported" ) );
+                    
+                fi;
+
+                Assert( 0, IsBound( number_of_assignments[tree.func_id][tree.pos] ) );
+                
+                number_of_assignments[tree.func_id][tree.pos] := number_of_assignments[tree.func_id][tree.pos] + 1;
+                
+            fi;
+            
+            # do not count rapid reassignments
+            if tree.type = "STAT_SEQ_STAT" then
+                
+                for i in [ 1 .. Length( tree.statements ) - 1 ]  do
+                    
+                    statement := tree.statements[i];
+                    next_statement := tree.statements[i + 1];
+                    
+                    if statement.type = "STAT_ASS_FVAR" and next_statement.type = "STAT_ASS_FVAR" and statement.func_id = next_statement.func_id and statement.pos = next_statement.pos then
+                        
+                        if IsBound( number_of_assignments[statement.func_id] ) then
+                            
+                            Assert( 0, IsBound( number_of_assignments[statement.func_id][statement.pos] ) );
+                            
+                            number_of_assignments[statement.func_id][statement.pos] := number_of_assignments[statement.func_id][statement.pos] - 1;
+                            
+                        fi;
+                        
+                    fi;
+                    
+                od;
+                
+            fi;
+            
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    additional_arguments_func := function( tree, key, func_id_stack )
+        
+        if IsRecord( tree ) and tree.type = "EXPR_FUNC" then
+            
+            Assert( 0, IsBound( tree.id ) );
+            
+            return Concatenation( func_id_stack, [ tree.id ] );
+            
+        else
+            
+            return func_id_stack;
+            
+        fi;
+        
+    end;
+    
+    CapJitIterateOverTree( tree, pre_func, ReturnTrue, additional_arguments_func, [] );
+    
+    # make sure no variables is assigned more than once
+    for i in [ 1 .. Length( number_of_assignments ) ] do
+        
+        if IsBound( number_of_assignments[i] ) then
+            
+            for j in [ 1 .. Length( number_of_assignments[i] ) ] do
+                
+                if number_of_assignments[i][j] >= 2 then
+                    
+                    Error( Concatenation( "a local variable with name ", nams[i][j], " is assigned more than once (not as a part of a rapid reassignment), this is not supported" ) );
+                    
+                fi;
+                
+            od;
+            
+        fi;
+        
+    od;
+    
+end );
+
+InstallGlobalFunction( CapJitFindNodeDeep, function( tree, condition_func )
+  local result_func, additional_arguments_func;
+    
+    result_func := function( tree, result, path )
+      local key, type;
+        
+        if IsList( result ) then
+            
+            return First( result, r -> r <> fail );
+            
+        elif IsRecord( result ) then
+        
+            for key in RecNames( result ) do
+                
+                if result.(key) <> fail then
+                    
+                    return result.(key);
+                
+                fi;
+                    
+            od;
+
+            # none of the descendants fulfills condition, otherwise we would already have returned above 
+            if condition_func( tree, path ) then
+                
+                return path;
+                
+            fi;
+            
+            # neither this record nor any of its descendants fulfills the condition
+            return fail;
+
+        else
+            
+            Error( "this should never happen" );
+            
+        fi;
+        
+    end;
+
+    additional_arguments_func := function( tree, key, path )
+        
+        return Concatenation( path, [ key ] );
+        
+    end;
+  
+    return CapJitIterateOverTree( tree, ReturnFirst, result_func, additional_arguments_func, [] );
+
+end );
+
+InstallGlobalFunction( CapJitGetNodeByPath, function( tree, path )
+    
+    if Length( path ) = 0 then
+        
+        return tree;
+        
+    elif IsList( tree ) then
+        
+        Assert( 0, IsPosInt( path[1] ) and path[1] <= Length( tree ) );
+
+        return CapJitGetNodeByPath( tree[path[1]], path{[ 2 .. Length( path ) ]} );
+
+    else
+       
+        Assert( 0, IsBound( tree.(path[1]) ) );
+        
+        return CapJitGetNodeByPath( tree.(path[1]), path{[ 2 .. Length( path ) ]} );
+        
+    fi;
+    
+end );

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -1,0 +1,37 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# Reading the declaration part of the package.
+#
+
+ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gd");
+
+ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gd");
+
+ReadPackage( "CompilerForCAP", "gap/Tools.gd");
+
+ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gd");
+
+ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gd");
+
+ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gd");
+
+ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gd");
+
+ReadPackage( "CompilerForCAP", "gap/InlineArguments.gd");
+
+ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gd");
+
+ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gd");
+
+ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gd");
+
+ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gd");
+
+ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gd");
+
+ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gd");
+
+ReadPackage( "CompilerForCAP", "gap/Logic.gd");
+
+ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gd");

--- a/CompilerForCAP/makedoc.g
+++ b/CompilerForCAP/makedoc.g
@@ -1,0 +1,18 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# This file is a script which compiles the package manual.
+#
+if fail = LoadPackage("AutoDoc", "2019.05.20") then
+    Error("AutoDoc version 2019.05.20 or newer is required.");
+fi;
+
+AutoDoc(rec(
+    scaffold := rec(
+        entities := [ "GAP4", "CAP" ],
+    ),
+    autodoc := rec( files := [ "doc/Doc.autodoc" ] ),
+    extract_examples := rec( units := "Single" ),
+));
+
+QUIT;

--- a/CompilerForCAP/makedoc_with_overfull_box_warnings.g
+++ b/CompilerForCAP/makedoc_with_overfull_box_warnings.g
@@ -1,0 +1,25 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# This file is a script which compiles the package manual and prints overfull hbox warnings.
+#
+if fail = LoadPackage("AutoDoc", "2019.05.20") then
+    Error("AutoDoc version 2019.05.20 or newer is required.");
+fi;
+
+AutoDoc(rec(
+    gapdoc := rec(
+        LaTeXOptions := rec(
+            LateExtraPreamble := """
+                \RecustomVerbatimEnvironment{Verbatim}{BVerbatim}{}
+                """
+        ),
+    ),
+    scaffold := rec(
+        entities := [ "GAP4", "CAP" ],
+    ),
+    autodoc := rec( files := [ "doc/Doc.autodoc" ] ),
+    extract_examples := rec( units := "Single" ),
+));
+
+QUIT;

--- a/CompilerForCAP/makefile
+++ b/CompilerForCAP/makefile
@@ -1,0 +1,28 @@
+all: doc test
+
+doc: doc/manual.six
+
+doc/manual.six: makedoc.g \
+		PackageInfo.g \
+		doc/Doc.autodoc \
+		gap/*.gd gap/*.gi examples/*.g
+			gap makedoc.g
+
+clean:
+	(cd doc ; ./clean)
+
+test: doc
+	gap tst/testall.g
+
+test-tabs:
+	! grep -RP "\t" examples/ gap/
+
+# broken by the arguments of CapJitIterateOverTree, which we cannot influence
+test-overfull-hboxes:
+	gap makedoc_with_overfull_box_warnings.g | perl -pe 'END { exit $$status } $$status=1 if /Overfull \\hbox/;'
+
+test-with-coverage: doc
+	gap --quitonbreak --cover stats tst/testall.g
+	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
+
+ci-test: test-tabs test-with-coverage

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -1,0 +1,37 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# Reading the implementation part of the package.
+#
+
+ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gi");
+
+ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gi");
+
+ReadPackage( "CompilerForCAP", "gap/Tools.gi");
+
+ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gi");
+
+ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gi");
+
+ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gi");
+
+ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gi");
+
+ReadPackage( "CompilerForCAP", "gap/InlineArguments.gi");
+
+ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gi");
+
+ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gi");
+
+ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gi");
+
+ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gi");
+
+ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gi");
+
+ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gi");
+
+ReadPackage( "CompilerForCAP", "gap/Logic.gi");
+
+ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gi");

--- a/CompilerForCAP/tst/000_LoadPackage.tst
+++ b/CompilerForCAP/tst/000_LoadPackage.tst
@@ -1,0 +1,8 @@
+gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
+gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
+gap> LoadPackage( "CompilerForCAP", false );
+true
+gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
+gap> LoadPackage( "CompilerForCAP" );
+true
+gap> SetInfoLevel( InfoPackageLoading, package_loading_info_level );;

--- a/CompilerForCAP/tst/testall.g
+++ b/CompilerForCAP/tst/testall.g
@@ -1,0 +1,17 @@
+#
+# CompilerForCAP: This package allows to "compile" the code of CAP categories.
+#
+# This file runs package tests. It is also referenced in the package
+# metadata in PackageInfo.g.
+#
+
+options := rec(
+    exitGAP := true,
+    testOptions := rec(
+        compareFunction := "uptowhitespace"
+    ),
+);
+
+TestDirectory( DirectoriesPackageLibrary( "CompilerForCAP", "tst" ), options );
+
+FORCE_QUIT_GAP( 1 ); # if we ever get here, there was an error

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
@@ -53,6 +53,7 @@ InstallMethod( VectorSpaceMorphism,
                
   function( source, homalg_matrix, range )
     local homalg_field, category;
+    #% CAP_JIT_RESOLVE_FUNCTION
     
     category := CapCategory( source );
     
@@ -85,7 +86,7 @@ InstallMethod( VectorSpaceMorphism,
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), category,
                                            source,
                                            range,
-                                           UnderlyingFieldForHomalg, homalg_field,
+                                           UnderlyingFieldForHomalg, category!.field_for_matrix_category,
                                            UnderlyingMatrix, homalg_matrix
     );
     

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ homalg_compatibility:
 	gap load_cap_sheaves.g
 	gap load_sheaves_cap.g
 
-test: CAP_test Modules_test GradedModules_test Linear_test Generalized_test GroupRepresentations_test InternalExteriorAlgebra_test
+test: CAP_test Modules_test GradedModules_test Linear_test Generalized_test GroupRepresentations_test InternalExteriorAlgebra_test CompilerForCAP_test
 
 CAP_test:
 	cd CAP && make test
@@ -29,7 +29,10 @@ GroupRepresentations_test:
 InternalExteriorAlgebra_test:
 	cd InternalExteriorAlgebraForCAP && make test
 
-doc: CAP_doc Modules_doc GradedModules_doc Linear_doc Generalized_doc GroupRepresentations_doc InternalExteriorAlgebra_doc
+CompilerForCAP_test:
+	cd CompilerForCAP && make test
+
+doc: CAP_doc Modules_doc GradedModules_doc Linear_doc Generalized_doc GroupRepresentations_doc InternalExteriorAlgebra_doc CompilerForCAP_doc
 
 CAP_doc:
 	cd CAP && make doc
@@ -52,6 +55,9 @@ GroupRepresentations_doc:
 InternalExteriorAlgebra_doc:
 	cd InternalExteriorAlgebraForCAP && make doc
 
+CompilerForCAP_doc:
+	cd CompilerForCAP && make doc
+
 ci-test: homalg_compatibility doc
 	cd CAP && make ci-test
 	cd ModulePresentationsForCAP && make ci-test
@@ -60,3 +66,4 @@ ci-test: homalg_compatibility doc
 	cd GeneralizedMorphismsForCAP && make ci-test
 	cd GroupRepresentationsForCAP && make ci-test
 	cd InternalExteriorAlgebraForCAP && make ci-test
+	cd CompilerForCAP && make ci-test


### PR DESCRIPTION
Finally, the pull request of `CompilerForCAP`, including an example in `LinearAlgebraForCAP` showing that the compiler could compile the primitive operation `MorphismBetweenDirectSums` on its own from the generic derivation.

I have written lots of documentation and hope its in a "useful" state, but some parts of it depend on knowledge about GAP's syntax trees, which do not seem to have documentation sadly :-(

I have not tested this with many examples, so applying this to other examples probably gives some "this is not supported" errors. See the FAQ in the manual for explanations for some expected errors.

@sebastianpos Do you want to review all of this, or is this "my" package and you only want to review the parts touching `CAP`? In the first case, we should probably meet for a review session, since I think some/many parts of the code need additional explanations. I would love to add these explanations as comments to the code, but for this I would first have to write documentation for GAP's syntax tree -> this would need a lot of time :-(