### PR TITLE
LaTeX strings for semisimple categories

### DIFF
--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -14,6 +14,8 @@ Version := Maximum( [
   "2017.01.11", ## Sepp's version
   ## this line prevents merge conflicts
   "2019.09.02", ## Mohamed's version
+  ## this line prevents merge conflicts
+  "2020.09.08", ## Fabian's version
 ] ),
 
 Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -78,6 +78,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.8",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
+                           [ "ToolsForHomalg", ">= 2020.09.01" ],
                            [ "CAP", ">= 2015.08.17" ],
                            [ "LinearAlgebraForCAP", ">=2015.12.03" ],
                            [ "RingsForHomalg", ">=2016.08.12" ],

--- a/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gi
+++ b/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gi
@@ -244,7 +244,7 @@ InstallMethod( String,
               
   function( object )
     
-    return String( object!.UnderlyingCharacterNumber );
+    return Concatenation( "x_", String( object!.UnderlyingCharacterNumber ) );
     
 end );
 
@@ -254,6 +254,6 @@ InstallMethod( ViewObj,
 
   function( object )
 
-    Print( Concatenation( "<x_", String( object ), ">" ) );
+    Print( Concatenation( "<", String( object ), ">" ) );
 
 end );

--- a/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gi
+++ b/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gi
@@ -388,7 +388,7 @@ InstallMethod( String,
               
   function( object )
     
-    return Concatenation( "[", String( object!.UnderlyingDegree ), ", ", String( object!.UnderlyingCharacterNumber ), "]" );
+    return Concatenation( "x_[", String( object!.UnderlyingDegree ), ", ", String( object!.UnderlyingCharacterNumber ), "]" );
     
 end );
 
@@ -398,6 +398,6 @@ InstallMethod( ViewObj,
 
   function( object )
 
-    Print( Concatenation( "<x_", String( object ), ">" ) );
+    Print( Concatenation( "<", String( object ), ">" ) );
 
 end );

--- a/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gd
+++ b/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gd
@@ -83,6 +83,19 @@ DeclareOperation( "RepresentationCategory", [ IsGroup, IsList ] );
 #! @Arguments L, C
 DeclareOperation( "RepresentationCategoryObject", [ IsList, IsCapCategory ] );
 
+#! @Description
+#!  There are 3 arguments.
+#!  The first argument is
+#!  an irreducible character <A>c</A>.
+#!  The second argument is the CAP category $C = G$-mod.
+#!  The third argument is a string used as follows:
+#!  <C>SetString</C>( <C>GIrreducibleObject</C>( <A>c</A> ), <A>str</A> ).
+#!  The output is the unique object in $G$-mod
+#!  having $[ [ 1, c ] ]$ as its character decomposition.
+#! @Returns an object in $G$-mod
+#! @Arguments c, C, str
+DeclareOperation( "RepresentationCategoryObject", [ IsCharacter, IsCapCategory, IsString ] );
+
 ##
 DeclareOperation( "RepresentationCategoryMorphism", [ IsSemisimpleCategoryObject, IsList, IsSemisimpleCategoryObject ] );
 

--- a/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gi
+++ b/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gi
@@ -169,6 +169,19 @@ InstallMethod( RepresentationCategoryObject,
 end );
 
 ##
+InstallMethod( RepresentationCategoryObject,
+        "for a character, a CAP category, and a string",
+        [ IsCharacter, IsCapCategory, IsString ],
+        
+  function ( character, category, str )
+    
+    SetString( GIrreducibleObject( character ), str );
+    
+    return RepresentationCategoryObject( character, category );
+    
+end );
+
+##
 InstallMethod( RepresentationCategoryMorphism,
                [ IsSemisimpleCategoryObject, IsList, IsSemisimpleCategoryObject ],
                

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gd
@@ -151,3 +151,11 @@ DeclareAttribute( "SupportOfMorphismList",
 #! @Returns a vector space morphism 
 #! @Arguments alpha, i
 DeclareOperation( "Component", [ IsSemisimpleCategoryMorphism, IsObject ] );
+
+#! @Description
+#! The argument is a morphism <A>m</A> in a semisimple category.
+#! The output is a LaTeX string (without enclosing dollar signs) that may be used to print out <A>m</A> nicely.
+#! @Returns a string
+#! @Arguments m
+DeclareOperation( "LaTeXStringOp",
+        [ IsSemisimpleCategoryMorphism ] );

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
@@ -329,3 +329,59 @@ InstallMethod( Display,
     
 end );
 
+##
+InstallMethod( LaTeXStringOp,
+        "for a morphism in a semisimple category",
+        [ IsSemisimpleCategoryMorphism ],
+        
+  function ( morphism )
+    local morphism_list, source_object_list, range_object_list, source_object_string, range_object_string, diag_entries, matrix, string, elem;
+    
+    morphism_list := SemisimpleCategoryMorphismList( morphism );
+    
+    morphism_list := Filtered( morphism_list, pair -> not( IsZeroForObjects( Source( pair[1] ) ) or IsZeroForObjects( Range( pair[1] ) ) ) );
+    
+    if IsEmpty( morphism_list ) then
+        
+        Display( "0" );
+        
+    else
+        
+        source_object_list := List( morphism_list, m -> [ NrRows( UnderlyingMatrix( m[1] ) ), m[2] ] );
+        range_object_list := List( morphism_list, m -> [ NrCols( UnderlyingMatrix( m[1] ) ), m[2] ] );
+        
+        source_object_string := LaTeXStringOfSemisimpleCategoryObjectList( source_object_list );
+        range_object_string := LaTeXStringOfSemisimpleCategoryObjectList( range_object_list );
+        
+        diag_entries := [ ];
+        
+        for elem in morphism_list do
+            
+            matrix := UnderlyingMatrix( elem[1] );
+            
+            if NrRows( matrix ) = 1 and NrCols( matrix ) = 1 then
+                
+                Add( diag_entries, LaTeXStringOp( matrix[1, 1] ) );
+                
+            else
+                
+                Add( diag_entries, LaTeXStringOp( matrix ) );
+                
+            fi;
+            
+        od;
+        
+        string := "";
+        Append( string, source_object_string );
+        Append( string, " \\xrightarrow{\\operatorname{diag}(" );
+        Append( string, JoinStringsWithSeparator( diag_entries, "," ) );
+        Append( string, ")} " );
+        Append( string, range_object_string );
+        
+        return string;
+        
+    fi;
+    
+end );
+
+MakeShowable( [ "text/latex", "application/x-latex" ], IsSemisimpleCategoryMorphism );

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
@@ -315,7 +315,7 @@ InstallMethod( Display,
         
         for elem in morphism_list do
             
-            Print( Concatenation( "Component: (x_", String( elem[2] ), ")\n" ) );
+            Print( Concatenation( "Component: (", String( elem[2] ), ")\n" ) );
             
             Print( "\n" );
             

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
@@ -215,3 +215,11 @@ DeclareOperation( "TestZigZagIdentitiesForDual", [ IsSemisimpleCategoryObject ] 
 #! @Returns a boolean
 #! @Arguments L
 DeclareOperation( "TestZigZagIdentitiesForDualForAllObjectsInList", [ IsList ] );
+
+#! @Description
+#! The argument is an object <A>c</A> in a semisimple category.
+#! The output is a LaTeX string (without enclosing dollar signs) that may be used to print out <A>c</A> nicely.
+#! @Returns a string
+#! @Arguments c
+DeclareOperation( "LaTeXStringOp",
+        [ IsSemisimpleCategoryObject ] );

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
@@ -468,3 +468,16 @@ InstallMethod( Display,
     Print( Concatenation( String( object ), "\n" ) );
     
 end );
+
+##
+InstallMethod( LaTeXStringOp,
+        "for an object in a semisimple category",
+        [ IsSemisimpleCategoryObject ],
+        
+  function ( object )
+    
+    return LaTeXStringOfSemisimpleCategoryObjectList( SemisimpleCategoryObjectList( object ) );
+    
+end );
+
+MakeShowable( [ "text/latex", "application/x-latex" ], IsSemisimpleCategoryObject );

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
@@ -437,11 +437,11 @@ InstallMethod( String,
         
     fi;
     
-    string := Concatenation( String( object_list[1][1] ), "*(x_", String( object_list[1][2] ), ")" );
+    string := Concatenation( String( object_list[1][1] ), "*(", String( object_list[1][2] ), ")" );
     
     for i in [ 2 .. size ] do
         
-        Append( string, Concatenation( " + ", String( object_list[i][1] ), "*(x_", String( object_list[i][2] ), ")" ) );
+        Append( string, Concatenation( " + ", String( object_list[i][1] ), "*(", String( object_list[i][2] ), ")" ) );
         
     od;
     

--- a/GroupRepresentationsForCAP/gap/Tools.gd
+++ b/GroupRepresentationsForCAP/gap/Tools.gd
@@ -10,3 +10,12 @@ DeclareAttribute( "MultiplicityArray", IsGroup );
 
 ##
 DeclareAttribute( "MultiplicityTripleArray", IsGroup );
+
+#! @Section Helper functions
+
+#! @Description
+#! The argument is a list <A>L</A> defining an object `c` in a semisimple category.
+#! The output is a LaTeX string (without enclosing dollar signs) that may be used to print out `c` nicely.
+#! @Returns a string
+#! @Arguments L
+DeclareGlobalFunction( "LaTeXStringOfSemisimpleCategoryObjectList" );

--- a/GroupRepresentationsForCAP/gap/Tools.gi
+++ b/GroupRepresentationsForCAP/gap/Tools.gi
@@ -45,3 +45,50 @@ InstallMethod( MultiplicityTripleArray,
       );
     
 end );
+
+##
+InstallGlobalFunction( LaTeXStringOfSemisimpleCategoryObjectList,
+  function ( object_list )
+    local size, parts;
+    
+    size := Size( object_list );
+    
+    if size = 0 then
+        
+        return "0";
+        
+    fi;
+    
+    parts := List( object_list, function ( l )
+      local mult, irr, string;
+        
+        mult := l[1];
+        irr := l[2];
+        
+        if mult = 1 then
+            
+            string := "";
+            
+        else
+            
+            string := Concatenation( String( mult ), " \\cdot " );
+            
+        fi;
+        
+        if IsShowable( "text/latex", irr ) then
+            
+            Append( string, LaTeXStringOp( irr ) );
+            
+        else
+            
+            Append( string, String( irr ) );
+            
+        fi;
+        
+        return string;
+        
+    end );
+    
+    return JoinStringsWithSeparator( parts, " \\oplus " );
+    
+end );


### PR DESCRIPTION
This consists of multiple commits:

1. Move the "x_" in the output of GIrreducibleObjects from the view methods to the string (so the string actually functions as a name). This is not necessarily required but I think it makes things clearer.
2. Add version of `RepresentationCategoryObject` which allows to set the string of the underlying GIrreducibleObject (for example, to "\chi" or "χ"). Also include a convenience method for calling this with Julia strings.
3. Add `LaTeXStringOp` for objects and morphisms of semisimple categories. Uses the helper function `LaTeXStringOfSemisimpleCategoryObjectList`. Also add `IsShowable` so the LaTeX string is used in Jupyter notebooks.

Notes:
1. If you like I can add tests but since they would depend on homalg's LaTeX strings I fear they would break regularly, at least in the near future where all of the LaTeX stuff is still in flux.
2. We now have an inconsistency of names in CAP/homalg: `LaTeXString(Op)` vs `LaTeXOutput`. I think the term `LaTeXString` is better suited because `Output` might hint to something being displayed immediately. However, I might be biased here as my code already uses `LaTeXString(Op)` :D