### PR TITLE
Preparation for #547

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -21,7 +21,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.04.16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.07.22", ## Fabian's version
+  "2020.09.01", ## Fabian's version
   ## this line prevents merge conflicts
   "2020.08.01", ## Kamal's version
 ] ),

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -109,6 +109,96 @@ end : CategoryFilter := IsAdditiveCategory,
       Description := "UniversalMorphismFromDirectSum using projections of the direct sum" );
 
 ##
+AddWithGivenDerivationPairToCAP( ProjectionInFactorOfDirectSum,
+  
+  function( list, projection_number )
+    local morphisms;
+    
+    morphisms := List( [ 1 .. Length( list ) ], function( i )
+        
+        if i = projection_number then
+            
+            return IdentityMorphism( list[projection_number] );
+            
+        else
+            
+            return ZeroMorphism( list[i], list[projection_number] );
+            
+        fi;
+        
+    end );
+    
+    return UniversalMorphismFromDirectSum( list, morphisms );
+    
+  end,
+  
+  function( list, projection_number, direct_sum_object )
+    local morphisms;
+    
+    morphisms := List( [ 1 .. Length( list ) ], function( i )
+        
+        if i = projection_number then
+            
+            return IdentityMorphism( list[projection_number] );
+            
+        else
+            
+            return ZeroMorphism( list[i], list[projection_number] );
+            
+        fi;
+        
+    end );
+    
+    return UniversalMorphismFromDirectSumWithGivenDirectSum( list, morphisms, direct_sum_object );
+    
+end : Description := "ProjectionInFactorOfDirectSum using UniversalMorphismFromDirectSum" );
+
+##
+AddWithGivenDerivationPairToCAP( InjectionOfCofactorOfDirectSum,
+  
+  function( list, injection_number )
+    local morphisms;
+    
+    morphisms := List( [ 1 .. Length( list ) ], function( i )
+        
+        if i = injection_number then
+            
+            return IdentityMorphism( list[injection_number] );
+            
+        else
+            
+            return ZeroMorphism( list[injection_number], list[i] );
+            
+        fi;
+        
+    end );
+    
+    return UniversalMorphismIntoDirectSum( list, morphisms );
+    
+  end,
+  
+  function( list, injection_number, direct_sum_object )
+    local morphisms;
+    
+    morphisms := List( [ 1 .. Length( list ) ], function( i )
+        
+        if i = injection_number then
+            
+            return IdentityMorphism( list[injection_number] );
+            
+        else
+            
+            return ZeroMorphism( list[injection_number], list[i] );
+            
+        fi;
+        
+    end );
+    
+    return UniversalMorphismIntoDirectSumWithGivenDirectSum( list, morphisms, direct_sum_object );
+    
+end : Description := "InjectionOfCofactorOfDirectSum using UniversalMorphismIntoDirectSum" );
+
+##
 AddWithGivenDerivationPairToCAP( UniversalMorphismIntoTerminalObject,
   
   function( test_source )

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -99,7 +99,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.8",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2020.05.16" ],
+                           [ "CAP", ">= 2020.09.01" ],
                            [ "MatricesForHomalg", ">= 2020.09.06" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "LinearAlgebraForCAP", ">= 2020.05.16" ],

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -180,19 +180,11 @@ DeclareOperation( "\[\]",
 
 
 #! @Description
-#! The arguments are morphism $\alpha:A\to B$ between formal direct sums in some additive category $C^\oplus$ and an integer $i$.
-#! The output is the $i$'th entry in <C>MorphismMatrix</C>($\alpha$).
-#! @Arguments alpha, i
-#! @Returns a list of morphisms in $C$
-DeclareOperation( "\[\]",
-                  [ IsAdditiveClosureMorphism, IsInt ] );
-
-#! @Description
 #! The arguments are a morphism $\alpha:A\to B$ between formal direct sums in some additive category $C^\oplus$ and two integers $i,j$.
 #! The output is the $(i,j)$'th entry in <C>MorphismMatrix</C>($\alpha$).
 #! @Arguments alpha, i, j
 #! @Returns a morphism $C$
-DeclareOperation( "\[\]",
+DeclareOperation( "[,]",
                   [ IsAdditiveClosureMorphism, IsInt, IsInt ] );
 
 #! @Description

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -725,19 +725,29 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
     ##
     AddAdditionForMorphisms( category,
       function( morphism_1, morphism_2 )
+        local listlist;
+        
+        listlist := List( [ 1 .. NrRows( morphism_1 ) ],
+                        i -> List( [ 1 .. NrCols( morphism_1 ) ],
+                            j -> morphism_1[i, j] + morphism_2[i, j] ) );
         
         return AdditiveClosureMorphism( Source( morphism_1 ),
-                                        MorphismMatrix( morphism_1 ) + MorphismMatrix( morphism_2 ),
-                                        Range( morphism_2 ) );
+                                        listlist,
+                                        Range( morphism_1 ) );
         
     end );
     
     ##
     AddAdditiveInverseForMorphisms( category,
       function( morphism )
+        local listlist;
+        
+        listlist := List( [ 1 .. NrRows( morphism ) ],
+                        i -> List( [ 1 .. NrCols( morphism ) ],
+                            j -> - ( morphism[i, j] ) ) );
         
         return AdditiveClosureMorphism( Source( morphism ),
-                                        -MorphismMatrix( morphism ),
+                                        listlist,
                                         Range( morphism ) );
         
     end );

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -797,73 +797,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
     end );
     
     ##
-    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( category,
-      function( sink, zero_object )
-        
-        return AdditiveClosureMorphism( sink, [ ], zero_object );
-        
-    end );
-    
-    ##
-    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( category,
-      function( source, zero_object )
-        
-        return AdditiveClosureMorphism( zero_object, [ ], source );
-        
-    end );
-    
-    ##
     AddDirectSum( category,
       function( list )
         
         return AdditiveClosureObject( Concatenation( List( list, ObjectList ) ), category );
-        
-    end );
-    
-    ##
-    AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
-      function( list, projection_number, direct_sum_object )
-        local pre_object, range, post_object, pre_zero, id, post_zero;
-        
-        pre_object := DirectSum( category, list{[1 .. projection_number - 1]} );
-        
-        range := list[projection_number];
-        
-        post_object := DirectSum( category, list{[projection_number + 1 .. Size( list )]} );
-        
-        pre_zero := ZeroMorphism( pre_object, range );
-        
-        id := IdentityMorphism( range );
-        
-        post_zero := ZeroMorphism( post_object, range );
-        
-        return AdditiveClosureMorphism( direct_sum_object,
-                                        Concatenation( MorphismMatrix( pre_zero ), MorphismMatrix( id ), MorphismMatrix( post_zero ) ),
-                                        range );
-        
-    end );
-    
-    
-    ##
-    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
-      function( list, injection_number, direct_sum_object )
-        local pre_object, source, post_object, pre_zero, id, post_zero;
-        
-        pre_object := DirectSum( category, list{[1 .. injection_number - 1]} );
-        
-        source := list[injection_number];
-        
-        post_object := DirectSum( category, list{[injection_number + 1 .. Size( list )]} );
-        
-        pre_zero := ZeroMorphism( source, pre_object );
-        
-        id := IdentityMorphism( source );
-        
-        post_zero := ZeroMorphism( source, post_object );
-        
-        return AdditiveClosureMorphism( source,
-                                        List( [ 1 .. NrRows( id ) ], i -> Concatenation( pre_zero[i], id[i], post_zero[i] ) ),
-                                        direct_sum_object );
         
     end );
     
@@ -898,49 +835,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         return AdditiveClosureMorphism( direct_sum,
                                         Concatenation( List( sink, MorphismMatrix ) ),
                                         test_object );
-        
-    end );
-    
-    ##
-    AddMorphismBetweenDirectSums( category,
-      function( source, listlist, range )
-        local nr_cols_out, mat, outer_row, nr_inner_rows, i, new_row;
-        
-        if IsEmpty( listlist ) or IsEmpty( listlist[1] ) then
-          
-          return ZeroMorphism( source, range );
-          
-        fi;
-        
-        nr_cols_out := Size( listlist[1] );
-        
-        mat := [];
-        
-        for outer_row in listlist do
-          
-          nr_inner_rows := NrRows( outer_row[1] );
-          
-          if nr_inner_rows > 0 then
-            
-            for i in [ 1 .. nr_inner_rows ] do
-                
-                new_row := Concatenation(
-                  List( [ 1 .. nr_cols_out ], c -> outer_row[c][i] )
-              );
-              
-              Add( mat, new_row );
-              
-            od;
-            
-          fi;
-            
-        od;
-        
-        return AdditiveClosureMorphism(
-          source,
-          mat,
-          range
-        );
         
     end );
     

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -4,12 +4,6 @@
 # Implementations
 #
 
-## Specification of data structure of morphisms:
-## there are two valid lists that can represent a morphism:
-## 1) an m x n matrix of morphisms with m,n >=1
-## 2) the empty list [], which represents the zero morphism
-## In particular, [ [ ] ] or [ [], [] ] is not allowed
-
 ####################################
 ##
 ## Constructors
@@ -780,12 +774,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                             )
                         )
                     );
-        
-        if not IsEmpty( listlist ) and IsEmpty( listlist[1] ) then
-            
-            listlist := [];
-            
-        fi;
         
         return AdditiveClosureMorphism( test_object,
                                         listlist,


### PR DESCRIPTION
I finally took some time to split up #547 (to get rid of too many branches to rebase :D ). I have decided to not only split it into commits but even into two separate PRs, so this PR serves as a preparation for #547.

This PR makes `AdditiveClosure` not depend on lists (of lists) as the underlying data structure of morphisms anymore (with regard to the original input of the user, results of operations are still stored as lists of list). So theoretically, after this PR one can use any data structure having the operation `[,]`. However, one can still not use homalg matrices for example, since their entries are not CAP morphisms. This will be tackled in #547.

See commit messages for details.