### PR TITLE
Allow to use different matrix data structures for AdditiveClosure

### DIFF
--- a/FreydCategoriesForCAP/doc/Doc.autodoc
+++ b/FreydCategoriesForCAP/doc/Doc.autodoc
@@ -2,6 +2,8 @@
 
 @Chapter Additive closure
 
+@Chapter Example on additive closure
+
 @Chapter Adelman category
 
 @Chapter Category of rows

--- a/FreydCategoriesForCAP/examples/AdditiveClosure.g
+++ b/FreydCategoriesForCAP/examples/AdditiveClosure.g
@@ -1,0 +1,92 @@
+#! @Chapter Example on additive closure
+
+#! @Section Using matrix data structures
+
+LoadPackage( "FreydCategoriesForCAP" );;
+
+#! @Example
+QQ := HomalgFieldOfRationalsInSingular();;
+
+R := QQ * "x,y,z";;
+
+matrix_element_as_morphism :=
+        r -> RingAsCategoryMorphism( RingAsCategory( R ), r );;
+
+list_list_as_matrix := {listlist, m, n} ->
+    HomalgMatrix(
+        List( listlist,
+            row -> List( row,
+                entry -> UnderlyingRingElement( entry )
+            )
+        ), m, n, R );;
+
+CR := RingAsCategory( R );;
+CRplus := AdditiveClosure( CR :
+    matrix_element_as_morphism := matrix_element_as_morphism,
+    list_list_as_matrix := list_list_as_matrix
+);;
+
+M := HomalgMatrix( "[[x^2,4*y]]", 1, 2, R );;
+N := HomalgMatrix( "[[1,3*x], [2*y^3,5*y]]", 2, 2, R );;
+P := M * N;;
+
+o := AsAdditiveClosureObject( RingAsCategoryUniqueObject( CR ) );;
+
+A := o;;
+B := DirectSum( o, o );;
+
+alpha := AdditiveClosureMorphism( A, M, B );;
+IsWellDefined( alpha );
+#! true
+beta := AdditiveClosureMorphism( B, N, B );;
+IsWellDefined( beta );
+#! true
+gamma := PreCompose( alpha, beta );;
+IsWellDefined( gamma );
+#! true
+MorphismMatrix( gamma ) = P;
+#! true
+
+
+# E and EE are both occupied by GAP
+EEE := KoszulDualRing( R );;
+
+matrix_element_as_morphism :=
+        r -> RingAsCategoryMorphism( RingAsCategory( EEE ), r );;
+
+list_list_as_matrix := {listlist, m, n} ->
+    HomalgMatrix(
+        List( listlist,
+            row -> List( row,
+                entry -> UnderlyingRingElement( entry )
+            )
+        ), m, n, EEE );;
+
+CEEE := RingAsCategory( EEE );;
+CEEEplus := AdditiveClosure( CEEE :
+    matrix_element_as_morphism := matrix_element_as_morphism,
+    list_list_as_matrix := list_list_as_matrix
+);;
+
+M := HomalgMatrix( "[[e0*e1,3*e0]]", 1, 2, EEE );;
+N := HomalgMatrix( "[[1,e0*e2], [2*e0*e1*e2,5*e2]]", 2, 2, EEE );;
+P := M * N;;
+
+o := AsAdditiveClosureObject( RingAsCategoryUniqueObject( CEEE ) );;
+
+A := o;;
+B := DirectSum( o, o );;
+
+alpha := AdditiveClosureMorphism( A, M, B );;
+IsWellDefined( alpha );
+#! true
+beta := AdditiveClosureMorphism( B, N, B );;
+IsWellDefined( beta );
+#! true
+gamma := PreCompose( alpha, beta );;
+IsWellDefined( gamma );
+#! true
+MorphismMatrix( gamma ) = P;
+#! true
+
+#! @EndExample

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -43,6 +43,9 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE" );
 
 #! @Description
 #! The argument is an Ab-category $C$. The output is its additive closure $C^\oplus$.
+#! By default, lists of lists are used as the underlying data structure for morphisms. This can be changed via the two
+#! options `matrix_element_as_morphism` and `list_list_as_matrix`, see
+#! <Ref Func="AdditiveClosureMorphism" Label="for IsAdditiveClosureObject, IsObject, IsAdditiveClosureObject" /> for details.
 #! @Arguments C
 #! @Returns the category $C^\oplus$
 DeclareAttribute( "AdditiveClosure",
@@ -65,11 +68,29 @@ DeclareAttribute( "AsAdditiveClosureObject",
 
 #! @Description
 #! The arguments are formal direct sums $A=A_1\oplus\dots\oplus A_m$, $B=B_1\oplus\dots\oplus B_n$ in some additive category $C^\oplus$
-#! and an $m\times n$ matrix $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
+#! and an $m\times n$ matrix (see below) $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
 #! The output is the formal morphism between $A$ and $B$ that is defined by $M$.
+#! 
+#! If $m \neq 0 \neq n$, <A>M</A> has to provide access to its elements via the operation `[,]`. In case that the elements of <A>M</A> first have to be wrapped
+#! to actually obtain morphisms in $C$, you can provide the function `matrix_element_as_morphism` (default: `IdFunc`) as an option to
+#! <Ref Attr="AdditiveClosure" Label="for IsCapCategory" /> which will internally be automatically applied to the elements of <A>M</A>.
+#! In this case you also have to provide the function `list_list_as_matrix` (default: `ReturnFirst`) as an option to
+#! <Ref Attr="AdditiveClosure" Label="for IsCapCategory" />: It gets passed a list of list of morphisms $\alpha_{ij}$ as well as $m$ and $n$
+#! as above and has to return the corresponding matrix <A>M</A>.
+#! If `IsMatrixObj( <A>M</A> )`, then `NrRows( M )` resp. `NrCols( M )` must be $m$ resp. $n$.
+#! 
+#! The default values of `matrix_element_as_morphism` and `list_list_as_matrix` allow to use lists of lists as the data structure of <A>M</A>.
 #! @Arguments A, M, B
 #! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
 DeclareOperation( "AdditiveClosureMorphism",
+                  [ IsAdditiveClosureObject, IsObject, IsAdditiveClosureObject ] );
+
+#! @Description
+#! Input and return value are the same as for `AdditiveClosureMorphism` except that the matrix `M`
+#! can be given as a list (of lists) <A>L</A> to which `list_list_as_matrix` will be applied automatically.
+#! @Arguments A, L, B
+#! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
+DeclareOperation( "AdditiveClosureMorphismListList",
                   [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
 
 #! @Description

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -906,17 +906,17 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             ##
             AddHomomorphismStructureOnMorphismsWithGivenObjects( category,
               function( source, alpha, beta, range )
-                local size_i, size_k, size_j, size_l;
+                local size_i, size_j, size_s, size_t;
                 
-                size_i := NrCols( alpha );
+                size_i := NrRows( alpha );
                 
-                size_k := NrRows( alpha );
+                size_j := NrCols( alpha );
                 
-                size_j := NrRows( beta );
+                size_s := NrRows( beta );
                 
-                size_l := NrCols( beta );
+                size_t := NrCols( beta );
                 
-                if ForAny( [ size_i, size_k, size_j, size_l ], IsZero ) then
+                if ForAny( [ size_i, size_j, size_s, size_t ], IsZero ) then
                     
                     return ZeroMorphism( source, range );
                     
@@ -924,12 +924,12 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                 
                 return MorphismBetweenDirectSums(
                         source,
-                        List( [ 1 .. size_i ], i ->
-                          List( [ 1 .. size_k ], k -> 
+                        List( [ 1 .. size_j ], j ->
+                          List( [ 1 .. size_i ], i ->
                             MorphismBetweenDirectSums(
-                              List( [ 1 .. size_j ], j ->
-                                List( [ 1 .. size_l ], l ->
-                                  HomomorphismStructureOnMorphisms( alpha[k, i], beta[j, l] )
+                              List( [ 1 .. size_s ], s ->
+                                List( [ 1 .. size_t ], t ->
+                                  HomomorphismStructureOnMorphisms( alpha[i, j], beta[s, t] )
                                 )
                               )
                             )

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -680,21 +680,21 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         
         size := Size( object_list );
         
-        listlist := List( [ 1 .. size ], i -> [ ] );
-        
-        for i in [ 1 .. size ] do
-            
-            listlist[i][i] := IdentityMorphism( object_list[i] );
-            
-            for j in [ i + 1 .. size ]  do
-                
-                listlist[i][j] := ZeroMorphism( object_list[i], object_list[j] );
-                
-                listlist[j][i] := ZeroMorphism( object_list[j], object_list[i] );
-                
-            od;
-            
-        od;
+        listlist := List( [ 1 .. size ], i ->
+                        List( [ 1 .. size ], function( j )
+                            
+                            if i = j then
+                                
+                                return IdentityMorphism( object_list[i] );
+                                
+                            else
+                                
+                                return ZeroMorphism( object_list[i], object_list[j] );
+                                
+                            fi;
+                            
+                        end )
+                    );
         
         return AdditiveClosureMorphismListList( object, listlist, object );
         
@@ -713,23 +713,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         
         size_list_range := Size( object_list_range );
         
-        if size_list_source = 0 or size_list_range = 0 then
-            
-            return AdditiveClosureMorphismListList( source, [ ], range );
-            
-        fi;
-        
-        listlist := List( [ 1 .. size_list_source ], i -> [ ] );
-        
-        for i in [ 1 .. size_list_source ] do
-            
-            for j in [ 1 .. size_list_range ] do
-                
-                listlist[i][j] := ZeroMorphism( object_list_source[i], object_list_range[j] );
-                
-            od;
-            
-        od;
+        listlist := List( [ 1 .. size_list_source ], i ->
+                        List( [ 1 .. size_list_range ], j ->
+                            ZeroMorphism( object_list_source[i], object_list_range[j] )
+                        )
+                    );
         
         return AdditiveClosureMorphismListList( source, listlist, range );
         
@@ -748,29 +736,17 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         
         nr_cols_2 := NrCols( morphism_2 );
         
-        if ForAny( [ nr_rows_1, nr_cols_2 ], IsZero ) then
-            
-            return AdditiveClosureMorphismListList( Source( morphism_1 ), [ ], Range( morphism_2 ) );
-            
-        fi;
-        
         if ForAny( [ nr_cols_1, nr_rows_2 ], IsZero ) then
             
             return ZeroMorphism( Source( morphism_1 ), Range( morphism_2 ) );
             
         fi;
         
-        listlist := List( [ 1 .. nr_rows_1 ], i -> [ ] );
-        
-        for i in [ 1 .. nr_rows_1 ] do
-            
-            for j in [ 1 .. nr_cols_2 ] do
-                
-                listlist[i][j] := Sum( List( [ 1 .. nr_cols_1 ], k -> PreCompose( morphism_1[i, k], morphism_2[k, j] ) ) );
-                
-            od;
-            
-        od;
+        listlist := List( [ 1 .. nr_rows_1 ], i ->
+                        List( [ 1 .. nr_cols_2 ], j ->
+                            Sum( List( [ 1 .. nr_cols_1 ], k -> PreCompose( morphism_1[i, k], morphism_2[k, j] ) ) )
+                        )
+                    );
         
         return AdditiveClosureMorphismListList( Source( morphism_1 ), listlist, Range( morphism_2 ) );
         

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -235,8 +235,17 @@ InstallMethod( NrRows,
                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
+    #% CAP_JIT_RESOLVE_FUNCTION
     
-    return Size( ObjectList( Source( morphism ) ) );
+    if IsMatrixObj( MorphismMatrix( morphism ) ) then
+        
+        return NrRows( MorphismMatrix( morphism ) );
+        
+    else
+        
+        return Size( ObjectList( Source( morphism ) ) );
+        
+    fi;
     
 end );
 
@@ -245,8 +254,17 @@ InstallMethod( NrCols,
                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
+    #% CAP_JIT_RESOLVE_FUNCTION
     
-    return Size( ObjectList( Range( morphism ) ) );
+    if IsMatrixObj( MorphismMatrix( morphism ) ) then
+        
+        return NrCols( MorphismMatrix( morphism ) );
+        
+    else
+        
+        return Size( ObjectList( Range( morphism ) ) );
+        
+    fi;
     
 end );
 
@@ -448,6 +466,7 @@ InstallMethod( \[\,\],
                
   function( morphism, i, j )
     local matrix_element_as_morphism;
+    #% CAP_JIT_RESOLVE_FUNCTION
     
     if not ( i in [ 1 .. NrRows( morphism ) ]
         and j in [ 1 .. NrCols( morphism ) ] ) then
@@ -916,7 +935,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                 
                 size_t := NrCols( beta );
                 
-                if ForAny( [ size_i, size_j, size_s, size_t ], IsZero ) then
+                if size_i <= 0 or size_j <= 0 or size_s <= 0 or size_t <= 0 then
                     
                     return ZeroMorphism( source, range );
                     


### PR DESCRIPTION
~Depends on #575.~

As mentioned before, I would like to make AdditiveClosure compatible with other matrix data structures, in particular homalg matrices (in the case that the UnderlyingCategory is a homalg ring). I wanted to use MatrixObj as an interface for this, but this is not advanced enough. Thus, I have the following proposal and would like to gather some feedback on this.

Concept behind this PR:
1. AdditiveClosure should really "invent" matrix calculus, that is, it should not make use of any matrix features.
2. To allow other data structures than lists of lists, AdditiveClosure should never use list accesses (i.e. `list[i]`) but only matrix accesses (i.e. `matrix[i,j]`).
4. If performance is relevant, rely on the new compiler.

This PR implements this concept:
1. I have replaced the + und - operations on matrices by explicit operations on the entries.
2. I have replaced all list accesses by matrix accesses.
3. Then it is easy to allow other matrix data structures, we only have to provide two operations: one for interpreting matrix elements as morphisms of the underlying category, and one interpreting lists of lists of such morphisms as matrices again.
4. I have implemented two new derivations: `ProjectionInFactorOfDirectSum` using `UniversalMorphismFromDirectSum` and the dual for injections.
5. I have removed `ProjectionInFactorOfDirectSum` (and injections), `MorphismBetweenDirectSums`, `UniversalMorphismFrom/IntoZeroObject` (all of these can be derived).

Now AdditiveClosure really "invents" matrix calculus in the sense that the remaining operations map exactly to matrix operations:
1. IdentityMorphism = IdentityMatrix
2. ZeroMorphism = ZeroMatrix
3. PreCompose = *
4. AdditionForMorphisms = +
5. UniversalMorphismFromDirectSum = UnionOfRows
6. UniversalMorphismIntoDirectSum = UnionOfColumns
7. HomomorphismStructureOnMorphisms = KroneckerMatrix (including the dual version I asked about)

In a sense, AdditiveClosure is now what I hoped MatrixObj would be.

Regarding performance: the runtime for the Freyd tests seems more or less unchanged on my system.

Note: Currently this PR has only one big commit. If you like the concept, I would split it into several commits so it's easier to review.