### PR TITLE
Do not format functions printed to streams in the derivation mechanism

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -13,7 +13,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.04.16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.06.17", ## Fabian's version
+  "2020.07.22", ## Fabian's version
   ## this line prevents merge conflicts
   "2020.01.10", ## Kamal's version
 ] ),

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -1078,6 +1078,8 @@ InstallGlobalFunction( CAP_INTERNAL_DERIVATION_SANITY_CHECK,
         
         string_stream := OutputTextString( function_string, false );
         
+        SetPrintFormattingStatus( string_stream, false );
+        
         PrintTo( string_stream, function_object );
         
         CloseStream( string_stream );

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -31,6 +31,8 @@ BindGlobal( "CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK",
         
         string_stream := OutputTextString( function_string, false );
         
+        SetPrintFormattingStatus( string_stream, false );
+        
         PrintTo( string_stream, function_object );
         
         CloseStream( string_stream );

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -583,6 +583,8 @@ InstallGlobalFunction( "CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION",
     
     func_stream := OutputTextString( func_as_string, false );
     
+    SetPrintFormattingStatus( func_stream, false );
+    
     PrintTo( func_stream, func );
     
     CloseStream( func_stream );


### PR DESCRIPTION
GAP breaks lines when printing strings longer than `SizeScreen`. This can also break the names of operations. Such operations are not detected by `CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION` anymore. This leads to wrong derivations being installed or correct derivations not being installed. To test this, execute `make test` in a narrow terminal (e.g. 40 characters) or execute `SizeScreen( [ 40 ] );` before loading CAP. The fix is to disable the formatting of the stream before calling `PrintTo`.

Note: There are more calls to `PrintTo` in `GroupRepresentationsForCAP/gap/AssociatorsForRepresentationCategoryOfGroup.gi` which I have not touched. They might need such a handling, too.