### PR TITLE
Apply PackageJanitor and introduce new versioning scheme

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         image: [gapsystem/gap-docker, gapsystem/gap-docker-master]
+      fail-fast: false
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
@@ -39,77 +40,10 @@ jobs:
           git config --global user.email "empty"
           cd CAP_project
           CUR_SHA=$(git rev-parse --verify HEAD)
-          git worktree add branch_doc/ doc || (echo "There was an error. Make sure there is a branch named 'doc'. See https://github.com/homalg-project/PackageJanitor#error-there-was-an-error-make-sure-there-is-a-branch-named-doc"; exit 1)
-          cp ActionsForCAP/doc/manual.pdf branch_doc/ActionsForCAP.pdf
-          cd branch_doc
-          git add ActionsForCAP.pdf
-          git commit -m "Add ActionsForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp AttributeCategoryForCAP/doc/manual.pdf branch_doc/AttributeCategoryForCAP.pdf
-          cd branch_doc
-          git add AttributeCategoryForCAP.pdf
-          git commit -m "Add AttributeCategoryForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp CompilerForCAP/doc/manual.pdf branch_doc/CompilerForCAP.pdf
-          cd branch_doc
-          git add CompilerForCAP.pdf
-          git commit -m "Add CompilerForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp ComplexesAndFilteredObjectsForCAP/doc/manual.pdf branch_doc/ComplexesAndFilteredObjectsForCAP.pdf
-          cd branch_doc
-          git add ComplexesAndFilteredObjectsForCAP.pdf
-          git commit -m "Add ComplexesAndFilteredObjectsForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp DeductiveSystemForCAP/doc/manual.pdf branch_doc/DeductiveSystemForCAP.pdf
-          cd branch_doc
-          git add DeductiveSystemForCAP.pdf
-          git commit -m "Add DeductiveSystemForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp FreydCategoriesForCAP/doc/manual.pdf branch_doc/FreydCategoriesForCAP.pdf
-          cd branch_doc
-          git add FreydCategoriesForCAP.pdf
-          git commit -m "Add FreydCategoriesForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp GradedModulePresentationsForCAP/doc/manual.pdf branch_doc/GradedModulePresentationsForCAP.pdf
-          cd branch_doc
-          git add GradedModulePresentationsForCAP.pdf
-          git commit -m "Add GradedModulePresentationsForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp GroupRepresentationsForCAP/doc/manual.pdf branch_doc/GroupRepresentationsForCAP.pdf
-          cd branch_doc
-          git add GroupRepresentationsForCAP.pdf
-          git commit -m "Add GroupRepresentationsForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp HomologicalAlgebraForCAP/doc/manual.pdf branch_doc/HomologicalAlgebraForCAP.pdf
-          cd branch_doc
-          git add HomologicalAlgebraForCAP.pdf
-          git commit -m "Add HomologicalAlgebraForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp InternalExteriorAlgebraForCAP/doc/manual.pdf branch_doc/InternalExteriorAlgebraForCAP.pdf
-          cd branch_doc
-          git add InternalExteriorAlgebraForCAP.pdf
-          git commit -m "Add InternalExteriorAlgebraForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp ModulesOverLocalRingsForCAP/doc/manual.pdf branch_doc/ModulesOverLocalRingsForCAP.pdf
-          cd branch_doc
-          git add ModulesOverLocalRingsForCAP.pdf
-          git commit -m "Add ModulesOverLocalRingsForCAP.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          cp ToricSheaves/doc/manual.pdf branch_doc/ToricSheaves.pdf
-          cd branch_doc
-          git add ToricSheaves.pdf
-          git commit -m "Add ToricSheaves.pdf for $CUR_SHA" --allow-empty
-          cd ..
-          # push iff using gap-stable and if on master branch
-          if [ "${{ matrix.image }}" = "gapsystem/gap-docker" ] && [ "$CUR_SHA" = "$(git rev-parse origin/master)" ]; then \
-            git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git doc:doc; \
-          else \
-            echo "Not pushing result."; \
-          fi
           if [ "${{ matrix.image }}" = "gapsystem/gap-docker" ] && [ "$CUR_SHA" = "$(git rev-parse origin/master)" ] && [ $(dirname "$GITHUB_REPOSITORY") = "homalg-project" ]; then \
             git worktree add gh-pages/ gh-pages || (echo "There was an error. Make sure there is a branch named 'gh-pages'. See https://github.com/homalg-project/PackageJanitor#error-there-was-an-error-make-sure-there-is-a-branch-named-gh-pages"; exit 1); \
             git checkout master; \
-            ./make_dist.sh --token "${{ secrets.GITHUB_TOKEN }}"; \
+            LANG=C.UTF-8 ./make_dist.sh --token "${{ secrets.GITHUB_TOKEN }}"; \
           else \
             echo "Not making a release."; \
           fi

--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -12,17 +12,16 @@ PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
 
 Version := Maximum( [
-  "2019.09.16", ## Mohamed's version
+  "2019.09-16", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2015.08.19", ## Sebas' version
+  "2015.08-19", ## Sebas' version
   ## this line prevents merge conflicts
-  "2017.01.11", ## Sepp's version
+  "2017.01-11", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.04.27", ## Fabian's version
+  "2020.10-01", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -60,13 +59,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/ActionsForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ActionsForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ActionsForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/ActionsForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/ActionsForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/ActionsForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/ActionsForCAP-", ~.Version, "/ActionsForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/ActionsForCAP/README.md
+++ b/ActionsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ActionsForCAP – Actions and Coactions for CAP
+# ActionsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Actions and Coactions for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/ActionsForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ActionsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ActionsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/AttributeCategoryForCAP/PackageInfo.g
+++ b/AttributeCategoryForCAP/PackageInfo.g
@@ -12,17 +12,16 @@ PackageName := "AttributeCategoryForCAP",
 Subtitle := "Automatic enhancement with attributes of a CAP category",
 
 Version := Maximum( [
-  "2019.01.16", ## Mohamed's version
+  "2019.01-16", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2016.09.14", ## Sebas' version
+  "2016.09-14", ## Sebas' version
   ## this line prevents merge conflicts
-  "2016.09.14", ## Sepp's version
+  "2016.09-14", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.04.27", ## Fabian's version
+  "2020.10-01", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -61,13 +60,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/AttributeCategoryForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/AttributeCategoryForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/AttributeCategoryForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/AttributeCategoryForCAP-", ~.Version, "/AttributeCategoryForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/AttributeCategoryForCAP/README.md
+++ b/AttributeCategoryForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# AttributeCategoryForCAP – Automatic enhancement with attributes of a CAP category
+# AttributeCategoryForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Automatic enhancement with attributes of a CAP category
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/AttributeCategoryForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -13,20 +13,20 @@ PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
 
 Version := Maximum( [
-  "2020.05.16", ## Mohamed's version
+  "2020.05-16", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2015.04.01", ## Oystein's version
+  "2015.04-01", ## Oystein's version
   ## this line prevents merge conflicts
-  "2019.06.05", ## Sebas' version
+  "2019.06-05", ## Sebas' version
   ## this line prevents merge conflicts
-  "2020.04.16", ## Sepp's version
+  "2020.04-16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.09.01", ## Fabian's version
+  "2020.10-01", ## Fabian's version
   ## this line prevents merge conflicts
-  "2020.08.01", ## Kamal's version
+  "2020.08-01", ## Kamal's version
 ] ),
 
-Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 

--- a/CAP/README.md
+++ b/CAP/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN HEADER -->
-# CAP – Categories, Algorithms, Programming
+# CAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Categories, Algorithms, Programming
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 
@@ -12,8 +14,17 @@ This is the central package of the CAP project.
 Its website is located [here](http://homalg-project.github.io/CAP_project/CAP).
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/CAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/CAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/CAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/CAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/CAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -11,10 +11,10 @@ SetPackageInfo( rec(
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
 Version := Maximum( [
-  "2020.07.09", ## Fabian's version
+  "2020.10-01", ## Fabian's version
   ## this line prevents merge conflicts
 ] ),
-Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 Persons := [
@@ -40,13 +40,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/CompilerForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/CompilerForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/CompilerForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/CompilerForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/CompilerForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/CompilerForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/CompilerForCAP-", ~.Version, "/CompilerForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/CompilerForCAP/README.md
+++ b/CompilerForCAP/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN HEADER -->
-# CompilerForCAP – Speed up computations in CAP categories
+# CompilerForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Speed up computations in CAP categories
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 
@@ -42,8 +44,17 @@ Thus, there is no penalty in writing high-level code: Using `CompilerForCAP`, an
 * [planned] In some settings, e.g. in product categories, opportunities for parallelisation arise naturally. `CompilerForCAP` should be able to detect such situations and parallelise code using HPC-GAP or Julia where possible.
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/CompilerForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/CompilerForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/CompilerForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
+++ b/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
@@ -4,14 +4,14 @@ PackageName := "ComplexesAndFilteredObjectsForCAP",
 Subtitle := "Implementation of complexes, cocomplexes and filtered objects for CAP",
 
 Version := Maximum( [
-  "2018.08.02", ## Sebas' version
+  "2018.08-02", ## Sebas' version
 ## this line prevents merge conflicts
-  "2015.04.15", ## Sepp's version
+  "2015.04-15", ## Sepp's version
 ## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
    ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -56,13 +56,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/ComplexesAndFilteredObjectsForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ComplexesAndFilteredObjectsForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ComplexesAndFilteredObjectsForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/ComplexesAndFilteredObjectsForCAP-", ~.Version, "/ComplexesAndFilteredObjectsForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/ComplexesAndFilteredObjectsForCAP/README.md
+++ b/ComplexesAndFilteredObjectsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ComplexesAndFilteredObjectsForCAP – Implementation of complexes, cocomplexes and filtered objects for CAP
+# ComplexesAndFilteredObjectsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Implementation of complexes, cocomplexes and filtered objects for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/ComplexesAndFilteredObjectsForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/DeductiveSystemForCAP/PackageInfo.g
+++ b/DeductiveSystemForCAP/PackageInfo.g
@@ -3,13 +3,14 @@ SetPackageInfo( rec(
 PackageName := "DeductiveSystemForCAP",
 Subtitle := "Deductive system for CAP",
 Version := Maximum( [
-  "2016.01.17", ## Sebas' version
+  "2016.01-17", ## Sebas' version
   ## this line prevents merge conflicts
-  "2015.04.15", ## Sepp's version
+  "2015.04-15", ## Sepp's version
+  ## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -53,13 +54,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/DeductiveSystemForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/DeductiveSystemForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/DeductiveSystemForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/DeductiveSystemForCAP-", ~.Version, "/DeductiveSystemForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/DeductiveSystemForCAP/README.md
+++ b/DeductiveSystemForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# DeductiveSystemForCAP – Deductive system for CAP
+# DeductiveSystemForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Deductive system for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/DeductiveSystemForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -11,17 +11,17 @@ SetPackageInfo( rec(
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
 Version := Maximum( [
-  "2019.03.04", ## Martin's version
+  "2019.03-04", ## Martin's version
   ## this line prevents merge conflicts
-  "2020.09.21", ## Sepp's version
+  "2020.09-21", ## Sepp's version
   ## this line prevents merge conflicts
-  "2020.05.17", ## Mohamed's version
+  "2020.05-17", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2019.08.07", ## Fabian's version
+  "2020.10-01", ## Fabian's version
   ## this line prevents merge conflicts
-  "2020.04.18", ## Kamal's version
+  "2020.04-18", ## Kamal's version
 ] ),
-Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -67,13 +67,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/FreydCategoriesForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/FreydCategoriesForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/FreydCategoriesForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/FreydCategoriesForCAP-", ~.Version, "/FreydCategoriesForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/FreydCategoriesForCAP/README.md
+++ b/FreydCategoriesForCAP/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN HEADER -->
-# FreydCategoriesForCAP – Freyd categories - Formal (co)kernels for additive categories
+# FreydCategoriesForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Freyd categories - Formal (co)kernels for additive categories
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 
@@ -46,8 +48,17 @@ Additive closures provide a universal way of equipping a given Ab-category with 
 Sebastian Posur, [*Methods of constructive category theory*](https://arxiv.org/abs/1908.04132).
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/FreydCategoriesForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GeneralizedMorphismsForCAP/PackageInfo.g
+++ b/GeneralizedMorphismsForCAP/PackageInfo.g
@@ -4,16 +4,17 @@ PackageName := "GeneralizedMorphismsForCAP",
 Subtitle := "Implementations of generalized morphisms for the CAP project",
 
 Version := Maximum( [
-  "2017.12.30", ## Sebas' version
+  "2017.12-30", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.04.16", ## Sepp's version
+  "2020.04-16", ## Sepp's version
 ## this line prevents merge conflicts
-  "2020.04.29", ## Mohamed's version
+  "2020.04-29", ## Mohamed's version
+## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
 ## this line prevents merge conflicts
    ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 

--- a/GeneralizedMorphismsForCAP/README.md
+++ b/GeneralizedMorphismsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# GeneralizedMorphismsForCAP – Implementations of generalized morphisms for the CAP project
+# GeneralizedMorphismsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Implementations of generalized morphisms for the CAP project
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -12,18 +12,17 @@ PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
 Version := Maximum( [
            ##
-           "2017.03.20", # Sebas version
+           "2017.03-20", # Sebas version
            ##
-           "2018.03.20", # Sepps version
+           "2018.03-20", # Sepps version
            ##
-           "2019.04.03", # Mohamed's version
+           "2019.04-03", # Mohamed's version
            ##
-           "2019.08.07", # Fabian's version
+           "2020.10-01", # Fabian's version
            ##
            ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 Persons := [
@@ -51,13 +50,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/GradedModulePresentationsForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/GradedModulePresentationsForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/GradedModulePresentationsForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/GradedModulePresentationsForCAP-", ~.Version, "/GradedModulePresentationsForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/GradedModulePresentationsForCAP/README.md
+++ b/GradedModulePresentationsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# GradedModulePresentationsForCAP – Presentations for graded modules
+# GradedModulePresentationsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Presentations for graded modules
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -11,14 +11,14 @@ SetPackageInfo( rec(
 PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
 Version := Maximum( [
-  "2017.01.11", ## Sepp's version
+  "2017.01-11", ## Sepp's version
   ## this line prevents merge conflicts
-  "2019.09.02", ## Mohamed's version
+  "2019.09-02", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2020.09.08", ## Fabian's version
+  "2020.10-01", ## Fabian's version
 ] ),
 
-Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -48,13 +48,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/GroupRepresentationsForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/GroupRepresentationsForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/GroupRepresentationsForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/GroupRepresentationsForCAP-", ~.Version, "/GroupRepresentationsForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/GroupRepresentationsForCAP/README.md
+++ b/GroupRepresentationsForCAP/README.md
@@ -1,15 +1,26 @@
 <!-- BEGIN HEADER -->
-# GroupRepresentationsForCAP – Skeletal category of group representations for CAP
+# GroupRepresentationsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Skeletal category of group representations for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/HomologicalAlgebraForCAP/PackageInfo.g
+++ b/HomologicalAlgebraForCAP/PackageInfo.g
@@ -4,14 +4,14 @@ PackageName := "HomologicalAlgebraForCAP",
 Subtitle := "Homological algebra algorithms for CAP",
 
 Version := Maximum( [
-  "2015.05.08", ## Sebas' version
-## this line prevents merge conflicts
-   "2015.04.15", ## Sepp's version
-## this line prevents merge conflicts
-    ] ),
+  "2015.05-08", ## Sebas' version
+  ## this line prevents merge conflicts
+  "2015.04-15", ## Sepp's version
+  ## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
+] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -55,13 +55,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/HomologicalAlgebraForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/HomologicalAlgebraForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/HomologicalAlgebraForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/HomologicalAlgebraForCAP-", ~.Version, "/HomologicalAlgebraForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/HomologicalAlgebraForCAP/README.md
+++ b/HomologicalAlgebraForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# HomologicalAlgebraForCAP – Homological algebra algorithms for CAP
+# HomologicalAlgebraForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Homological algebra algorithms for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/HomologicalAlgebraForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/InternalExteriorAlgebraForCAP/PackageInfo.g
+++ b/InternalExteriorAlgebraForCAP/PackageInfo.g
@@ -11,11 +11,12 @@ SetPackageInfo( rec(
 PackageName := "InternalExteriorAlgebraForCAP",
 Subtitle := "Constructions for Modules over the Internal Exterior Algebra for CAP",
 Version := Maximum( [
-  "2017.01.11", ## Sepp's version
+  "2017.01-11", ## Sepp's version
+  ## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 
@@ -44,13 +45,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/InternalExteriorAlgebraForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/InternalExteriorAlgebraForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/InternalExteriorAlgebraForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/InternalExteriorAlgebraForCAP-", ~.Version, "/InternalExteriorAlgebraForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/InternalExteriorAlgebraForCAP/README.md
+++ b/InternalExteriorAlgebraForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# InternalExteriorAlgebraForCAP – Constructions for Modules over the Internal Exterior Algebra for CAP
+# InternalExteriorAlgebraForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Constructions for Modules over the Internal Exterior Algebra for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -13,20 +13,19 @@ PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
 
 Version := Maximum( [
-  "2020.05.17", ## Mohamed's version
+  "2020.05-17", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2017.12.30", ## Sebas' version
+  "2017.12-30", ## Sebas' version
   ## this line prevents merge conflicts
-  "2020.04.16", ## Sepp's version
+  "2020.04-16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2019.08.07", ## Fabian's version
+  "2020.10-01", ## Fabian's version
   ## this line prevents merge conflicts
-  "2020.01.10", ## Kamal's version
+  "2020.01-10", ## Kamal's version
 
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 

--- a/LinearAlgebraForCAP/README.md
+++ b/LinearAlgebraForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# LinearAlgebraForCAP – Category of Matrices over a Field for CAP
+# LinearAlgebraForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Category of Matrices over a Field for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -4,18 +4,17 @@ PackageName := "ModulePresentationsForCAP",
 Subtitle := "Category R-pres for CAP",
 Version := Maximum( [
            ##
-           "2017.12.30", # Sebas version
+           "2017.12-30", # Sebas version
            ##
-           "2020.04.16", # Sepps version
+           "2020.04-16", # Sepps version
            ##
-           "2019.01.16", # Mohamed's version
+           "2019.01-16", # Mohamed's version
            ##
-           "2019.08.07", # Fabian's version
+           "2020.10-01", # Fabian's version
            ##
            ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 

--- a/ModulePresentationsForCAP/README.md
+++ b/ModulePresentationsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ModulePresentationsForCAP – Category R-pres for CAP
+# ModulePresentationsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Category R-pres for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ModulesOverLocalRingsForCAP/PackageInfo.g
+++ b/ModulesOverLocalRingsForCAP/PackageInfo.g
@@ -11,9 +11,11 @@ SetPackageInfo( rec(
 PackageName := "ModulesOverLocalRingsForCAP",
 Subtitle := "Category of modules over a local ring modeled by Serre quotients for CAP",
 Version := Maximum( [
-           "2017.04.10" # Sepps version
-           ] ),
-Date := "04/04/2017", # dd/mm/yyyy format
+  "2017.04-10", # Sepps version
+  ## this line prevents merge conflicts
+  "2020.10-01", ## Fabian's version
+] ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 Persons := [
@@ -41,13 +43,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/ModulesOverLocalRingsForCAP",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ModulesOverLocalRingsForCAP/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ModulesOverLocalRingsForCAP/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/ModulesOverLocalRingsForCAP-", ~.Version, "/ModulesOverLocalRingsForCAP-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/ModulesOverLocalRingsForCAP/README.md
+++ b/ModulesOverLocalRingsForCAP/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ModulesOverLocalRingsForCAP – Category of modules over a local ring modeled by Serre quotients for CAP
+# ModulesOverLocalRingsForCAP
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Category of modules over a local ring modeled by Serre quotients for CAP
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/ModulesOverLocalRingsForCAP.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -11,18 +11,18 @@ SetPackageInfo( rec(
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
 Version := Maximum( [
-  "2020.03.01", ## Mohamed's version
+  "2020.03-01", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2019.06.07", ## Sebas' version
+  "2019.06-07", ## Sebas' version
   ## this line prevents merge conflicts
-  "2020.04.16", ## Sepp's version
+  "2020.04-16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2019.08.10", ## Fabian's version
+  "2020.10-01", ## Fabian's version
   ## this line prevents merge conflicts
-  "2019.02.01", ## Tom's version
+  "2019.02-01", ## Tom's version
 ] ),
 
-Date := Concatenation( ~.Version{[ 9, 10 ]}, "/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 Persons := [

--- a/MonoidalCategories/README.md
+++ b/MonoidalCategories/README.md
@@ -1,15 +1,26 @@
 <!-- BEGIN HEADER -->
-# MonoidalCategories – Monoidal and monoidal (co)closed categories
+# MonoidalCategories
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Monoidal and monoidal (co)closed categories
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/MonoidalCategories/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/MonoidalCategories/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <!-- BEGIN HEADER -->
-# CAP project – Categories, Algorithms, and Programming
+# CAP project
+
+### Categories, Algorithms, and Programming
 
 | Build Status | Code Coverage |
 | ------------ | ------------- |
@@ -17,77 +19,145 @@ Please take a look at our [manual](https://github.com/homalg-project/CAP_project
 
 Please visit our website: https://homalg-project.github.io/docs/CAP_project/
 <!-- BEGIN FOOTER -->
-## Packages of [CAP_project](/../../):
+### Packages of [CAP_project](/../../):
 | Name | Description | Documentation |
 | ---- | ----------- | ------------- |
-| [CAP](CAP) | Categories, Algorithms, Programming | [![HTML stable documentation][docs-CAP-img]][docs-CAP-url] |
-| [ActionsForCAP](ActionsForCAP) | Actions and Coactions for CAP | [![PDF development documentation][docs-ActionsForCAP-img]][docs-ActionsForCAP-url] |
-| [AttributeCategoryForCAP](AttributeCategoryForCAP) | Automatic enhancement with attributes of a CAP category | [![PDF development documentation][docs-AttributeCategoryForCAP-img]][docs-AttributeCategoryForCAP-url] |
-| [CompilerForCAP](CompilerForCAP) | Speed up computations in CAP categories | [![PDF development documentation][docs-CompilerForCAP-img]][docs-CompilerForCAP-url] |
-| [ComplexesAndFilteredObjectsForCAP](ComplexesAndFilteredObjectsForCAP) | Implementation of complexes, cocomplexes and filtered objects for CAP | [![PDF development documentation][docs-ComplexesAndFilteredObjectsForCAP-img]][docs-ComplexesAndFilteredObjectsForCAP-url] |
-| [DeductiveSystemForCAP](DeductiveSystemForCAP) | Deductive system for CAP | [![PDF development documentation][docs-DeductiveSystemForCAP-img]][docs-DeductiveSystemForCAP-url] |
-| [FreydCategoriesForCAP](FreydCategoriesForCAP) | Freyd categories - Formal (co)kernels for additive categories | [![PDF development documentation][docs-FreydCategoriesForCAP-img]][docs-FreydCategoriesForCAP-url] |
-| [GeneralizedMorphismsForCAP](GeneralizedMorphismsForCAP) | Implementations of generalized morphisms for the CAP project | [![HTML stable documentation][docs-GeneralizedMorphismsForCAP-img]][docs-GeneralizedMorphismsForCAP-url] |
-| [GradedModulePresentationsForCAP](GradedModulePresentationsForCAP) | Presentations for graded modules | [![PDF development documentation][docs-GradedModulePresentationsForCAP-img]][docs-GradedModulePresentationsForCAP-url] |
-| [GroupRepresentationsForCAP](GroupRepresentationsForCAP) | Skeletal category of group representations for CAP | [![PDF development documentation][docs-GroupRepresentationsForCAP-img]][docs-GroupRepresentationsForCAP-url] |
-| [HomologicalAlgebraForCAP](HomologicalAlgebraForCAP) | Homological algebra algorithms for CAP | [![PDF development documentation][docs-HomologicalAlgebraForCAP-img]][docs-HomologicalAlgebraForCAP-url] |
-| [InternalExteriorAlgebraForCAP](InternalExteriorAlgebraForCAP) | Constructions for Modules over the Internal Exterior Algebra for CAP | [![PDF development documentation][docs-InternalExteriorAlgebraForCAP-img]][docs-InternalExteriorAlgebraForCAP-url] |
-| [LinearAlgebraForCAP](LinearAlgebraForCAP) | Category of Matrices over a Field for CAP | [![HTML stable documentation][docs-LinearAlgebraForCAP-img]][docs-LinearAlgebraForCAP-url] |
-| [ModulePresentationsForCAP](ModulePresentationsForCAP) | Category R-pres for CAP | [![HTML stable documentation][docs-ModulePresentationsForCAP-img]][docs-ModulePresentationsForCAP-url] |
-| [ModulesOverLocalRingsForCAP](ModulesOverLocalRingsForCAP) | Category of modules over a local ring modeled by Serre quotients for CAP | [![PDF development documentation][docs-ModulesOverLocalRingsForCAP-img]][docs-ModulesOverLocalRingsForCAP-url] |
-| [MonoidalCategories](MonoidalCategories) | Monoidal and monoidal (co)closed categories | [![HTML stable documentation][docs-MonoidalCategories-img]][docs-MonoidalCategories-url] |
-| [ToricSheaves](ToricSheaves) | Toric sheaves as Serre quotients | [![PDF development documentation][docs-ToricSheaves-img]][docs-ToricSheaves-url] |
+| [CAP](CAP) | Categories, Algorithms, Programming | [![HTML stable documentation][html-CAP-img]][html-CAP-url] [![PDF stable documentation][pdf-CAP-img]][pdf-CAP-url] |
+| [ActionsForCAP](ActionsForCAP) | Actions and Coactions for CAP | [![HTML stable documentation][html-ActionsForCAP-img]][html-ActionsForCAP-url] [![PDF stable documentation][pdf-ActionsForCAP-img]][pdf-ActionsForCAP-url] |
+| [AttributeCategoryForCAP](AttributeCategoryForCAP) | Automatic enhancement with attributes of a CAP category | [![HTML stable documentation][html-AttributeCategoryForCAP-img]][html-AttributeCategoryForCAP-url] [![PDF stable documentation][pdf-AttributeCategoryForCAP-img]][pdf-AttributeCategoryForCAP-url] |
+| [CompilerForCAP](CompilerForCAP) | Speed up computations in CAP categories | [![HTML stable documentation][html-CompilerForCAP-img]][html-CompilerForCAP-url] [![PDF stable documentation][pdf-CompilerForCAP-img]][pdf-CompilerForCAP-url] |
+| [ComplexesAndFilteredObjectsForCAP](ComplexesAndFilteredObjectsForCAP) | Implementation of complexes, cocomplexes and filtered objects for CAP | [![HTML stable documentation][html-ComplexesAndFilteredObjectsForCAP-img]][html-ComplexesAndFilteredObjectsForCAP-url] [![PDF stable documentation][pdf-ComplexesAndFilteredObjectsForCAP-img]][pdf-ComplexesAndFilteredObjectsForCAP-url] |
+| [DeductiveSystemForCAP](DeductiveSystemForCAP) | Deductive system for CAP | [![HTML stable documentation][html-DeductiveSystemForCAP-img]][html-DeductiveSystemForCAP-url] [![PDF stable documentation][pdf-DeductiveSystemForCAP-img]][pdf-DeductiveSystemForCAP-url] |
+| [FreydCategoriesForCAP](FreydCategoriesForCAP) | Freyd categories - Formal (co)kernels for additive categories | [![HTML stable documentation][html-FreydCategoriesForCAP-img]][html-FreydCategoriesForCAP-url] [![PDF stable documentation][pdf-FreydCategoriesForCAP-img]][pdf-FreydCategoriesForCAP-url] |
+| [GeneralizedMorphismsForCAP](GeneralizedMorphismsForCAP) | Implementations of generalized morphisms for the CAP project | [![HTML stable documentation][html-GeneralizedMorphismsForCAP-img]][html-GeneralizedMorphismsForCAP-url] [![PDF stable documentation][pdf-GeneralizedMorphismsForCAP-img]][pdf-GeneralizedMorphismsForCAP-url] |
+| [GradedModulePresentationsForCAP](GradedModulePresentationsForCAP) | Presentations for graded modules | [![HTML stable documentation][html-GradedModulePresentationsForCAP-img]][html-GradedModulePresentationsForCAP-url] [![PDF stable documentation][pdf-GradedModulePresentationsForCAP-img]][pdf-GradedModulePresentationsForCAP-url] |
+| [GroupRepresentationsForCAP](GroupRepresentationsForCAP) | Skeletal category of group representations for CAP | [![HTML stable documentation][html-GroupRepresentationsForCAP-img]][html-GroupRepresentationsForCAP-url] [![PDF stable documentation][pdf-GroupRepresentationsForCAP-img]][pdf-GroupRepresentationsForCAP-url] |
+| [HomologicalAlgebraForCAP](HomologicalAlgebraForCAP) | Homological algebra algorithms for CAP | [![HTML stable documentation][html-HomologicalAlgebraForCAP-img]][html-HomologicalAlgebraForCAP-url] [![PDF stable documentation][pdf-HomologicalAlgebraForCAP-img]][pdf-HomologicalAlgebraForCAP-url] |
+| [InternalExteriorAlgebraForCAP](InternalExteriorAlgebraForCAP) | Constructions for Modules over the Internal Exterior Algebra for CAP | [![HTML stable documentation][html-InternalExteriorAlgebraForCAP-img]][html-InternalExteriorAlgebraForCAP-url] [![PDF stable documentation][pdf-InternalExteriorAlgebraForCAP-img]][pdf-InternalExteriorAlgebraForCAP-url] |
+| [LinearAlgebraForCAP](LinearAlgebraForCAP) | Category of Matrices over a Field for CAP | [![HTML stable documentation][html-LinearAlgebraForCAP-img]][html-LinearAlgebraForCAP-url] [![PDF stable documentation][pdf-LinearAlgebraForCAP-img]][pdf-LinearAlgebraForCAP-url] |
+| [ModulePresentationsForCAP](ModulePresentationsForCAP) | Category R-pres for CAP | [![HTML stable documentation][html-ModulePresentationsForCAP-img]][html-ModulePresentationsForCAP-url] [![PDF stable documentation][pdf-ModulePresentationsForCAP-img]][pdf-ModulePresentationsForCAP-url] |
+| [ModulesOverLocalRingsForCAP](ModulesOverLocalRingsForCAP) | Category of modules over a local ring modeled by Serre quotients for CAP | [![HTML stable documentation][html-ModulesOverLocalRingsForCAP-img]][html-ModulesOverLocalRingsForCAP-url] [![PDF stable documentation][pdf-ModulesOverLocalRingsForCAP-img]][pdf-ModulesOverLocalRingsForCAP-url] |
+| [MonoidalCategories](MonoidalCategories) | Monoidal and monoidal (co)closed categories | [![HTML stable documentation][html-MonoidalCategories-img]][html-MonoidalCategories-url] [![PDF stable documentation][pdf-MonoidalCategories-img]][pdf-MonoidalCategories-url] |
+| [ToricSheaves](ToricSheaves) | Toric sheaves as Serre quotients | [![HTML stable documentation][html-ToricSheaves-img]][html-ToricSheaves-url] [![PDF stable documentation][pdf-ToricSheaves-img]][pdf-ToricSheaves-url] |
 
-[docs-CAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-CAP-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
+[html-CAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-CAP-url]: https://homalg-project.github.io/CAP_project/CAP/doc/chap0_mj.html
 
-[docs-ActionsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-ActionsForCAP-url]: /../../raw/doc/ActionsForCAP.pdf
+[pdf-CAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-CAP-url]: https://homalg-project.github.io/CAP_project/CAP/download_pdf.html
 
-[docs-AttributeCategoryForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-AttributeCategoryForCAP-url]: /../../raw/doc/AttributeCategoryForCAP.pdf
 
-[docs-CompilerForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-CompilerForCAP-url]: /../../raw/doc/CompilerForCAP.pdf
+[html-ActionsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ActionsForCAP-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/doc/chap0_mj.html
 
-[docs-ComplexesAndFilteredObjectsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-ComplexesAndFilteredObjectsForCAP-url]: /../../raw/doc/ComplexesAndFilteredObjectsForCAP.pdf
+[pdf-ActionsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ActionsForCAP-url]: https://homalg-project.github.io/CAP_project/ActionsForCAP/download_pdf.html
 
-[docs-DeductiveSystemForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-DeductiveSystemForCAP-url]: /../../raw/doc/DeductiveSystemForCAP.pdf
 
-[docs-FreydCategoriesForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-FreydCategoriesForCAP-url]: /../../raw/doc/FreydCategoriesForCAP.pdf
+[html-AttributeCategoryForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-AttributeCategoryForCAP-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/doc/chap0_mj.html
 
-[docs-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+[pdf-AttributeCategoryForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-AttributeCategoryForCAP-url]: https://homalg-project.github.io/CAP_project/AttributeCategoryForCAP/download_pdf.html
 
-[docs-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-GradedModulePresentationsForCAP-url]: /../../raw/doc/GradedModulePresentationsForCAP.pdf
 
-[docs-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-GroupRepresentationsForCAP-url]: /../../raw/doc/GroupRepresentationsForCAP.pdf
+[html-CompilerForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-CompilerForCAP-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/doc/chap0_mj.html
 
-[docs-HomologicalAlgebraForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-HomologicalAlgebraForCAP-url]: /../../raw/doc/HomologicalAlgebraForCAP.pdf
+[pdf-CompilerForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-CompilerForCAP-url]: https://homalg-project.github.io/CAP_project/CompilerForCAP/download_pdf.html
 
-[docs-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-InternalExteriorAlgebraForCAP-url]: /../../raw/doc/InternalExteriorAlgebraForCAP.pdf
 
-[docs-LinearAlgebraForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+[html-ComplexesAndFilteredObjectsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ComplexesAndFilteredObjectsForCAP-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/doc/chap0_mj.html
 
-[docs-ModulePresentationsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+[pdf-ComplexesAndFilteredObjectsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ComplexesAndFilteredObjectsForCAP-url]: https://homalg-project.github.io/CAP_project/ComplexesAndFilteredObjectsForCAP/download_pdf.html
 
-[docs-ModulesOverLocalRingsForCAP-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-ModulesOverLocalRingsForCAP-url]: /../../raw/doc/ModulesOverLocalRingsForCAP.pdf
 
-[docs-MonoidalCategories-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-MonoidalCategories-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
+[html-DeductiveSystemForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-DeductiveSystemForCAP-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/doc/chap0_mj.html
 
-[docs-ToricSheaves-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-ToricSheaves-url]: /../../raw/doc/ToricSheaves.pdf
+[pdf-DeductiveSystemForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-DeductiveSystemForCAP-url]: https://homalg-project.github.io/CAP_project/DeductiveSystemForCAP/download_pdf.html
+
+
+[html-FreydCategoriesForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-FreydCategoriesForCAP-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/doc/chap0_mj.html
+
+[pdf-FreydCategoriesForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-FreydCategoriesForCAP-url]: https://homalg-project.github.io/CAP_project/FreydCategoriesForCAP/download_pdf.html
+
+
+[html-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/doc/chap0_mj.html
+
+[pdf-GeneralizedMorphismsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GeneralizedMorphismsForCAP-url]: https://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/download_pdf.html
+
+
+[html-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GradedModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/doc/chap0_mj.html
+
+[pdf-GradedModulePresentationsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GradedModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/GradedModulePresentationsForCAP/download_pdf.html
+
+
+[html-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GroupRepresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/doc/chap0_mj.html
+
+[pdf-GroupRepresentationsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GroupRepresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/GroupRepresentationsForCAP/download_pdf.html
+
+
+[html-HomologicalAlgebraForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-HomologicalAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-HomologicalAlgebraForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-HomologicalAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/HomologicalAlgebraForCAP/download_pdf.html
+
+
+[html-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-InternalExteriorAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-InternalExteriorAlgebraForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-InternalExteriorAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/InternalExteriorAlgebraForCAP/download_pdf.html
+
+
+[html-LinearAlgebraForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/doc/chap0_mj.html
+
+[pdf-LinearAlgebraForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-LinearAlgebraForCAP-url]: https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/download_pdf.html
+
+
+[html-ModulePresentationsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/doc/chap0_mj.html
+
+[pdf-ModulePresentationsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ModulePresentationsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/download_pdf.html
+
+
+[html-ModulesOverLocalRingsForCAP-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ModulesOverLocalRingsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/doc/chap0_mj.html
+
+[pdf-ModulesOverLocalRingsForCAP-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ModulesOverLocalRingsForCAP-url]: https://homalg-project.github.io/CAP_project/ModulesOverLocalRingsForCAP/download_pdf.html
+
+
+[html-MonoidalCategories-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-MonoidalCategories-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/doc/chap0_mj.html
+
+[pdf-MonoidalCategories-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-MonoidalCategories-url]: https://homalg-project.github.io/CAP_project/MonoidalCategories/download_pdf.html
+
+
+[html-ToricSheaves-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ToricSheaves-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/doc/chap0_mj.html
+
+[pdf-ToricSheaves-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ToricSheaves-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/download_pdf.html
+
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ToricSheaves/PackageInfo.g
+++ b/ToricSheaves/PackageInfo.g
@@ -10,8 +10,8 @@ SetPackageInfo( rec(
 
 PackageName := "ToricSheaves",
 Subtitle := "Toric sheaves as Serre quotients",
-Version := "2016.08.12",
-Date := "12/08/2016", # dd/mm/yyyy format
+Version := "2020.10-01",
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
 Persons := [
@@ -34,13 +34,13 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/CAP_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://github.com/homalg-project/CAP_project/tree/master/ToricSheaves",
-PackageInfoURL  := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ToricSheaves/PackageInfo.g",
-README_URL      := "https://raw.githubusercontent.com/homalg-project/CAP_project/master/ToricSheaves/README.md",
+PackageWWWHome  := "https://homalg-project.github.io/CAP_project/ToricSheaves",
+PackageInfoURL  := "https://homalg-project.github.io/CAP_project/ToricSheaves/PackageInfo.g",
+README_URL      := "https://homalg-project.github.io/CAP_project/ToricSheaves/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/CAP_project/releases/download/ToricSheaves-", ~.Version, "/ToricSheaves-", ~.Version ),
 # END URLS
 
-ArchiveFormats := ".tar.gz",
+ArchiveFormats := ".tar.gz .zip",
 
 ##  Status information. Currently the following cases are recognized:
 ##    "accepted"      for successfully refereed packages

--- a/ToricSheaves/README.md
+++ b/ToricSheaves/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ToricSheaves – Toric sheaves as Serre quotients
+# ToricSheaves
 
-| Documentation | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![PDF development documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Toric sheaves as Serre quotients
+
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/PDF-dev-blue.svg
-[docs-url]: /../../raw/doc/ToricSheaves.pdf
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ToricSheaves/badge_version.json
+[version-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/CAP_project/ToricSheaves/badge_date.json
+[date-url]: https://homalg-project.github.io/CAP_project/ToricSheaves/view_release.html
 
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/release-gap-package
+++ b/release-gap-package
@@ -244,6 +244,7 @@ else
     tmp := GAPInfo.PackageInfoCurrent.ArchiveURL;
     Print("GAP_ERROR=\"The ArchiveURL has unexpected value '",tmp,"'\"\n");
 fi;
+Print("PDFFile=\"",GAPInfo.PackageInfoCurrent.PackageDoc.PDFFile,"\"\n");
 EOF
 
 # evaluate the output of GAP, which should be valid shell script code
@@ -407,6 +408,13 @@ git archive --prefix="$BASENAME/" "$TAG" . | tar xf - -C "$TMP_DIR"
 # Build the package documentation, run autoconf, etc.
 cd "$TMP_DIR/$BASENAME"
 
+# adjust date
+# Note that we cannot use sed's `-i` option for in-place editing, as
+# that is a non-portable extension of POSIX, which works differently in
+# BSD and GNU make.
+sed "s;Date := .*;Date := \"$(date +%d/%m/%Y)\",;" PackageInfo.g > PackageInfo.g.bak
+mv PackageInfo.g.bak PackageInfo.g
+
 notice "Removing unnecessary files"
 rm -rf .github .circleci
 rm -f .git* .hg* .cvs*
@@ -450,6 +458,20 @@ fi
 
 # make sure every file is readable
 chmod -R a+r .
+
+# adjust links to other manuals
+# Note that we cannot use sed's `-i` option for in-place editing, as
+# that is a non-portable extension of POSIX, which works differently in
+# BSD and GNU make.
+for f in ./*/*.htm* ; do
+  sed 's;href="/home/gap/.gap/pkg/homalg_project/Modules/doc/;href="https://homalg-project.github.io/homalg_project/Modules/doc/;g' "$f" > "$f.bak"
+  mv "$f.bak" "$f"
+done
+
+for f in ./*/*.htm* ; do
+  sed 's;href="/home/gap/.gap/pkg/homalg_project/homalg/doc/;href="https://homalg-project.github.io/homalg_project/homalg/doc/;g' "$f" > "$f.bak"
+  mv "$f.bak" "$f"
+done
 
 # basic sanity check
 fgrep -q -r '<a href="/' */*.htm* &&
@@ -591,6 +613,26 @@ for EXT in $ARCHIVE_FORMATS ; do
         -H "Content-Type: $MIMETYPE" \
         --data-binary @"$FULLNAME")
 done
+
+
+######################################################################
+#
+# Upload PDF
+#
+cd "$TMP_DIR"
+echo ""
+
+FULLNAME="$TMP_DIR/$BASENAME/$PDFFile"
+if [ ! -f "$FULLNAME" ] ; then
+	error "could not find PDF"
+fi
+notice "Uploading PDF"
+response=$(curl --fail --progress-bar -o "$TMP_DIR/upload.log" \
+	-X POST "$UPLOAD_URL/$RELEASE_ID/assets?name=$BASENAME.pdf" \
+	-H "Accept: application/vnd.github.v3+json" \
+	-H "Authorization: token $TOKEN" \
+	-H "Content-Type: application/pdf" \
+	--data-binary @"$FULLNAME")
 
 
 ######################################################################


### PR DESCRIPTION
The new versioning scheme is of the form `YYYY.MM-xx`, where `YYYY` and `MM` are the current year and month, respectively, and `xx` is a number which is incremented with every release of this month starting from `01`. For development versions, the date then is calculated as `01/MM/YYYY`. During the release, this is automatically replaced with the actual date.

The motivation behind this is that one can make multiple releases per day without having to choose dates in the past or in the future. And maybe in the future we can even increase the version automatically every time one pushes to master.

Edit: Merge #607 first.