### PR TITLE
Declare the operation LaTeXOutputOnlyMorphismData

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -530,6 +530,15 @@ DeclareGlobalFunction( "DisableAddForCategoricalOperations" );
 DeclareOperation( "LaTeXOutput", [ IsCapCategoryCell ] );
 
 #! @Description
+#! The argument is a morphism $c$.
+#! The output is a LaTeX string $s$ (without enclosing dollar signs) that may be used to print out nicely
+#! the data which are needed to reconstruct $c$ (e.g., by passing it to an appropriate constructor,
+#! possibly together with its source and range).
+#! @Returns a string
+#! @Arguments c
+DeclareOperation( "LaTeXOutputOnlyMorphismData", [ IsCapCategoryMorphism ] );
+
+#! @Description
 #! The argument is a category $C$.
 #! The output is a LaTeX string $s$ (without enclosing dollar signs) that may be used to print out $C$ nicely.
 #! @Returns a string


### PR DESCRIPTION
Sometimes one wants to print nicely only the data of the morphism without its source and range. This is helpful at least in complexes categories and algebroids and additive closures categories.