### PR TITLE
Add GaussForHomalg dependency to LinearAlgebraForCAP

### DIFF
--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -99,6 +99,7 @@ Dependencies := rec(
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
                            [ "ToolsForHomalg", ">=2015.09.18" ],
                            [ "MatricesForHomalg", ">= 2020.05.12" ],
+                           [ "GaussForHomalg", ">= 2019.09.02" ],
                            [ "CAP", ">= 2020.05.16" ],
                            [ "MonoidalCategories", ">= 2019.01.16" ],
                            ],


### PR DESCRIPTION
To create a valid input ring one has to load `GaussForHomalg` anyway (either directly or via `RingsForHomalg`), and this way one can use `HomalgFieldOfRationals` in examples without having to load `GaussForHomalg` explicitly.