### PR TITLE
Fix func being an operation in CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION

### DIFF
--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -574,15 +574,23 @@ InstallGlobalFunction( "CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION",
   function( func, symbol_list, loop_multiple, replacement_record )
     local func_as_string, func_stream, i, func_as_list, loop_power, symbol_appearance_rec, current_symbol;
     
-    func_as_string := "";
-    
-    func_stream := OutputTextString( func_as_string, false );
-    
-    SetPrintFormattingStatus( func_stream, false );
-    
-    PrintTo( func_stream, func );
-    
-    CloseStream( func_stream );
+    if IsOperation( func ) then
+        
+        func_as_string := NameFunction( func );
+        
+    else
+        
+        func_as_string := "";
+        
+        func_stream := OutputTextString( func_as_string, false );
+        
+        SetPrintFormattingStatus( func_stream, false );
+        
+        PrintTo( func_stream, func );
+        
+        CloseStream( func_stream );
+        
+    fi;
     
     ## Make List, Perform, Apply look like loops
     ## Beginning space is important here, to avoid scanning things like CallFuncList


### PR DESCRIPTION
If func is an operation MyOperation, previously "MyOperation" was not detected as a symbol.

Thus, for example the following final derivation
```
AddFinalDerivation( IsEqualForMorphisms,
                    [ [ IsCongruentForMorphisms, 1 ] ],
                    [ IsEqualForMorphisms ],
                    
  IsCongruentForMorphisms : Description := "Use IsCongruentForMorphisms for IsEqualForMorphisms" );
```
was installed with weight 1 instead of the weight of `IsCongruentForMorphisms` + 1.

Notes:
1. This is NOT related to #588.
2. I have not tested this extensively. The worst-case scenario should be that results change in some packages due to other derivations being triggered.
3. The proper way to do this in recent GAP version would probably be making use of syntax trees.