### PR TITLE
Bump version of CAP

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -15,7 +15,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.07.22", ## Fabian's version
   ## this line prevents merge conflicts
-  "2020.01.10", ## Kamal's version
+  "2020.08.01", ## Kamal's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},


### PR DESCRIPTION
Bump version to 2020.08.01 to be able to require this version in the packages affected by https://github.com/homalg-project/CAP_project/pull/557