### PR TITLE
Add documentation of subpackages to README

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  disable_default_path_fixes: true
+fixes:
+  - "/home/gap/.gap/pkg/CAP_project/::"
+ignore:
+  - "home/"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        image: [gapsystem/gap-docker, gapsystem/gap-docker-master]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v1
+      - run: mkdir -p /home/gap/.gap/pkg/
+      - run: sudo cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/
+      - run: sudo chown -R gap:gap /home/gap/.gap/pkg/
+      - run: |
+          export HOME="/home/gap"
+          cd /home/gap/.gap/pkg/
+          sudo apt update
+          sudo apt dist-upgrade -y
+          sudo apt install -y texlive-latex-extra texlive-science
+          git clone --depth 1 https://github.com/gap-packages/AutoDoc.git
+          git clone --depth 1 https://github.com/homalg-project/homalg_project.git
+          TERM=dumb make -C CAP_project -j $(nproc) --output-sync ci-test
+          curl -s https://codecov.io/bash | bash

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,3 +31,32 @@ jobs:
           git clone --depth 1 https://github.com/homalg-project/homalg_project.git
           TERM=dumb make -C CAP_project -j $(nproc) --output-sync ci-test
           curl -s https://codecov.io/bash | bash
+          cd CAP_project
+          CUR_SHA=$(git rev-parse --verify HEAD)
+          git worktree add branch_doc/ doc || (echo "There was an error. Make sure there is a branch named 'doc'."; exit 1)
+          cp CompilerForCAP/doc/manual.pdf branch_doc/CompilerForCAP.pdf
+          cd branch_doc
+          git add CompilerForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add CompilerForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp GradedModulePresentationsForCAP/doc/manual.pdf branch_doc/GradedModulePresentationsForCAP.pdf
+          cd branch_doc
+          git add GradedModulePresentationsForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add GradedModulePresentationsForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp GroupRepresentationsForCAP/doc/manual.pdf branch_doc/GroupRepresentationsForCAP.pdf
+          cd branch_doc
+          git add GroupRepresentationsForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add GroupRepresentationsForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp InternalExteriorAlgebraForCAP/doc/manual.pdf branch_doc/InternalExteriorAlgebraForCAP.pdf
+          cd branch_doc
+          git add InternalExteriorAlgebraForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add InternalExteriorAlgebraForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          # push iff using gap-stable and if on master branch
+          if [ "${{ matrix.image }}" = "gapsystem/gap-docker" ] && [ "$CUR_SHA" = "$(git rev-parse origin/master)" ]; then \
+            git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git doc:doc; \
+          else \
+            echo "Not pushing result."; \
+          fi; \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- BEGIN HEADER -->
 # CAP_project – Categories, Algorithms, and Programming
 
-| **Build Status**                                            |
-|:-----------------------------------------------------------:|
-| [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| **Documentation**         | **Build Status**                                            |
+|:-------------------------:|:-----------------------------------------------------------:|
+| [![][docs-CAP-img]][docs-CAP-url]<br> [![][docs-CompilerForCAP-img]][docs-CompilerForCAP-url]<br> [![][docs-ModulePresentationsForCAP-img]][docs-ModulePresentationsForCAP-url]<br> [![][docs-GradedModulePresentationsForCAP-img]][docs-GradedModulePresentationsForCAP-url]<br> [![][docs-LinearAlgebraForCAP-img]][docs-LinearAlgebraForCAP-url]<br> [![][docs-GeneralizedMorphismsForCAP-img]][docs-GeneralizedMorphismsForCAP-url]<br> [![][docs-GroupRepresentationsForCAP-img]][docs-GroupRepresentationsForCAP-url]<br> [![][docs-InternalExteriorAlgebraForCAP-img]][docs-InternalExteriorAlgebraForCAP-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
 <!-- END HEADER -->
 
 Welcome to the CAP project.
@@ -16,6 +16,30 @@ Please take a look at our [manual](https://github.com/homalg-project/CAP_project
 
 Please visit our website: http://homalg-project.github.io/CAP_project/
 <!-- BEGIN FOOTER -->
+[docs-CAP-img]: https://img.shields.io/badge/CAP-HTML-blue.svg
+[docs-CAP-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0.html
+
+[docs-CompilerForCAP-img]: https://img.shields.io/badge/CompilerForCAP-PDF-blue.svg
+[docs-CompilerForCAP-url]: /../../raw/doc/CompilerForCAP.pdf
+
+[docs-ModulePresentationsForCAP-img]: https://img.shields.io/badge/ModulePresentationsForCAP-HTML-blue.svg
+[docs-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0.html
+
+[docs-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/GradedModulePresentationsForCAP-PDF-blue.svg
+[docs-GradedModulePresentationsForCAP-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
+
+[docs-LinearAlgebraForCAP-img]: https://img.shields.io/badge/LinearAlgebraForCAP-HTML-blue.svg
+[docs-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0.html
+
+[docs-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/GeneralizedMorphismsForCAP-HTML-blue.svg
+[docs-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0.html
+
+[docs-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/GroupRepresentationsForCAP-PDF-blue.svg
+[docs-GroupRepresentationsForCAP-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
+
+[docs-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/InternalExteriorAlgebraForCAP-PDF-blue.svg
+[docs-InternalExteriorAlgebraForCAP-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
+
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# CAP Project
+<!-- BEGIN HEADER -->
+# CAP_project – Categories, Algorithms, and Programming
+
+| **Build Status**                                            |
+|:-----------------------------------------------------------:|
+| [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+<!-- END HEADER -->
 
 Welcome to the CAP project.
 
@@ -9,3 +15,10 @@ Please take a look at our [manual](https://github.com/homalg-project/CAP_project
 ## Website
 
 Please visit our website: http://homalg-project.github.io/CAP_project/
+<!-- BEGIN FOOTER -->
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->


### PR DESCRIPTION
Note: the first commit is the one from #562.

This PR adds links to the documentations of all subpackages which are part of `make ci-test` to the README. If a package has HTML documentation, this is used. If not, its `manual.pdf` is added to the branch `doc` (which I will have to create) automatically by the CI and then used for the link. You can view the result here: https://github.com/zickgraf/CAP_project/blob/documentation/README.md

I'm not 100% satisfied with the layout, so if you like the basic idea feel free to suggest improvements. Also, the order of the packages is more or less random right now and can be adjusted.