### PR TITLE
Use GitHub Actions and update README

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  disable_default_path_fixes: true
+fixes:
+  - "/home/gap/.gap/pkg/CAP_project/::"
+ignore:
+  - "home/"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        image: [gapsystem/gap-docker, gapsystem/gap-docker-master]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v1
+      - run: mkdir -p /home/gap/.gap/pkg/
+      - run: sudo cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/
+      - run: sudo chown -R gap:gap /home/gap/.gap/pkg/
+      - run: |
+          export HOME="/home/gap"
+          cd /home/gap/.gap/pkg/
+          sudo apt update
+          sudo apt dist-upgrade -y
+          sudo apt install -y texlive-latex-extra texlive-science
+          git clone --depth 1 https://github.com/gap-packages/AutoDoc.git
+          git clone --depth 1 https://github.com/homalg-project/homalg_project.git
+          TERM=dumb make -C CAP_project -j $(nproc) --output-sync ci-test
+          curl -s https://codecov.io/bash | bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# CAP Project
+<!-- BEGIN HEADER -->
+# CAP_project – Categories, Algorithms, and Programming
+
+| **Build Status**                                            |
+|:-----------------------------------------------------------:|
+| [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+<!-- END HEADER -->
 
 Welcome to the CAP project.
 
@@ -9,3 +15,10 @@ Please take a look at our [manual](https://github.com/homalg-project/CAP_project
 ## Website
 
 Please visit our website: http://homalg-project.github.io/CAP_project/
+<!-- BEGIN FOOTER -->
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->


### PR DESCRIPTION
This modifies the heading in the README and adds a build status linking to the GitHub Action and codecov.

This was automatically generated by [PackageMakerAnsible](https://github.com/zickgraf/PackageMakerAnsible), a project I have started to automatically generate common code (like the build status header or the CI definition) across all our packages. The reason for the tags `<!-- BEGIN HEADER -->`, `<!-- END HEADER -->`,... in the README is the following: using these headers, PackageMakerAnsible can update the blocks if there is some change (for example, if we would change our coverage provider from codecov to coveralls in the future).

Edit: GitHub Actions will only trigger once the PR is merged, so the build status will not be shown until then. If you want to view what the result would look like, see https://github.com/homalg-project/InternalModules