### PR TITLE
Avoid "method installed for /" ... in QuiverRows

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -13,7 +13,7 @@ Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
 Version := Maximum( [
   "2019.03.04", ## Martin's version
   ## this line prevents merge conflicts
-  "2020.09.17", ## Sepp's version
+  "2020.09.21", ## Sepp's version
   ## this line prevents merge conflicts
   "2020.05.17", ## Mohamed's version
   ## this line prevents merge conflicts

--- a/FreydCategoriesForCAP/gap/QuiverRows.gd
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gd
@@ -53,9 +53,6 @@ DeclareOperation( "AsQuiverRowsMorphism",
                   [ IsQuiverAlgebraElement, IsQuiverRowsCategory ] );
 
 DeclareOperation( "\/",
-                  [ IsQuiverVertex, IsQuiverRowsCategory ] );
-
-DeclareOperation( "\/",
                   [ IsQuiverAlgebraElement, IsQuiverRowsCategory ] );
 
 DeclareOperation( "\/",

--- a/FreydCategoriesForCAP/tst/000_LoadPackage.tst
+++ b/FreydCategoriesForCAP/tst/000_LoadPackage.tst
@@ -6,7 +6,6 @@
 gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
 gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for / matches more than one declaration
 #I  method installed for IsInjective matches more than one declaration
 true
 gap> LoadPackage( "IO_ForHomalg", false );


### PR DESCRIPTION
`IsQuiverVertex` appears to be a specialization of `IsPath`, which is the reason for the info message while loading the Freyd package.

@mohamed-barakat  if you are okay with this solution, we may discard #579