### PR TITLE
Add dot method to convert vertices and arrows of a quiver to objects and

### DIFF
--- a/FreydCategoriesForCAP/gap/QuiverRows.gi
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gi
@@ -1529,6 +1529,36 @@ end );
 ####################################
 
 ##
+InstallMethod( \.,
+        [ IsQuiverRowsCategory, IsPosInt ],
+  function( QRows, string_as_int )
+    local name, A, q, a;
+
+    name := NameRNam( string_as_int );
+
+    A := UnderlyingQuiverAlgebra( QRows );
+
+    q := QuiverOfAlgebra( A );
+
+    a  := q.( name );
+
+    if IsQuiverVertex( a ) then
+
+      return AsQuiverRowsObject( a, QRows );
+
+    elif IsArrow( a ) then
+
+      return AsQuiverRowsMorphism( A.( name ), QRows );
+
+    else
+
+      Error( "the given component ", name, " is neither a vertex nor an arrow of the quiver q = ", q, "\n" );
+
+    fi;
+
+end );
+
+##
 InstallMethod( \/,
                [ IsQuiverVertex, IsQuiverRowsCategory ],
                AsQuiverRowsObject


### PR DESCRIPTION
morphisms in quiver rows category by using their labels

After this commit you can do the following:

Q := RightQuiver( "q(2)[#:1->2]" );
QRows := QuiverRows( PathAlgebra( HomalgFieldOfRationals(), Q ) );
QRows.("#");
<A morphism in QuiverRows( Q * q ) defined by a 1 x 1 matrix of quiver algebra elements>

This has been for a long time in derived categories package and I think it is very useful when the labels of arrows and vertices are complicated strings.