### PR TITLE
Apply PackageJanitor and add index files

### DIFF
--- a/ActionsForCAP/badge_date.json
+++ b/ActionsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.ActionsForCAP.date }}",
+  "color": "orange"
+}

--- a/ActionsForCAP/badge_version.json
+++ b/ActionsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.ActionsForCAP.version }}",
+  "color": "orange"
+}

--- a/ActionsForCAP/download_pdf.html
+++ b/ActionsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.ActionsForCAP.pdf }}">
+  <script>location="{{ site.data.ActionsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.ActionsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.ActionsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/ActionsForCAP/index.md
+++ b/ActionsForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: ActionsForCAP
+layout: package
+---

--- a/ActionsForCAP/view_release.html
+++ b/ActionsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/ActionsForCAP-{{ site.data.ActionsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/ActionsForCAP-{{ site.data.ActionsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/ActionsForCAP-{{ site.data.ActionsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/ActionsForCAP-{{ site.data.ActionsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/AttributeCategoryForCAP/badge_date.json
+++ b/AttributeCategoryForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.AttributeCategoryForCAP.date }}",
+  "color": "orange"
+}

--- a/AttributeCategoryForCAP/badge_version.json
+++ b/AttributeCategoryForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.AttributeCategoryForCAP.version }}",
+  "color": "orange"
+}

--- a/AttributeCategoryForCAP/download_pdf.html
+++ b/AttributeCategoryForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.AttributeCategoryForCAP.pdf }}">
+  <script>location="{{ site.data.AttributeCategoryForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.AttributeCategoryForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.AttributeCategoryForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/AttributeCategoryForCAP/index.md
+++ b/AttributeCategoryForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: AttributeCategoryForCAP
+layout: package
+---

--- a/AttributeCategoryForCAP/view_release.html
+++ b/AttributeCategoryForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/AttributeCategoryForCAP-{{ site.data.AttributeCategoryForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/AttributeCategoryForCAP-{{ site.data.AttributeCategoryForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/AttributeCategoryForCAP-{{ site.data.AttributeCategoryForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/AttributeCategoryForCAP-{{ site.data.AttributeCategoryForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/CAP/badge_date.json
+++ b/CAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.CAP.date }}",
+  "color": "orange"
+}

--- a/CAP/badge_version.json
+++ b/CAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.CAP.version }}",
+  "color": "orange"
+}

--- a/CAP/download_pdf.html
+++ b/CAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.CAP.pdf }}">
+  <script>location="{{ site.data.CAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.CAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.CAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/CAP/view_release.html
+++ b/CAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/CAP-{{ site.data.CAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/CAP-{{ site.data.CAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/CAP-{{ site.data.CAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/CAP-{{ site.data.CAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/CompilerForCAP/badge_date.json
+++ b/CompilerForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.CompilerForCAP.date }}",
+  "color": "orange"
+}

--- a/CompilerForCAP/badge_version.json
+++ b/CompilerForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.CompilerForCAP.version }}",
+  "color": "orange"
+}

--- a/CompilerForCAP/download_pdf.html
+++ b/CompilerForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.CompilerForCAP.pdf }}">
+  <script>location="{{ site.data.CompilerForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.CompilerForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.CompilerForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/CompilerForCAP/index.md
+++ b/CompilerForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: CompilerForCAP
+layout: package
+---

--- a/CompilerForCAP/view_release.html
+++ b/CompilerForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/CompilerForCAP-{{ site.data.CompilerForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/CompilerForCAP-{{ site.data.CompilerForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/CompilerForCAP-{{ site.data.CompilerForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/CompilerForCAP-{{ site.data.CompilerForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/ComplexesAndFilteredObjectsForCAP/badge_date.json
+++ b/ComplexesAndFilteredObjectsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.ComplexesAndFilteredObjectsForCAP.date }}",
+  "color": "orange"
+}

--- a/ComplexesAndFilteredObjectsForCAP/badge_version.json
+++ b/ComplexesAndFilteredObjectsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.ComplexesAndFilteredObjectsForCAP.version }}",
+  "color": "orange"
+}

--- a/ComplexesAndFilteredObjectsForCAP/download_pdf.html
+++ b/ComplexesAndFilteredObjectsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.ComplexesAndFilteredObjectsForCAP.pdf }}">
+  <script>location="{{ site.data.ComplexesAndFilteredObjectsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.ComplexesAndFilteredObjectsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.ComplexesAndFilteredObjectsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/ComplexesAndFilteredObjectsForCAP/index.md
+++ b/ComplexesAndFilteredObjectsForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: ComplexesAndFilteredObjectsForCAP
+layout: package
+---

--- a/ComplexesAndFilteredObjectsForCAP/view_release.html
+++ b/ComplexesAndFilteredObjectsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/ComplexesAndFilteredObjectsForCAP-{{ site.data.ComplexesAndFilteredObjectsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/ComplexesAndFilteredObjectsForCAP-{{ site.data.ComplexesAndFilteredObjectsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/ComplexesAndFilteredObjectsForCAP-{{ site.data.ComplexesAndFilteredObjectsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/ComplexesAndFilteredObjectsForCAP-{{ site.data.ComplexesAndFilteredObjectsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/DeductiveSystemForCAP/badge_date.json
+++ b/DeductiveSystemForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.DeductiveSystemForCAP.date }}",
+  "color": "orange"
+}

--- a/DeductiveSystemForCAP/badge_version.json
+++ b/DeductiveSystemForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.DeductiveSystemForCAP.version }}",
+  "color": "orange"
+}

--- a/DeductiveSystemForCAP/download_pdf.html
+++ b/DeductiveSystemForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.DeductiveSystemForCAP.pdf }}">
+  <script>location="{{ site.data.DeductiveSystemForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.DeductiveSystemForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.DeductiveSystemForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/DeductiveSystemForCAP/index.md
+++ b/DeductiveSystemForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: DeductiveSystemForCAP
+layout: package
+---

--- a/DeductiveSystemForCAP/view_release.html
+++ b/DeductiveSystemForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/DeductiveSystemForCAP-{{ site.data.DeductiveSystemForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/DeductiveSystemForCAP-{{ site.data.DeductiveSystemForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/DeductiveSystemForCAP-{{ site.data.DeductiveSystemForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/DeductiveSystemForCAP-{{ site.data.DeductiveSystemForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/FreydCategoriesForCAP/badge_date.json
+++ b/FreydCategoriesForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.FreydCategoriesForCAP.date }}",
+  "color": "orange"
+}

--- a/FreydCategoriesForCAP/badge_version.json
+++ b/FreydCategoriesForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.FreydCategoriesForCAP.version }}",
+  "color": "orange"
+}

--- a/FreydCategoriesForCAP/download_pdf.html
+++ b/FreydCategoriesForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.FreydCategoriesForCAP.pdf }}">
+  <script>location="{{ site.data.FreydCategoriesForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.FreydCategoriesForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.FreydCategoriesForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/FreydCategoriesForCAP/index.md
+++ b/FreydCategoriesForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: FreydCategoriesForCAP
+layout: package
+---

--- a/FreydCategoriesForCAP/view_release.html
+++ b/FreydCategoriesForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/FreydCategoriesForCAP-{{ site.data.FreydCategoriesForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/FreydCategoriesForCAP-{{ site.data.FreydCategoriesForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/FreydCategoriesForCAP-{{ site.data.FreydCategoriesForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/FreydCategoriesForCAP-{{ site.data.FreydCategoriesForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/GeneralizedMorphismsForCAP/badge_date.json
+++ b/GeneralizedMorphismsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.GeneralizedMorphismsForCAP.date }}",
+  "color": "orange"
+}

--- a/GeneralizedMorphismsForCAP/badge_version.json
+++ b/GeneralizedMorphismsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.GeneralizedMorphismsForCAP.version }}",
+  "color": "orange"
+}

--- a/GeneralizedMorphismsForCAP/download_pdf.html
+++ b/GeneralizedMorphismsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.GeneralizedMorphismsForCAP.pdf }}">
+  <script>location="{{ site.data.GeneralizedMorphismsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.GeneralizedMorphismsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.GeneralizedMorphismsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/GeneralizedMorphismsForCAP/view_release.html
+++ b/GeneralizedMorphismsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/GeneralizedMorphismsForCAP-{{ site.data.GeneralizedMorphismsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/GeneralizedMorphismsForCAP-{{ site.data.GeneralizedMorphismsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/GeneralizedMorphismsForCAP-{{ site.data.GeneralizedMorphismsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/GeneralizedMorphismsForCAP-{{ site.data.GeneralizedMorphismsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/GradedModulePresentationsForCAP/badge_date.json
+++ b/GradedModulePresentationsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.GradedModulePresentationsForCAP.date }}",
+  "color": "orange"
+}

--- a/GradedModulePresentationsForCAP/badge_version.json
+++ b/GradedModulePresentationsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.GradedModulePresentationsForCAP.version }}",
+  "color": "orange"
+}

--- a/GradedModulePresentationsForCAP/download_pdf.html
+++ b/GradedModulePresentationsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.GradedModulePresentationsForCAP.pdf }}">
+  <script>location="{{ site.data.GradedModulePresentationsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.GradedModulePresentationsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.GradedModulePresentationsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/GradedModulePresentationsForCAP/index.md
+++ b/GradedModulePresentationsForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: GradedModulePresentationsForCAP
+layout: package
+---

--- a/GradedModulePresentationsForCAP/view_release.html
+++ b/GradedModulePresentationsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/GradedModulePresentationsForCAP-{{ site.data.GradedModulePresentationsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/GradedModulePresentationsForCAP-{{ site.data.GradedModulePresentationsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/GradedModulePresentationsForCAP-{{ site.data.GradedModulePresentationsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/GradedModulePresentationsForCAP-{{ site.data.GradedModulePresentationsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/GroupRepresentationsForCAP/badge_date.json
+++ b/GroupRepresentationsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.GroupRepresentationsForCAP.date }}",
+  "color": "orange"
+}

--- a/GroupRepresentationsForCAP/badge_version.json
+++ b/GroupRepresentationsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.GroupRepresentationsForCAP.version }}",
+  "color": "orange"
+}

--- a/GroupRepresentationsForCAP/download_pdf.html
+++ b/GroupRepresentationsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.GroupRepresentationsForCAP.pdf }}">
+  <script>location="{{ site.data.GroupRepresentationsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.GroupRepresentationsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.GroupRepresentationsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/GroupRepresentationsForCAP/index.md
+++ b/GroupRepresentationsForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: GroupRepresentationsForCAP
+layout: package
+---

--- a/GroupRepresentationsForCAP/view_release.html
+++ b/GroupRepresentationsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/GroupRepresentationsForCAP-{{ site.data.GroupRepresentationsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/GroupRepresentationsForCAP-{{ site.data.GroupRepresentationsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/GroupRepresentationsForCAP-{{ site.data.GroupRepresentationsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/GroupRepresentationsForCAP-{{ site.data.GroupRepresentationsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/HomologicalAlgebraForCAP/badge_date.json
+++ b/HomologicalAlgebraForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.HomologicalAlgebraForCAP.date }}",
+  "color": "orange"
+}

--- a/HomologicalAlgebraForCAP/badge_version.json
+++ b/HomologicalAlgebraForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.HomologicalAlgebraForCAP.version }}",
+  "color": "orange"
+}

--- a/HomologicalAlgebraForCAP/download_pdf.html
+++ b/HomologicalAlgebraForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.HomologicalAlgebraForCAP.pdf }}">
+  <script>location="{{ site.data.HomologicalAlgebraForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.HomologicalAlgebraForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.HomologicalAlgebraForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/HomologicalAlgebraForCAP/index.md
+++ b/HomologicalAlgebraForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: HomologicalAlgebraForCAP
+layout: package
+---

--- a/HomologicalAlgebraForCAP/view_release.html
+++ b/HomologicalAlgebraForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/HomologicalAlgebraForCAP-{{ site.data.HomologicalAlgebraForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/HomologicalAlgebraForCAP-{{ site.data.HomologicalAlgebraForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/HomologicalAlgebraForCAP-{{ site.data.HomologicalAlgebraForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/HomologicalAlgebraForCAP-{{ site.data.HomologicalAlgebraForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/InternalExteriorAlgebraForCAP/badge_date.json
+++ b/InternalExteriorAlgebraForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.InternalExteriorAlgebraForCAP.date }}",
+  "color": "orange"
+}

--- a/InternalExteriorAlgebraForCAP/badge_version.json
+++ b/InternalExteriorAlgebraForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.InternalExteriorAlgebraForCAP.version }}",
+  "color": "orange"
+}

--- a/InternalExteriorAlgebraForCAP/download_pdf.html
+++ b/InternalExteriorAlgebraForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.InternalExteriorAlgebraForCAP.pdf }}">
+  <script>location="{{ site.data.InternalExteriorAlgebraForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.InternalExteriorAlgebraForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.InternalExteriorAlgebraForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/InternalExteriorAlgebraForCAP/index.md
+++ b/InternalExteriorAlgebraForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: InternalExteriorAlgebraForCAP
+layout: package
+---

--- a/InternalExteriorAlgebraForCAP/view_release.html
+++ b/InternalExteriorAlgebraForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/InternalExteriorAlgebraForCAP-{{ site.data.InternalExteriorAlgebraForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/InternalExteriorAlgebraForCAP-{{ site.data.InternalExteriorAlgebraForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/InternalExteriorAlgebraForCAP-{{ site.data.InternalExteriorAlgebraForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/InternalExteriorAlgebraForCAP-{{ site.data.InternalExteriorAlgebraForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/LinearAlgebraForCAP/badge_date.json
+++ b/LinearAlgebraForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.LinearAlgebraForCAP.date }}",
+  "color": "orange"
+}

--- a/LinearAlgebraForCAP/badge_version.json
+++ b/LinearAlgebraForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.LinearAlgebraForCAP.version }}",
+  "color": "orange"
+}

--- a/LinearAlgebraForCAP/download_pdf.html
+++ b/LinearAlgebraForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.LinearAlgebraForCAP.pdf }}">
+  <script>location="{{ site.data.LinearAlgebraForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.LinearAlgebraForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.LinearAlgebraForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/LinearAlgebraForCAP/view_release.html
+++ b/LinearAlgebraForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/LinearAlgebraForCAP-{{ site.data.LinearAlgebraForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/LinearAlgebraForCAP-{{ site.data.LinearAlgebraForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/LinearAlgebraForCAP-{{ site.data.LinearAlgebraForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/LinearAlgebraForCAP-{{ site.data.LinearAlgebraForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/ModulePresentationsForCAP/badge_date.json
+++ b/ModulePresentationsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.ModulePresentationsForCAP.date }}",
+  "color": "orange"
+}

--- a/ModulePresentationsForCAP/badge_version.json
+++ b/ModulePresentationsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.ModulePresentationsForCAP.version }}",
+  "color": "orange"
+}

--- a/ModulePresentationsForCAP/download_pdf.html
+++ b/ModulePresentationsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.ModulePresentationsForCAP.pdf }}">
+  <script>location="{{ site.data.ModulePresentationsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.ModulePresentationsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.ModulePresentationsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/ModulePresentationsForCAP/view_release.html
+++ b/ModulePresentationsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/ModulePresentationsForCAP-{{ site.data.ModulePresentationsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/ModulePresentationsForCAP-{{ site.data.ModulePresentationsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/ModulePresentationsForCAP-{{ site.data.ModulePresentationsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/ModulePresentationsForCAP-{{ site.data.ModulePresentationsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/ModulesOverLocalRingsForCAP/badge_date.json
+++ b/ModulesOverLocalRingsForCAP/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.ModulesOverLocalRingsForCAP.date }}",
+  "color": "orange"
+}

--- a/ModulesOverLocalRingsForCAP/badge_version.json
+++ b/ModulesOverLocalRingsForCAP/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.ModulesOverLocalRingsForCAP.version }}",
+  "color": "orange"
+}

--- a/ModulesOverLocalRingsForCAP/download_pdf.html
+++ b/ModulesOverLocalRingsForCAP/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.ModulesOverLocalRingsForCAP.pdf }}">
+  <script>location="{{ site.data.ModulesOverLocalRingsForCAP.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.ModulesOverLocalRingsForCAP.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.ModulesOverLocalRingsForCAP.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/ModulesOverLocalRingsForCAP/index.md
+++ b/ModulesOverLocalRingsForCAP/index.md
@@ -1,0 +1,4 @@
+---
+package_name: ModulesOverLocalRingsForCAP
+layout: package
+---

--- a/ModulesOverLocalRingsForCAP/view_release.html
+++ b/ModulesOverLocalRingsForCAP/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/ModulesOverLocalRingsForCAP-{{ site.data.ModulesOverLocalRingsForCAP.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/ModulesOverLocalRingsForCAP-{{ site.data.ModulesOverLocalRingsForCAP.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/ModulesOverLocalRingsForCAP-{{ site.data.ModulesOverLocalRingsForCAP.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/ModulesOverLocalRingsForCAP-{{ site.data.ModulesOverLocalRingsForCAP.version }}">Click here if you are not redirected.</a>
+</html>

--- a/MonoidalCategories/badge_date.json
+++ b/MonoidalCategories/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.MonoidalCategories.date }}",
+  "color": "orange"
+}

--- a/MonoidalCategories/badge_version.json
+++ b/MonoidalCategories/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.MonoidalCategories.version }}",
+  "color": "orange"
+}

--- a/MonoidalCategories/download_pdf.html
+++ b/MonoidalCategories/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.MonoidalCategories.pdf }}">
+  <script>location="{{ site.data.MonoidalCategories.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.MonoidalCategories.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.MonoidalCategories.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/MonoidalCategories/view_release.html
+++ b/MonoidalCategories/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/MonoidalCategories-{{ site.data.MonoidalCategories.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/MonoidalCategories-{{ site.data.MonoidalCategories.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/MonoidalCategories-{{ site.data.MonoidalCategories.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/MonoidalCategories-{{ site.data.MonoidalCategories.version }}">Click here if you are not redirected.</a>
+</html>

--- a/ToricSheaves/badge_date.json
+++ b/ToricSheaves/badge_date.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "released on",
+  "message": "{{ site.data.ToricSheaves.date }}",
+  "color": "orange"
+}

--- a/ToricSheaves/badge_version.json
+++ b/ToricSheaves/badge_version.json
@@ -1,0 +1,8 @@
+---
+---
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "{{ site.data.ToricSheaves.version }}",
+  "color": "orange"
+}

--- a/ToricSheaves/download_pdf.html
+++ b/ToricSheaves/download_pdf.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ site.data.ToricSheaves.pdf }}">
+  <script>location="{{ site.data.ToricSheaves.pdf }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ site.data.ToricSheaves.pdf }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ site.data.ToricSheaves.pdf }}">Click here if you are not redirected.</a>
+</html>

--- a/ToricSheaves/index.md
+++ b/ToricSheaves/index.md
@@ -1,0 +1,4 @@
+---
+package_name: ToricSheaves
+layout: package
+---

--- a/ToricSheaves/view_release.html
+++ b/ToricSheaves/view_release.html
@@ -1,0 +1,13 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://github.com/homalg-project/CAP_project/releases/tag/ToricSheaves-{{ site.data.ToricSheaves.version }}">
+  <script>location="https://github.com/homalg-project/CAP_project/releases/tag/ToricSheaves-{{ site.data.ToricSheaves.version }}"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/homalg-project/CAP_project/releases/tag/ToricSheaves-{{ site.data.ToricSheaves.version }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/homalg-project/CAP_project/releases/tag/ToricSheaves-{{ site.data.ToricSheaves.version }}">Click here if you are not redirected.</a>
+</html>

--- a/update.g
+++ b/update.g
@@ -1,7 +1,7 @@
 #
 # GitHubPagesForGAP - a template for using GitHub Pages within GAP packages
 #
-# Copyright (c) 2013-2014 Max Horn
+# Copyright (c) 2013-2018 Max Horn
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -46,15 +46,56 @@ PrintPackageList := function(stream, pkgs)
     AppendTo(stream, "\n");
 end;
 
+# verify date is of the form YYYY-MM-DD
+IsValidISO8601Date := function(date)
+    local day, month, year;
+    if Length(date) <> 10 then return false; fi;
+    if date[5] <> '-' or date[8] <> '-' then return false; fi;
+    if not ForAll(date{[1,2,3,4,6,7,9,10]}, IsDigitChar) then
+        return false;
+    fi;
+    date := List(SplitString(date, "-"), Int);
+    day := date[3];
+    month := date[2];
+    year := date[1];
+    return month in [1..12] and day in [1..DaysInMonth(month, year)];
+end;
+
 GeneratePackageYML:=function(pkg)
-    local stream, authors, maintainers, formats, f;
+    local stream, date, authors, maintainers, contributors, formats, f, tmp;
+
     stream := OutputTextFile("_data/package.yml", false);
     SetPrintFormattingStatus(stream, false);
     
     AppendTo(stream, "name: ", pkg.PackageName, "\n");
-    AppendTo(stream, "version: ", pkg.Version, "\n");
-    AppendTo(stream, "date: ", pkg.Date, "\n"); # TODO: convert to ISO 8601?
-    AppendTo(stream, "description: ", pkg.Subtitle, "\n");
+    AppendTo(stream, "version: \"", pkg.Version, "\"\n");
+    if IsBound(pkg.License) then
+        AppendTo(stream, "license: \"", pkg.License, "\"\n");
+    fi;
+
+    # convert date from DD/MM/YYYY to ISO 8601, i.e. YYYY-MM-DD
+    #
+    # in the future, GAP might support ISO 8601 dates in PackageInfo.g,
+    # so be prepared to accept that
+    date := pkg.Date;
+    tmp := SplitString(pkg.Date, "/");
+    if Length(tmp) = 3 then
+        # pad month and date if necessary
+        if Length(tmp[1]) = 1 then
+          tmp[1] := Concatenation("0", tmp[1]);
+        fi;
+        if Length(tmp[2]) = 1 then
+          tmp[2] := Concatenation("0", tmp[2]);
+        fi;
+        date := Concatenation(tmp[3], "-", tmp[2], "-", tmp[1]);
+    fi;
+    if not IsValidISO8601Date(date) then
+        Error("malformed release date ", pkg.Date);
+    fi;
+
+    AppendTo(stream, "date: ", date, "\n");
+    AppendTo(stream, "description: |\n");
+    AppendTo(stream, "    ", pkg.Subtitle, "\n");
     AppendTo(stream, "\n");
 
     authors := Filtered(pkg.Persons, p -> p.IsAuthor);
@@ -67,6 +108,12 @@ GeneratePackageYML:=function(pkg)
     if Length(maintainers) > 0 then
         AppendTo(stream, "maintainers:\n");
         PrintPeopleList(stream, maintainers);
+    fi;
+
+    contributors := Filtered(pkg.Persons, p -> not p.IsMaintainer and not p.IsAuthor);
+    if Length(contributors) > 0 then
+        AppendTo(stream, "contributors:\n");
+        PrintPeopleList(stream, contributors);
     fi;
 
     if IsBound(pkg.Dependencies.GAP) then
@@ -86,7 +133,9 @@ GeneratePackageYML:=function(pkg)
     fi;
 
     AppendTo(stream, "www: ", pkg.PackageWWWHome, "\n");
-    AppendTo(stream, "readme: ", pkg.README_URL, "\n");
+    tmp := SplitString(pkg.README_URL,"/");
+    tmp := tmp[Length(tmp)];  # extract README filename (typically "README" or "README.md")
+    AppendTo(stream, "readme: ", tmp, "\n");
     AppendTo(stream, "packageinfo: ", pkg.PackageInfoURL, "\n");
     if IsBound(pkg.GithubWWW) then
         AppendTo(stream, "github: ", pkg.GithubWWW, "\n");
@@ -103,14 +152,45 @@ GeneratePackageYML:=function(pkg)
         AppendTo(stream, "\n");
     fi;
 
-    AppendTo(stream, "abstract: ", pkg.AbstractHTML, "\n\n");
+    AppendTo(stream, "pdf: ", pkg.ArchiveURL, ".pdf\n");
+    AppendTo(stream, "\n");
+
+    AppendTo(stream, "abstract: |\n");
+    for tmp in SplitString(pkg.AbstractHTML,"\n") do
+        AppendTo(stream, "    ", tmp, "\n");
+    od;
+    AppendTo(stream, "\n");
 
     AppendTo(stream, "status: ", pkg.Status, "\n");
-    AppendTo(stream, "doc-html: ", pkg.PackageDoc.HTMLStart, "\n");
-    AppendTo(stream, "doc-pdf: ", pkg.PackageDoc.PDFFile, "\n");
+    if IsRecord(pkg.PackageDoc) then
+        AppendTo(stream, "doc-html: ", pkg.PackageDoc.HTMLStart, "\n");
+        AppendTo(stream, "doc-pdf: ", pkg.PackageDoc.PDFFile, "\n");
+    else
+        Assert(0, IsList(pkg.PackageDoc));
+        AppendTo(stream, "doc-html: ", pkg.PackageDoc[1].HTMLStart, "\n");
+        AppendTo(stream, "doc-pdf: ", pkg.PackageDoc[1].PDFFile, "\n");
+        if Length(pkg.PackageDoc) > 1 then
+            Print("Warning, this package has more than one help book!\n");
+        fi;
+    fi;
 
-    # TODO: use AbstractHTML?
-    # TODO: use Keywords?
+    if IsBound(pkg.Keywords) and
+        Length(pkg.Keywords) > 0 then
+        AppendTo(stream, "keywords: |\n");
+        AppendTo(stream, "    ", JoinStringsWithSeparator(pkg.Keywords,", "),".\n");
+    fi;
+
+    AppendTo(stream, "citeas: |\n");
+    for tmp in SplitString(StringBibXMLEntry(ParseBibXMLextString(BibEntry(pkg)).entries[1],"HTML"),"\n") do
+        AppendTo(stream, "    ", tmp, "\n");
+    od;
+    AppendTo(stream, "\n");
+
+    AppendTo(stream, "bibtex: |\n");
+    for tmp in SplitString(StringBibXMLEntry(ParseBibXMLextString(BibEntry(pkg)).entries[1],"BibTeX"),"\n") do
+        AppendTo(stream, "    ", tmp, "\n");
+    od;
+    AppendTo(stream, "\n");
 
     CloseStream(stream);
 end;


### PR DESCRIPTION
The files `badge_date.json`, `badge_version.json`, `download_pdf.html` and `view_release.html` will be used for enriching the READMEs as can be seen here: https://github.com/zickgraf/FinSetsForCAP

Edit: currently the gh-pages branch is broken. All fixes are already available, I just have to open appropriate PRs :D