### PR TITLE
Apply PackageJanitor

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -33,14 +33,40 @@ jobs:
           # set SOURCE_DATE_EPOCH for reproducible PDFs
           export SOURCE_DATE_EPOCH=0
           TERM=dumb make -C CAP_project -j $(nproc) --output-sync ci-test
+          cp ./CAP_project/.codecov.yml ./
           curl -s https://codecov.io/bash | bash
           cd CAP_project
           CUR_SHA=$(git rev-parse --verify HEAD)
-          git worktree add branch_doc/ doc || (echo "There was an error. Make sure there is a branch named 'doc'."; exit 1)
+          git worktree add branch_doc/ doc || (echo "There was an error. Make sure there is a branch named 'doc'. See https://github.com/homalg-project/PackageJanitor#error-there-was-an-error-make-sure-there-is-a-branch-named-doc"; exit 1)
+          cp ActionsForCAP/doc/manual.pdf branch_doc/ActionsForCAP.pdf
+          cd branch_doc
+          git add ActionsForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add ActionsForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp AttributeCategoryForCAP/doc/manual.pdf branch_doc/AttributeCategoryForCAP.pdf
+          cd branch_doc
+          git add AttributeCategoryForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add AttributeCategoryForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
           cp CompilerForCAP/doc/manual.pdf branch_doc/CompilerForCAP.pdf
           cd branch_doc
           git add CompilerForCAP.pdf
           git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add CompilerForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp ComplexesAndFilteredObjectsForCAP/doc/manual.pdf branch_doc/ComplexesAndFilteredObjectsForCAP.pdf
+          cd branch_doc
+          git add ComplexesAndFilteredObjectsForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add ComplexesAndFilteredObjectsForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp DeductiveSystemForCAP/doc/manual.pdf branch_doc/DeductiveSystemForCAP.pdf
+          cd branch_doc
+          git add DeductiveSystemForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add DeductiveSystemForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp FreydCategoriesForCAP/doc/manual.pdf branch_doc/FreydCategoriesForCAP.pdf
+          cd branch_doc
+          git add FreydCategoriesForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add FreydCategoriesForCAP.pdf for $CUR_SHA" --allow-empty
           cd ..
           cp GradedModulePresentationsForCAP/doc/manual.pdf branch_doc/GradedModulePresentationsForCAP.pdf
           cd branch_doc
@@ -52,15 +78,25 @@ jobs:
           git add GroupRepresentationsForCAP.pdf
           git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add GroupRepresentationsForCAP.pdf for $CUR_SHA" --allow-empty
           cd ..
+          cp HomologicalAlgebraForCAP/doc/manual.pdf branch_doc/HomologicalAlgebraForCAP.pdf
+          cd branch_doc
+          git add HomologicalAlgebraForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add HomologicalAlgebraForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
           cp InternalExteriorAlgebraForCAP/doc/manual.pdf branch_doc/InternalExteriorAlgebraForCAP.pdf
           cd branch_doc
           git add InternalExteriorAlgebraForCAP.pdf
           git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add InternalExteriorAlgebraForCAP.pdf for $CUR_SHA" --allow-empty
           cd ..
-          cp FreydCategoriesForCAP/doc/manual.pdf branch_doc/FreydCategoriesForCAP.pdf
+          cp ModulesOverLocalRingsForCAP/doc/manual.pdf branch_doc/ModulesOverLocalRingsForCAP.pdf
           cd branch_doc
-          git add FreydCategoriesForCAP.pdf
-          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add FreydCategoriesForCAP.pdf for $CUR_SHA" --allow-empty
+          git add ModulesOverLocalRingsForCAP.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add ModulesOverLocalRingsForCAP.pdf for $CUR_SHA" --allow-empty
+          cd ..
+          cp ToricSheaves/doc/manual.pdf branch_doc/ToricSheaves.pdf
+          cd branch_doc
+          git add ToricSheaves.pdf
+          git -c user.name='Doc Bot' -c user.email='empty' commit -m "Add ToricSheaves.pdf for $CUR_SHA" --allow-empty
           cd ..
           # push iff using gap-stable and if on master branch
           if [ "${{ matrix.image }}" = "gapsystem/gap-docker" ] && [ "$CUR_SHA" = "$(git rev-parse origin/master)" ]; then \

--- a/ActionsForCAP/README
+++ b/ActionsForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `ActionsForCAP'
-==============================
-

--- a/ActionsForCAP/README.md
+++ b/ActionsForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# ActionsForCAP – Actions and Coactions for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/ActionsForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/AttributeCategoryForCAP/README.md
+++ b/AttributeCategoryForCAP/README.md
@@ -1,3 +1,18 @@
-The GAP 4 package `AttributeCategoryForCAP'
-==============================
+<!-- BEGIN HEADER -->
+# AttributeCategoryForCAP – Automatic enhancement with attributes of a CAP category
 
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/AttributeCategoryForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/CAP/LICENSE
+++ b/CAP/LICENSE
@@ -1,24 +1,12 @@
-CAP is free software; you can redistribute and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your opinion) any later version.
-
-CAP is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-General Public License for more details.
-
-Version 2 of the GNU General Public License follows.
-
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -68,8 +56,7 @@ patent must be licensed for everyone's free use or not licensed at all.
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-
-		    GNU GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -123,7 +110,6 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
 
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
@@ -183,7 +169,6 @@ access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
 
-
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -241,7 +226,6 @@ impose that choice.
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
 
-
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -271,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -293,5 +277,63 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # This file contains package meta data. For additional information on

--- a/CAP/README.md
+++ b/CAP/README.md
@@ -1,9 +1,10 @@
 <!-- BEGIN HEADER -->
 # CAP – Categories, Algorithms, Programming
 
-| **Documentation**         | **Build Status of [CAP_project](/../../)**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 This is the central package of the CAP project.
@@ -11,11 +12,11 @@ This is the central package of the CAP project.
 Its website is located [here](http://homalg-project.github.io/CAP_project/CAP).
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/docs-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0.html
+[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/CategoriesCategory.gd
+++ b/CAP/gap/CategoriesCategory.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/CategoryTwoCells.gd
+++ b/CAP/gap/CategoryTwoCells.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/CategoryTwoCells.gi
+++ b/CAP/gap/CategoryTwoCells.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/ConstructiveCategoriesRecord.gd
+++ b/CAP/gap/ConstructiveCategoriesRecord.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/ConstructiveCategoriesRecord.gi
+++ b/CAP/gap/ConstructiveCategoriesRecord.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/Derivations.gd
+++ b/CAP/gap/Derivations.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/Finalize.gd
+++ b/CAP/gap/Finalize.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/InstallAdds.gd
+++ b/CAP/gap/InstallAdds.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/LimitConvenience.gd
+++ b/CAP/gap/LimitConvenience.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/LimitConvenience.gi
+++ b/CAP/gap/LimitConvenience.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/LogicForCAP.gd
+++ b/CAP/gap/LogicForCAP.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/LogicForCAP.gi
+++ b/CAP/gap/LogicForCAP.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/MethodRecord.gd
+++ b/CAP/gap/MethodRecord.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/OppositeCategory.gd
+++ b/CAP/gap/OppositeCategory.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/PreFunctions.gi
+++ b/CAP/gap/PreFunctions.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/PrepareFunctions.gd
+++ b/CAP/gap/PrepareFunctions.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/PrepareFunctions.gi
+++ b/CAP/gap/PrepareFunctions.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/PrintingFunctions.gd
+++ b/CAP/gap/PrintingFunctions.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/ProductCategory.gd
+++ b/CAP/gap/ProductCategory.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/TerminalCategory.gd
+++ b/CAP/gap/TerminalCategory.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/TheoremParser.gd
+++ b/CAP/gap/TheoremParser.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/TheoremParser.gi
+++ b/CAP/gap/TheoremParser.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Declarations

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Implementations

--- a/CAP/init.g
+++ b/CAP/init.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Reading the declaration part of the package.

--- a/CAP/makedoc.g
+++ b/CAP/makedoc.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # This file is a script which compiles the package manual.

--- a/CAP/makedoc_with_overfull_hbox_warnings.g
+++ b/CAP/makedoc_with_overfull_hbox_warnings.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # This file is a script which compiles the package manual and prints overfull hbox warnings.

--- a/CAP/read.g
+++ b/CAP/read.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # Reading the implementation part of the package.

--- a/CAP/tst/000_LoadPackage.tst
+++ b/CAP/tst/000_LoadPackage.tst
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # This file tests if the package can be loaded without errors or warnings.

--- a/CAP/tst/testall.g
+++ b/CAP/tst/testall.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CAP: Categories, Algorithms, Programming
 #
 # This file runs package tests. It is also referenced in the package

--- a/CompilerForCAP/LICENSE
+++ b/CompilerForCAP/LICENSE
@@ -1,24 +1,12 @@
-CompilerForCAP is free software; you can redistribute and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your opinion) any later version.
-
-CompilerForCAP is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-General Public License for more details.
-
-Version 2 of the GNU General Public License follows.
-
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -68,8 +56,7 @@ patent must be licensed for everyone's free use or not licensed at all.
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-
-		    GNU GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -123,7 +110,6 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
 
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
@@ -183,7 +169,6 @@ access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
 
-
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -241,7 +226,6 @@ impose that choice.
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
 
-
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -271,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -293,5 +277,63 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # This file contains package meta data. For additional information on

--- a/CompilerForCAP/README.md
+++ b/CompilerForCAP/README.md
@@ -1,9 +1,10 @@
 <!-- BEGIN HEADER -->
 # CompilerForCAP – Speed up computations in CAP categories
 
-| **Documentation**         | **Build Status of [CAP_project](/../../)**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 **WARNING**: This package is still in alpha and not tested or validated extensively!
@@ -44,8 +45,8 @@ Thus, there is no penalty in writing high-level code: Using `CompilerForCAP`, an
 [docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
 [docs-url]: /../../raw/doc/CompilerForCAP.pdf
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/CompilerForCAP/gap/CompilerForCAP.gd
+++ b/CompilerForCAP/gap/CompilerForCAP.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/DropHandledEdgeCases.gd
+++ b/CompilerForCAP/gap/DropHandledEdgeCases.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/DropHandledEdgeCases.gi
+++ b/CompilerForCAP/gap/DropHandledEdgeCases.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/DropUnusedVariables.gd
+++ b/CompilerForCAP/gap/DropUnusedVariables.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/DropUnusedVariables.gi
+++ b/CompilerForCAP/gap/DropUnusedVariables.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gd
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/GetValuesFromJitArgs.gd
+++ b/CompilerForCAP/gap/GetValuesFromJitArgs.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/GetValuesFromJitArgs.gi
+++ b/CompilerForCAP/gap/GetValuesFromJitArgs.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/InlineArguments.gd
+++ b/CompilerForCAP/gap/InlineArguments.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/InlineArguments.gi
+++ b/CompilerForCAP/gap/InlineArguments.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/InlineFunctionCalls.gd
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/InlineFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/InlineSimpleFunctionCalls.gd
+++ b/CompilerForCAP/gap/InlineSimpleFunctionCalls.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/InlineVariableAssignments.gd
+++ b/CompilerForCAP/gap/InlineVariableAssignments.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/InlineVariableAssignments.gi
+++ b/CompilerForCAP/gap/InlineVariableAssignments.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/IterateOverTree.gd
+++ b/CompilerForCAP/gap/IterateOverTree.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/IterateOverTree.gi
+++ b/CompilerForCAP/gap/IterateOverTree.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/Logic.gd
+++ b/CompilerForCAP/gap/Logic.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/LogicTemplates.gd
+++ b/CompilerForCAP/gap/LogicTemplates.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/PrettyPrintSyntaxTree.gd
+++ b/CompilerForCAP/gap/PrettyPrintSyntaxTree.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/PrettyPrintSyntaxTree.gi
+++ b/CompilerForCAP/gap/PrettyPrintSyntaxTree.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gd
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/ResolveOperations.gd
+++ b/CompilerForCAP/gap/ResolveOperations.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/gap/Tools.gd
+++ b/CompilerForCAP/gap/Tools.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Declarations

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Implementations

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Reading the declaration part of the package.

--- a/CompilerForCAP/makedoc.g
+++ b/CompilerForCAP/makedoc.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # This file is a script which compiles the package manual.

--- a/CompilerForCAP/makedoc_with_overfull_hbox_warnings.g
+++ b/CompilerForCAP/makedoc_with_overfull_hbox_warnings.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # This file is a script which compiles the package manual and prints overfull hbox warnings.

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # Reading the implementation part of the package.

--- a/CompilerForCAP/tst/000_LoadPackage.tst
+++ b/CompilerForCAP/tst/000_LoadPackage.tst
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # This file tests if the package can be loaded without errors or warnings.

--- a/CompilerForCAP/tst/testall.g
+++ b/CompilerForCAP/tst/testall.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # CompilerForCAP: Speed up computations in CAP categories
 #
 # This file runs package tests. It is also referenced in the package

--- a/ComplexesAndFilteredObjectsForCAP/README
+++ b/ComplexesAndFilteredObjectsForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `ComplexesAndFilteredObjectsForCAP'
-==============================
-

--- a/ComplexesAndFilteredObjectsForCAP/README.md
+++ b/ComplexesAndFilteredObjectsForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# ComplexesAndFilteredObjectsForCAP – Implementation of complexes, cocomplexes and filtered objects for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/ComplexesAndFilteredObjectsForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/ComplexesAndFilteredObjectsForCAP/makefile
+++ b/ComplexesAndFilteredObjectsForCAP/makefile
@@ -1,0 +1,6 @@
+doc: doc/manual.six
+
+doc/manual.six: makedoc.g \
+		PackageInfo.g \
+		$(wildcard doc/*.autodoc gap/*.gd gap/*.gi examples/*.g examples/*/*.g)
+			gap makedoc.g

--- a/DeductiveSystemForCAP/README
+++ b/DeductiveSystemForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `DeductiveSystemForCAP'
-==============================
-

--- a/DeductiveSystemForCAP/README.md
+++ b/DeductiveSystemForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# DeductiveSystemForCAP – Deductive system for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/DeductiveSystemForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/DeductiveSystemForCAP/makedoc.g
+++ b/DeductiveSystemForCAP/makedoc.g
@@ -1,7 +1,7 @@
-#if fail = LoadPackage("AutoDoc", ">= 2014.03.27") then
-#    Error("AutoDoc version 2014.03.27 is required.");
-#fi;
-#
-#AutoDoc( "DeductiveSystemForCAP" : scaffold := true, autodoc := true );
+if fail = LoadPackage("AutoDoc", ">= 2014.03.27") then
+    Error("AutoDoc version 2014.03.27 is required.");
+fi;
+
+AutoDoc( "DeductiveSystemForCAP" : scaffold := true, autodoc := true );
 
 QUIT;

--- a/DeductiveSystemForCAP/makefile
+++ b/DeductiveSystemForCAP/makefile
@@ -1,0 +1,6 @@
+doc: doc/manual.six
+
+doc/manual.six: makedoc.g \
+		PackageInfo.g \
+		$(wildcard doc/*.autodoc gap/*.gd gap/*.gi examples/*.g examples/*/*.g)
+			gap makedoc.g

--- a/FreydCategoriesForCAP/README.md
+++ b/FreydCategoriesForCAP/README.md
@@ -1,9 +1,10 @@
 <!-- BEGIN HEADER -->
 # FreydCategoriesForCAP – Freyd categories - Formal (co)kernels for additive categories
 
-| **Documentation**         | **Build Status of [CAP_project](/../../)**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 A package for various universal constructions mostly in an Ab-enriched context.
@@ -48,8 +49,8 @@ Sebastian Posur, [*Methods of constructive category theory*](https://arxiv.org/a
 [docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
 [docs-url]: /../../raw/doc/FreydCategoriesForCAP.pdf
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/GeneralizedMorphismsForCAP/README
+++ b/GeneralizedMorphismsForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `GeneralizedMorphismsForCAP'
-==============================
-

--- a/GeneralizedMorphismsForCAP/README.md
+++ b/GeneralizedMorphismsForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# GeneralizedMorphismsForCAP – Implementations of generalized morphisms for the CAP project
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/GradedModulePresentationsForCAP/README
+++ b/GradedModulePresentationsForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `GradedModulePresentationsForCAP'
-==============================
-

--- a/GradedModulePresentationsForCAP/README.md
+++ b/GradedModulePresentationsForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# GradedModulePresentationsForCAP – Presentations for graded modules
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/GroupRepresentationsForCAP/LICENSE
+++ b/GroupRepresentationsForCAP/LICENSE
@@ -1,24 +1,12 @@
-GroupRepresentationsForCAP is free software; you can redistribute and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your opinion) any later version.
-
-GroupRepresentationsForCAP is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-General Public License for more details.
-
-Version 2 of the GNU General Public License follows.
-
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -68,8 +56,7 @@ patent must be licensed for everyone's free use or not licensed at all.
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-
-		    GNU GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -123,7 +110,6 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
 
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
@@ -183,7 +169,6 @@ access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
 
-
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -241,7 +226,6 @@ impose that choice.
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
 
-
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -271,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -293,5 +277,63 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # This file contains package meta data. For additional information on

--- a/GroupRepresentationsForCAP/README.md
+++ b/GroupRepresentationsForCAP/README.md
@@ -1,17 +1,18 @@
 <!-- BEGIN HEADER -->
 # GroupRepresentationsForCAP – Skeletal category of group representations for CAP
 
-| **Documentation**         | **Build Status of [CAP_project](/../../)**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 <!-- BEGIN FOOTER -->
 [docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
 [docs-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/GroupRepresentationsForCAP/gap/AssociatorsForRepresentationCategoryOfGroup.gd
+++ b/GroupRepresentationsForCAP/gap/AssociatorsForRepresentationCategoryOfGroup.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/AssociatorsForRepresentationCategoryOfGroup.gi
+++ b/GroupRepresentationsForCAP/gap/AssociatorsForRepresentationCategoryOfGroup.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gd
+++ b/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gi
+++ b/GroupRepresentationsForCAP/gap/GIrreducibleObjects.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gd
+++ b/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gi
+++ b/GroupRepresentationsForCAP/gap/GZGradedIrreducibleObjects.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gd
+++ b/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gi
+++ b/GroupRepresentationsForCAP/gap/RepresentationCategoryOfGroup.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategory.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategory.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryMorphisms.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategoryObjects.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/gap/Tools.gd
+++ b/GroupRepresentationsForCAP/gap/Tools.gd
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Declarations

--- a/GroupRepresentationsForCAP/gap/Tools.gi
+++ b/GroupRepresentationsForCAP/gap/Tools.gi
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Implementations

--- a/GroupRepresentationsForCAP/init.g
+++ b/GroupRepresentationsForCAP/init.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Reading the declaration part of the package.

--- a/GroupRepresentationsForCAP/makedoc.g
+++ b/GroupRepresentationsForCAP/makedoc.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # This file is a script which compiles the package manual.

--- a/GroupRepresentationsForCAP/makedoc_with_overfull_hbox_warnings.g
+++ b/GroupRepresentationsForCAP/makedoc_with_overfull_hbox_warnings.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # This file is a script which compiles the package manual and prints overfull hbox warnings.

--- a/GroupRepresentationsForCAP/read.g
+++ b/GroupRepresentationsForCAP/read.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # Reading the implementation part of the package.

--- a/GroupRepresentationsForCAP/tst/000_LoadPackage.tst
+++ b/GroupRepresentationsForCAP/tst/000_LoadPackage.tst
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # This file tests if the package can be loaded without errors or warnings.

--- a/GroupRepresentationsForCAP/tst/testall.g
+++ b/GroupRepresentationsForCAP/tst/testall.g
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # GroupRepresentationsForCAP: Skeletal category of group representations for CAP
 #
 # This file runs package tests. It is also referenced in the package

--- a/HomologicalAlgebraForCAP/README
+++ b/HomologicalAlgebraForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `HomologicalAlgebraForCAP'
-==============================
-

--- a/HomologicalAlgebraForCAP/README.md
+++ b/HomologicalAlgebraForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# HomologicalAlgebraForCAP – Homological algebra algorithms for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/HomologicalAlgebraForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/HomologicalAlgebraForCAP/makedoc.g
+++ b/HomologicalAlgebraForCAP/makedoc.g
@@ -1,7 +1,7 @@
-#if fail = LoadPackage("AutoDoc", ">= 2014.03.27") then
-#    Error("AutoDoc version 2014.03.27 is required.");
-#fi;
-#
-#AutoDoc( "HomologicalAlgebraForCAP" : scaffold := true, autodoc := true );
+if fail = LoadPackage("AutoDoc", ">= 2014.03.27") then
+    Error("AutoDoc version 2014.03.27 is required.");
+fi;
+
+AutoDoc( "HomologicalAlgebraForCAP" : scaffold := true, autodoc := true );
 
 QUIT;

--- a/HomologicalAlgebraForCAP/makefile
+++ b/HomologicalAlgebraForCAP/makefile
@@ -1,0 +1,6 @@
+doc: doc/manual.six
+
+doc/manual.six: makedoc.g \
+		PackageInfo.g \
+		$(wildcard doc/*.autodoc gap/*.gd gap/*.gi examples/*.g examples/*/*.g)
+			gap makedoc.g

--- a/InternalExteriorAlgebraForCAP/README.md
+++ b/InternalExteriorAlgebraForCAP/README.md
@@ -1,3 +1,18 @@
-The GAP 4 package `InternalExteriorAlgebraForCAP'
-==============================
+<!-- BEGIN HEADER -->
+# InternalExteriorAlgebraForCAP – Constructions for Modules over the Internal Exterior Algebra for CAP
 
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/LinearAlgebraForCAP/README
+++ b/LinearAlgebraForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `LinearAlgebraForCAP'
-==============================
-

--- a/LinearAlgebraForCAP/README.md
+++ b/LinearAlgebraForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# LinearAlgebraForCAP – Category of Matrices over a Field for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/ModulePresentationsForCAP/README
+++ b/ModulePresentationsForCAP/README
@@ -1,3 +1,0 @@
-The GAP 4 package `ModulePresentationsForCAP'
-==============================
-

--- a/ModulePresentationsForCAP/README.md
+++ b/ModulePresentationsForCAP/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# ModulePresentationsForCAP – Category R-pres for CAP
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/ModulesOverLocalRingsForCAP/README.md
+++ b/ModulesOverLocalRingsForCAP/README.md
@@ -1,3 +1,18 @@
-The GAP 4 package `ModulesOverLocalRingsForCAP'
-==============================
+<!-- BEGIN HEADER -->
+# ModulesOverLocalRingsForCAP – Category of modules over a local ring modeled by Serre quotients for CAP
 
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/ModulesOverLocalRingsForCAP.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/MonoidalCategories/README.md
+++ b/MonoidalCategories/README.md
@@ -1,17 +1,18 @@
 <!-- BEGIN HEADER -->
 # MonoidalCategories – Monoidal and monoidal (co)closed categories
 
-| **Documentation**         | **Build Status of [CAP_project](/../../)**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/docs-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0.html
+[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <!-- BEGIN HEADER -->
 # CAP project – Categories, Algorithms, and Programming
 
-| **Documentation**         | **Build Status**                                            |
-|:-------------------------:|:-----------------------------------------------------------:|
-| [![][docs-CAP-img]][docs-CAP-url]<br> [![][docs-CompilerForCAP-img]][docs-CompilerForCAP-url]<br> [![][docs-ModulePresentationsForCAP-img]][docs-ModulePresentationsForCAP-url]<br> [![][docs-GradedModulePresentationsForCAP-img]][docs-GradedModulePresentationsForCAP-url]<br> [![][docs-LinearAlgebraForCAP-img]][docs-LinearAlgebraForCAP-url]<br> [![][docs-GeneralizedMorphismsForCAP-img]][docs-GeneralizedMorphismsForCAP-url]<br> [![][docs-GroupRepresentationsForCAP-img]][docs-GroupRepresentationsForCAP-url]<br> [![][docs-InternalExteriorAlgebraForCAP-img]][docs-InternalExteriorAlgebraForCAP-url]<br> [![][docs-MonoidalCategories-img]][docs-MonoidalCategories-url]<br> [![][docs-FreydCategoriesForCAP-img]][docs-FreydCategoriesForCAP-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
+| Build Status | Code Coverage |
+| ------------ | ------------- |
+| [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
 <!-- END HEADER -->
 
 Welcome to the CAP project.
@@ -16,38 +17,80 @@ Please take a look at our [manual](https://github.com/homalg-project/CAP_project
 
 Please visit our website: http://homalg-project.github.io/CAP_project/
 <!-- BEGIN FOOTER -->
-[docs-CAP-img]: https://img.shields.io/badge/CAP-HTML-blue.svg
+## Packages of [CAP_project](/../../):
+| Name | Description | Documentation |
+| ---- | ----------- | ------------- |
+| [CAP](CAP) | Categories, Algorithms, Programming | [![HTML stable documentation][docs-CAP-img]][docs-CAP-url] |
+| [ActionsForCAP](ActionsForCAP) | Actions and Coactions for CAP | [![PDF development documentation][docs-ActionsForCAP-img]][docs-ActionsForCAP-url] |
+| [AttributeCategoryForCAP](AttributeCategoryForCAP) | Automatic enhancement with attributes of a CAP category | [![PDF development documentation][docs-AttributeCategoryForCAP-img]][docs-AttributeCategoryForCAP-url] |
+| [CompilerForCAP](CompilerForCAP) | Speed up computations in CAP categories | [![PDF development documentation][docs-CompilerForCAP-img]][docs-CompilerForCAP-url] |
+| [ComplexesAndFilteredObjectsForCAP](ComplexesAndFilteredObjectsForCAP) | Implementation of complexes, cocomplexes and filtered objects for CAP | [![PDF development documentation][docs-ComplexesAndFilteredObjectsForCAP-img]][docs-ComplexesAndFilteredObjectsForCAP-url] |
+| [DeductiveSystemForCAP](DeductiveSystemForCAP) | Deductive system for CAP | [![PDF development documentation][docs-DeductiveSystemForCAP-img]][docs-DeductiveSystemForCAP-url] |
+| [FreydCategoriesForCAP](FreydCategoriesForCAP) | Freyd categories - Formal (co)kernels for additive categories | [![PDF development documentation][docs-FreydCategoriesForCAP-img]][docs-FreydCategoriesForCAP-url] |
+| [GeneralizedMorphismsForCAP](GeneralizedMorphismsForCAP) | Implementations of generalized morphisms for the CAP project | [![HTML stable documentation][docs-GeneralizedMorphismsForCAP-img]][docs-GeneralizedMorphismsForCAP-url] |
+| [GradedModulePresentationsForCAP](GradedModulePresentationsForCAP) | Presentations for graded modules | [![PDF development documentation][docs-GradedModulePresentationsForCAP-img]][docs-GradedModulePresentationsForCAP-url] |
+| [GroupRepresentationsForCAP](GroupRepresentationsForCAP) | Skeletal category of group representations for CAP | [![PDF development documentation][docs-GroupRepresentationsForCAP-img]][docs-GroupRepresentationsForCAP-url] |
+| [HomologicalAlgebraForCAP](HomologicalAlgebraForCAP) | Homological algebra algorithms for CAP | [![PDF development documentation][docs-HomologicalAlgebraForCAP-img]][docs-HomologicalAlgebraForCAP-url] |
+| [InternalExteriorAlgebraForCAP](InternalExteriorAlgebraForCAP) | Constructions for Modules over the Internal Exterior Algebra for CAP | [![PDF development documentation][docs-InternalExteriorAlgebraForCAP-img]][docs-InternalExteriorAlgebraForCAP-url] |
+| [LinearAlgebraForCAP](LinearAlgebraForCAP) | Category of Matrices over a Field for CAP | [![HTML stable documentation][docs-LinearAlgebraForCAP-img]][docs-LinearAlgebraForCAP-url] |
+| [ModulePresentationsForCAP](ModulePresentationsForCAP) | Category R-pres for CAP | [![HTML stable documentation][docs-ModulePresentationsForCAP-img]][docs-ModulePresentationsForCAP-url] |
+| [ModulesOverLocalRingsForCAP](ModulesOverLocalRingsForCAP) | Category of modules over a local ring modeled by Serre quotients for CAP | [![PDF development documentation][docs-ModulesOverLocalRingsForCAP-img]][docs-ModulesOverLocalRingsForCAP-url] |
+| [MonoidalCategories](MonoidalCategories) | Monoidal and monoidal (co)closed categories | [![HTML stable documentation][docs-MonoidalCategories-img]][docs-MonoidalCategories-url] |
+| [ToricSheaves](ToricSheaves) | Toric sheaves as Serre quotients | [![PDF development documentation][docs-ToricSheaves-img]][docs-ToricSheaves-url] |
+
+[docs-CAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
 [docs-CAP-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
 
-[docs-CompilerForCAP-img]: https://img.shields.io/badge/CompilerForCAP-PDF-blue.svg
+[docs-ActionsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-ActionsForCAP-url]: /../../raw/doc/ActionsForCAP.pdf
+
+[docs-AttributeCategoryForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-AttributeCategoryForCAP-url]: /../../raw/doc/AttributeCategoryForCAP.pdf
+
+[docs-CompilerForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
 [docs-CompilerForCAP-url]: /../../raw/doc/CompilerForCAP.pdf
 
-[docs-ModulePresentationsForCAP-img]: https://img.shields.io/badge/ModulePresentationsForCAP-HTML-blue.svg
-[docs-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+[docs-ComplexesAndFilteredObjectsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-ComplexesAndFilteredObjectsForCAP-url]: /../../raw/doc/ComplexesAndFilteredObjectsForCAP.pdf
 
-[docs-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/GradedModulePresentationsForCAP-PDF-blue.svg
-[docs-GradedModulePresentationsForCAP-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
+[docs-DeductiveSystemForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-DeductiveSystemForCAP-url]: /../../raw/doc/DeductiveSystemForCAP.pdf
 
-[docs-LinearAlgebraForCAP-img]: https://img.shields.io/badge/LinearAlgebraForCAP-HTML-blue.svg
-[docs-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
-
-[docs-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/GeneralizedMorphismsForCAP-HTML-blue.svg
-[docs-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
-
-[docs-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/GroupRepresentationsForCAP-PDF-blue.svg
-[docs-GroupRepresentationsForCAP-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
-
-[docs-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/InternalExteriorAlgebraForCAP-PDF-blue.svg
-[docs-InternalExteriorAlgebraForCAP-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
-
-[docs-MonoidalCategories-img]: https://img.shields.io/badge/MonoidalCategories-HTML-blue.svg
-[docs-MonoidalCategories-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
-
-[docs-FreydCategoriesForCAP-img]: https://img.shields.io/badge/FreydCategoriesForCAP-PDF-blue.svg
+[docs-FreydCategoriesForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
 [docs-FreydCategoriesForCAP-url]: /../../raw/doc/FreydCategoriesForCAP.pdf
 
-[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg
-[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests
+[docs-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+
+[docs-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-GradedModulePresentationsForCAP-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
+
+[docs-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-GroupRepresentationsForCAP-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
+
+[docs-HomologicalAlgebraForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-HomologicalAlgebraForCAP-url]: /../../raw/doc/HomologicalAlgebraForCAP.pdf
+
+[docs-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-InternalExteriorAlgebraForCAP-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
+
+[docs-LinearAlgebraForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+
+[docs-ModulePresentationsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+
+[docs-ModulesOverLocalRingsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-ModulesOverLocalRingsForCAP-url]: /../../raw/doc/ModulesOverLocalRingsForCAP.pdf
+
+[docs-MonoidalCategories-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[docs-MonoidalCategories-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
+
+[docs-ToricSheaves-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-ToricSheaves-url]: /../../raw/doc/ToricSheaves.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
 [codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/homalg-project/CAP_project

--- a/ToricSheaves/README.md
+++ b/ToricSheaves/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN HEADER -->
+# ToricSheaves – Toric sheaves as Serre quotients
+
+| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | ------------ | ------------- |
+| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+
+<!-- END HEADER -->
+<!-- BEGIN FOOTER -->
+[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
+[docs-url]: /../../raw/doc/ToricSheaves.pdf
+
+[tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
+[tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
+
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+<!-- END FOOTER -->

--- a/ToricSheaves/makefile
+++ b/ToricSheaves/makefile
@@ -1,0 +1,6 @@
+doc: doc/manual.six
+
+doc/manual.six: makedoc.g \
+		PackageInfo.g \
+		$(wildcard doc/*.autodoc gap/*.gd gap/*.gi examples/*.g examples/*/*.g)
+			gap makedoc.g

--- a/makefile
+++ b/makefile
@@ -32,31 +32,61 @@ InternalExteriorAlgebra_test:
 CompilerForCAP_test:
 	cd CompilerForCAP && make test
 
-doc: CAP_doc Modules_doc GradedModules_doc Linear_doc Generalized_doc GroupRepresentations_doc InternalExteriorAlgebra_doc CompilerForCAP_doc
+# BEGIN PACKAGE JANITOR
+doc: doc_CAP doc_ActionsForCAP doc_AttributeCategoryForCAP doc_CompilerForCAP doc_ComplexesAndFilteredObjectsForCAP doc_DeductiveSystemForCAP doc_FreydCategoriesForCAP doc_GeneralizedMorphismsForCAP doc_GradedModulePresentationsForCAP doc_GroupRepresentationsForCAP doc_HomologicalAlgebraForCAP doc_InternalExteriorAlgebraForCAP doc_LinearAlgebraForCAP doc_ModulePresentationsForCAP doc_ModulesOverLocalRingsForCAP doc_MonoidalCategories doc_ToricSheaves
 
-CAP_doc:
-	cd CAP && make doc
+doc_CAP:
+	$(MAKE) -C CAP doc
 
-Modules_doc:
-	cd ModulePresentationsForCAP && make doc
+doc_ActionsForCAP:
+	$(MAKE) -C ActionsForCAP doc
 
-GradedModules_doc:
-	cd GradedModulePresentationsForCAP && make doc
+doc_AttributeCategoryForCAP:
+	$(MAKE) -C AttributeCategoryForCAP doc
 
-Linear_doc:
-	cd LinearAlgebraForCAP && make doc
+doc_CompilerForCAP:
+	$(MAKE) -C CompilerForCAP doc
 
-Generalized_doc:
-	cd GeneralizedMorphismsForCAP && make doc
+doc_ComplexesAndFilteredObjectsForCAP:
+	$(MAKE) -C ComplexesAndFilteredObjectsForCAP doc
 
-GroupRepresentations_doc:
-	cd GroupRepresentationsForCAP && make doc
+doc_DeductiveSystemForCAP:
+	$(MAKE) -C DeductiveSystemForCAP doc
 
-InternalExteriorAlgebra_doc:
-	cd InternalExteriorAlgebraForCAP && make doc
+doc_FreydCategoriesForCAP:
+	$(MAKE) -C FreydCategoriesForCAP doc
 
-CompilerForCAP_doc:
-	cd CompilerForCAP && make doc
+doc_GeneralizedMorphismsForCAP:
+	$(MAKE) -C GeneralizedMorphismsForCAP doc
+
+doc_GradedModulePresentationsForCAP:
+	$(MAKE) -C GradedModulePresentationsForCAP doc
+
+doc_GroupRepresentationsForCAP:
+	$(MAKE) -C GroupRepresentationsForCAP doc
+
+doc_HomologicalAlgebraForCAP:
+	$(MAKE) -C HomologicalAlgebraForCAP doc
+
+doc_InternalExteriorAlgebraForCAP:
+	$(MAKE) -C InternalExteriorAlgebraForCAP doc
+
+doc_LinearAlgebraForCAP:
+	$(MAKE) -C LinearAlgebraForCAP doc
+
+doc_ModulePresentationsForCAP:
+	$(MAKE) -C ModulePresentationsForCAP doc
+
+doc_ModulesOverLocalRingsForCAP:
+	$(MAKE) -C ModulesOverLocalRingsForCAP doc
+
+doc_MonoidalCategories:
+	$(MAKE) -C MonoidalCategories doc
+
+doc_ToricSheaves:
+	$(MAKE) -C ToricSheaves doc
+
+# END PACKAGE JANITOR
 
 ci-test: homalg_compatibility doc
 	cd CAP && make ci-test


### PR DESCRIPTION
Notable changes:
1. All packages have READMEs now, and generate a PDF documentation (if no HTML documentation is available).
2. Use official version of GPL2, add license identifiers to headers.
3. Updated table of packages, see https://github.com/zickgraf/CAP_project/tree/PackageJanitor#readme