### PR TITLE
Only run CI on master branch and branches ending with "-ci"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ workflows:
     jobs:
       - test:
           docker_image: gapsystem/gap-docker
+          filters:
+            branches:
+              only:
+                - master
+                - /.*-ci/
   nightly:
     triggers:
       - schedule:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -3,7 +3,8 @@ name: Tests
 on:
   push:
     branches:
-      - "*"
+      - "master"
+      - "*-ci"
   pull_request:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
I have lots of branches I regularly rebase and push, but I do not want to trigger the CI every time for all of them. This change allows to actively activate the CI by appending "-ci" to the branch name, and disables the CI for all other branches except `master`.