### PR TITLE
Allow IsEqualForObjects/Morphisms to return fail

### DIFF
--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -607,13 +607,46 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
     
     else
         
-        SetCachingOfCategoryCrisp( category );
+        ##
+        AddIsEqualForObjects( category,
+          function( action_object_1, action_object_2 )
+            local object_equality, structure_morphism_equality;
+            
+            object_equality := IsEqualForObjects( ActionDomain( action_object_1 ), ActionDomain( action_object_2 ) );
+            
+            if object_equality = false then
+                
+                return false;
+                
+            elif object_equality = fail then
+                
+                return fail;
+                
+            else # object_equality = true
+                
+                structure_morphism_equality := IsEqualForMorphisms( StructureMorphism( action_object_1 ), StructureMorphism( action_object_2 ) );
+                
+                if structure_morphism_equality = true then
+                    
+                    return true;
+                    
+                else
+                    
+                    return fail; # we would have to decide IsCongruentForMorphisms
+                    
+                fi;
+                
+            fi;
+            
+        end );
         
         ##
-        AddIsEqualForObjects( category, IsIdenticalObj );
-        
-        ##
-        AddIsEqualForMorphisms( category, IsIdenticalObj );
+        AddIsEqualForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
         ## cannot AddIsCongruentForMorphisms
         category!.is_computable := false;

--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -578,33 +578,33 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_ACTIONS_CATEGORY,
     underlying_category := UnderlyingCategory( category );
     
     if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
-    
-    ##
-    AddIsEqualForObjects( category,
-      function( action_object_1, action_object_2 )
         
-        return IsEqualForObjects( ActionDomain( action_object_1 ), ActionDomain( action_object_2 ) )
-               and
-               IsCongruentForMorphisms( StructureMorphism( action_object_1 ), StructureMorphism( action_object_2 ) );
+        ##
+        AddIsEqualForObjects( category,
+          function( action_object_1, action_object_2 )
+            
+            return IsEqualForObjects( ActionDomain( action_object_1 ), ActionDomain( action_object_2 ) )
+                   and
+                   IsCongruentForMorphisms( StructureMorphism( action_object_1 ), StructureMorphism( action_object_2 ) );
+            
+        end );
         
-    end );
-    
-    ##
-    AddIsEqualForMorphisms( category,
-      function( morphism_1, morphism_2 )
+        ##
+        AddIsEqualForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
-        return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+        ##
+        AddIsCongruentForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
-    end );
-    
-    ##
-    AddIsCongruentForMorphisms( category,
-      function( morphism_1, morphism_2 )
-        
-        return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
-        
-    end );
-    
     else
         
         ##

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -564,13 +564,46 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
     
     else
         
-        SetCachingOfCategoryCrisp( category );
+        ##
+        AddIsEqualForObjects( category,
+          function( coaction_object_1, coaction_object_2 )
+            local object_equality, structure_morphism_equality;
+            
+            object_equality := IsEqualForObjects( CoactionDomain( coaction_object_1 ), CoactionDomain( coaction_object_2 ) );
+            
+            if object_equality = false then
+                
+                return false;
+                
+            elif object_equality = fail then
+                
+                return fail;
+                
+            else # object_equality = true
+                
+                structure_morphism_equality := IsEqualForMorphisms( StructureMorphism( coaction_object_1 ), StructureMorphism( coaction_object_2 ) );
+                
+                if structure_morphism_equality = true then
+                    
+                    return true;
+                    
+                else
+                    
+                    return fail; # we would have to decide IsCongruentForMorphisms
+                    
+                fi;
+                
+            fi;
+            
+        end );
         
         ##
-        AddIsEqualForObjects( category, IsIdenticalObj );
-        
-        ##
-        AddIsEqualForMorphisms( category, IsIdenticalObj );
+        AddIsEqualForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
         ## cannot AddIsCongruentForMorphisms
         category!.is_computable := false;

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -535,33 +535,33 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_AND_RIGHT_COACTIONS_CATEGORY,
     underlying_category := UnderlyingCategory( category );
     
     if CanCompute( underlying_category, "IsCongruentForMorphisms" ) then
-    
-    ##
-    AddIsEqualForObjects( category,
-      function( coaction_object_1, coaction_object_2 )
         
-        return IsEqualForObjects( CoactionDomain( coaction_object_1 ), CoactionDomain( coaction_object_2 ) )
-               and
-               IsCongruentForMorphisms( StructureMorphism( coaction_object_1 ), StructureMorphism( coaction_object_2 ) );
+        ##
+        AddIsEqualForObjects( category,
+          function( coaction_object_1, coaction_object_2 )
+            
+            return IsEqualForObjects( CoactionDomain( coaction_object_1 ), CoactionDomain( coaction_object_2 ) )
+                   and
+                   IsCongruentForMorphisms( StructureMorphism( coaction_object_1 ), StructureMorphism( coaction_object_2 ) );
+            
+        end );
         
-    end );
-    
-    ##
-    AddIsEqualForMorphisms( category,
-      function( morphism_1, morphism_2 )
+        ##
+        AddIsEqualForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
-        return IsEqualForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+        ##
+        AddIsCongruentForMorphisms( category,
+          function( morphism_1, morphism_2 )
+            
+            return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
+            
+        end );
         
-    end );
-    
-    ##
-    AddIsCongruentForMorphisms( category,
-      function( morphism_1, morphism_2 )
-        
-        return IsCongruentForMorphisms( UnderlyingCell( morphism_1 ), UnderlyingCell( morphism_2 ) );
-        
-    end );
-    
     else
         
         ##

--- a/CAP/examples/VectorSpacesAddKernel01.g
+++ b/CAP/examples/VectorSpacesAddKernel01.g
@@ -79,4 +79,4 @@ AddKernelLiftWithGivenKernelObject( vecspaces,
    
 end );
 
-Finalize( vecspaces );
+Finalize( vecspaces : SuppressEqualitiesWarning := true );

--- a/CAP/examples/VectorSpacesAddKernel02.g
+++ b/CAP/examples/VectorSpacesAddKernel02.g
@@ -79,4 +79,4 @@ AddKernelLiftWithGivenKernelObject( vecspaces,
    
 end );
 
-Finalize( vecspaces );
+Finalize( vecspaces : SuppressEqualitiesWarning := true );

--- a/CAP/examples/VectorSpacesAddKernel03.g
+++ b/CAP/examples/VectorSpacesAddKernel03.g
@@ -53,4 +53,4 @@ AddKernelEmbeddingWithGivenKernelObject( vecspaces,
 
 end );
 
-Finalize( vecspaces );
+Finalize( vecspaces : SuppressEqualitiesWarning := true );

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -36,6 +36,8 @@ InstallGlobalFunction( CAP_INTERNAL_CREATE_Cat,
     
     CREATE_CAP_CATEGORY_OBJECT( CapCat, [ [ "Name", "Cat" ] ] );
     
+    CapCat!.is_computable := false;
+    
     CREATE_CAP_CATEGORY_FILTERS( CapCat );
     
     return CapCat;
@@ -521,6 +523,12 @@ InstallGlobalFunction( ApplyFunctor,
     return computed_value;
     
 end );
+
+##
+AddIsEqualForObjects( CapCat, ReturnFail ); # IsIdenticalObj is handled by the pre-function
+
+##
+AddIsEqualForMorphisms( CapCat, ReturnFail ); # IsIdenticalObj is handled by the pre-function
 
 ##
 AddPreCompose( CapCat,

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -757,6 +757,9 @@ DeclareOperation( "IsEqualForMorphisms",
 #! This operation adds the given function $F$
 #! to the category for the basic operation <C>IsEqualForMorphisms</C>.
 #! $F: (\alpha, \beta) \mapsto \mathtt{IsEqualForMorphisms}(\alpha, \beta)$.
+#! Warning: If `F` is a partial function (returning `fail` if $\alpha = \beta$ is not decidable), CAP cannot type check all inputs,
+#! the usual guaranties coming with the specifications cannot be given, and some derivations (e.g. `IsIdenticalToIdentityMorphism`) might
+#! also yield partial functions.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddIsEqualForMorphisms",
@@ -786,6 +789,9 @@ DeclareOperation( "IsEqualForMorphismsOnMor",
 #! This operation adds the given function $F$
 #! to the category for the basic operation <C>IsEqualForMorphismsOnMor</C>.
 #! $F: (\alpha, \beta) \mapsto \mathtt{IsEqualForMorphismsOnMor}(\alpha, \beta)$.
+#! Warning: If `F` is a partial function (returning `fail` if $\alpha = \beta$ is not decidable), CAP cannot type check all inputs,
+#! the usual guaranties coming with the specifications cannot be given, and some derivations (e.g. `IsIdenticalToIdentityMorphism`) might
+#! also yield partial functions.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddIsEqualForMorphismsOnMor",

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -382,19 +382,30 @@ InstallMethod( \=,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
                
   function( morphism_1, morphism_2 )
+    local source_equality, range_equality;
     
     if CapCategory( morphism_1 )!.input_sanity_check_level > 0 or CapCategory( morphism_2 )!.input_sanity_check_level > 0  then
         if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
             Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
         fi;
     fi;
-    if not IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) ) or not IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) ) then
+
+    source_equality := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
+    range_equality := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
+    
+    if source_equality = false or range_equality = false then
         
         return false;
         
-    fi;
+    elif source_equality = fail or range_equality = fail then
+        
+        return fail;
+        
+    else # source_equality = true and range_equality = true
     
-    return IsCongruentForMorphisms( morphism_1, morphism_2 );
+        return IsCongruentForMorphisms( morphism_1, morphism_2 );
+        
+    fi;
     
 end );
 

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -62,6 +62,9 @@ DeclareOperationWithCache( "IsEqualForObjects",
 #! This operation adds the given function $F$
 #! to the category for the basic operation <C>IsEqualForObjects</C>.
 #! $F: (a,b) \mapsto \mathtt{IsEqualForObjects}(a,b)$.
+#! Warning: If `F` is a partial function (returning `fail` if $a = b$ is not decidable), CAP cannot type check all inputs,
+#! the usual guaranties coming with the specifications cannot be given, and some derivations (e.g. `IsEndomorphism`) might
+#! also yield partial functions.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddIsEqualForObjects",

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -3404,32 +3404,6 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
 end : CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
       Description := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject as the identity of the homology object constructed as an image object" );
 
-
-## Final method for IsEqualForObjects
-##
-AddFinalDerivation( IsEqualForObjects,
-                    [ ],
-                    [ IsEqualForObjects ],
-                    
-  ReturnFail );
-
-## Final methods for IsEqual/IsEqualForMorphisms
-##
-AddFinalDerivation( IsCongruentForMorphisms,
-                    [ ],
-                    [ IsCongruentForMorphisms,
-                      IsEqualForMorphisms ],
-                      
-  ReturnFail : Description := "Only IsIdenticalObj for comparing" );
-
-##
-AddFinalDerivation( IsEqualForMorphisms,
-                    [ ],
-                    [ IsCongruentForMorphisms,
-                      IsEqualForMorphisms ],
-                      
-  ReturnFail : Description := "Only IsIdenticalObj for comparing" );
-
 ##
 AddFinalDerivation( IsCongruentForMorphisms,
                     [ [ IsEqualForMorphisms, 1 ] ],

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -212,22 +212,26 @@ InstallMethod( IsFinalized,
         
     od;
     
-    # sanity checks
-    if not CanCompute( category, "IsEqualForObjects" ) then
+    if not ValueOption( "SuppressEqualitiesWarning" ) = true then
         
-        Error( Concatenation( "please provide IsEqualForObjects for the category with name \"", Name( category ) , "\"" ) );
+        # sanity checks
+        if not CanCompute( category, "IsEqualForObjects" ) then
+            
+            Error( Concatenation( "please provide IsEqualForObjects for the category with name \"", Name( category ) , "\". You can suppress this warning by passing the option \"SuppressEqualitiesWarning := true\" to Finalize." ) );
+            
+        fi;
         
-    fi;
-    
-    if not CanCompute( category, "IsEqualForMorphisms" ) then
+        if not CanCompute( category, "IsEqualForMorphisms" ) then
+            
+            Error( Concatenation( "please provide IsEqualForMorphisms for the category with name \"", Name( category ) , "\". You can suppress this warning by passing the option \"SuppressEqualitiesWarning := true\" to Finalize." ) );
+            
+        fi;
         
-        Error( Concatenation( "please provide IsEqualForMorphisms for the category with name \"", Name( category ) , "\"" ) );
-        
-    fi;
-    
-    if not CanCompute( category, "IsCongruentForMorphisms" ) and category!.is_computable then
-        
-        Error( Concatenation( "please provide IsCongruentForMorphisms for the category with name \"", Name( category ) , "\"" ) );
+        if not CanCompute( category, "IsCongruentForMorphisms" ) and category!.is_computable then
+            
+            Error( Concatenation( "please provide IsCongruentForMorphisms for the category with name \"", Name( category ) , "\". You can suppress this warning by passing the option \"SuppressEqualitiesWarning := true\" to Finalize." ) );
+            
+        fi;
         
     fi;
     

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -212,6 +212,25 @@ InstallMethod( IsFinalized,
         
     od;
     
+    # sanity checks
+    if not CanCompute( category, "IsEqualForObjects" ) then
+        
+        Error( Concatenation( "please provide IsEqualForObjects for the category with name \"", Name( category ) , "\"" ) );
+        
+    fi;
+    
+    if not CanCompute( category, "IsEqualForMorphisms" ) then
+        
+        Error( Concatenation( "please provide IsEqualForMorphisms for the category with name \"", Name( category ) , "\"" ) );
+        
+    fi;
+    
+    if not CanCompute( category, "IsCongruentForMorphisms" ) and category!.is_computable then
+        
+        Error( Concatenation( "please provide IsCongruentForMorphisms for the category with name \"", Name( category ) , "\"" ) );
+        
+    fi;
+    
     return true;
     
 end );

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -13,11 +13,7 @@ LiftAlongMonomorphism := rec(
     
     value := IsEqualForObjects( Range( iota ), Range( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal ranges" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal ranges" ];
         
@@ -36,11 +32,7 @@ IsLiftableAlongMonomorphism := rec(
     
     value := IsEqualForObjects( Range( iota ), Range( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal ranges" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal ranges" ];
         
@@ -60,11 +52,7 @@ ColiftAlongEpimorphism := rec(
     
     value := IsEqualForObjects( Source( epsilon ), Source( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal sources" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal sources" ];
         
@@ -83,11 +71,7 @@ IsColiftableAlongEpimorphism := rec(
     
     value := IsEqualForObjects( Source( epsilon ), Source( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal sources" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal sources" ];
         
@@ -107,11 +91,7 @@ Lift := rec(
     
     value := IsEqualForObjects( Range( iota ), Range( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal ranges" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal ranges" ];
         
@@ -132,11 +112,7 @@ IsLiftable := rec(
     
     value := IsEqualForObjects( Range( iota ), Range( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal ranges" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal ranges" ];
         
@@ -157,11 +133,7 @@ Colift := rec(
     
     value := IsEqualForObjects( Source( epsilon ), Source( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal sources" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal sources" ];
         
@@ -182,11 +154,7 @@ IsColiftable := rec(
     
     value := IsEqualForObjects( Source( epsilon ), Source( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal sources" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal sources" ];
         
@@ -207,11 +175,7 @@ ProjectiveLift := rec(
     
     value := IsEqualForObjects( Range( iota ), Range( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal ranges" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal ranges" ];
         
@@ -231,11 +195,7 @@ InjectiveColift := rec(
     
     value := IsEqualForObjects( Source( epsilon ), Source( tau ) );
     
-    if value = fail then
-        
-        return [ false, "cannot decide whether the two morphisms have equal sources" ];
-        
-    elif value = false then
+    if value = false then
         
         return [ false, "the two morphisms must have equal sources" ];
         
@@ -402,11 +362,7 @@ PreCompose := rec(
     
     is_equal_for_objects := IsEqualForObjects( Range( mor_left ), Source( mor_right ) );
     
-    if is_equal_for_objects = fail then
-      
-      return [ false, "cannot decide whether morphisms are composable" ];
-      
-    elif is_equal_for_objects = false then
+    if is_equal_for_objects = false then
         
         return [ false, "morphisms not composable" ];
         
@@ -427,11 +383,7 @@ PostCompose := rec(
     
     is_equal_for_objects := IsEqualForObjects( Range( mor_left ), Source( mor_right ) );
     
-    if is_equal_for_objects = fail then
-      
-      return [ false, "cannot decide whether morphisms are composable" ];
-      
-    elif is_equal_for_objects = false then
+    if is_equal_for_objects = false then
         
         return [ false, "morphisms not composable" ];
         
@@ -613,11 +565,7 @@ UniversalMorphismIntoDirectSum := rec(
         
         current_return := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "sources of morphisms must be equal in given source diagram" ];
             
@@ -647,11 +595,7 @@ UniversalMorphismIntoDirectSumWithGivenDirectSum := rec(
         
         current_return := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "sources of morphisms must be equal in given source diagram" ];
             
@@ -703,11 +647,7 @@ UniversalMorphismFromDirectSum := rec(
         
         current_return := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether ranges of morphisms in given sink diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "ranges of morphisms must be equal in given sink diagram" ];
             
@@ -737,11 +677,7 @@ UniversalMorphismFromDirectSumWithGivenDirectSum := rec(
         
         current_return := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether ranges of morphisms in given sink diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "ranges of morphisms must be equal in given sink diagram" ];
             
@@ -881,11 +817,7 @@ UniversalMorphismIntoDirectProduct := rec(
         
         current_return := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "sources of morphisms must be equal in given source diagram" ];
             
@@ -915,11 +847,7 @@ UniversalMorphismIntoDirectProductWithGivenDirectProduct := rec(
         
         current_return := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "sources of morphisms must be equal in given source diagram" ];
             
@@ -943,35 +871,22 @@ IsCongruentForMorphisms := rec(
     
     value_1 := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
     
-    if value_1 = fail then
+    if value_1 = false then
       
-      return [ false, "cannot decide whether sources are equal" ];
+      return [ false, "sources are not equal" ];
       
     fi;
     
     value_2 := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
     
-    if value_2 = fail then
+    if value_2 = false then
       
-      return [ false, "cannot decide whether ranges are equal" ];
+      return [ false, "ranges are not equal" ];
       
     fi;
     
-    
-    if value_1 and value_2 then
+    return [ true ];
         
-        return [ true ];
-        
-    elif value_1 then
-        
-        return [ false, "ranges are not equal" ];
-        
-    else
-        
-        return [ false, "sources are not equal" ];
-        
-    fi;
-    
   end,
   
   redirect_function := function( morphism_1, morphism_2 )
@@ -1012,34 +927,21 @@ IsEqualForMorphisms := rec(
     
     value_1 := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
     
-    if value_1 = fail then
+    if value_1 = false then
       
-      return [ false, "cannot decide whether sources are equal" ];
+      return [ false, "sources are not equal" ];
       
     fi;
     
     value_2 := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
     
-    if value_2 = fail then
+    if value_2 = false then
       
-      return [ false, "cannot decide whether ranges are equal" ];
+      return [ false, "ranges are not equal" ];
       
     fi;
     
-    
-    if value_1 and value_2 then
-        
-        return [ true ];
-        
-    elif value_1 then
-        
-        return [ false, "ranges are not equal" ];
-        
-    else
-        
-        return [ false, "sources are not equal" ];
-        
-    fi;
+    return [ true ];
     
   end,
   
@@ -1150,34 +1052,21 @@ AdditionForMorphisms := rec(
     
     value_1 := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
     
-    if value_1 = fail then
+    if value_1 = false then
       
-      return [ false, "cannot decide whether sources are equal" ];
+      return [ false, "sources are not equal" ];
       
     fi;
     
     value_2 := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
     
-    if value_2 = fail then
+    if value_2 = false then
       
-      return [ false, "cannot decide whether ranges are equal" ];
+      return [ false, "ranges are not equal" ];
       
     fi;
     
-    
-    if value_1 and value_2 then
-        
-        return [ true ];
-        
-    elif value_1 then
-        
-        return [ false, "ranges are not equal" ];
-        
-    else
-        
-        return [ false, "sources are not equal" ];
-        
-    fi;
+    return [ true ];
     
   end,
   return_type := "morphism" ),
@@ -1193,34 +1082,21 @@ SubtractionForMorphisms := rec(
     
     value_1 := IsEqualForObjects( Source( morphism_1 ), Source( morphism_2 ) );
     
-    if value_1 = fail then
+    if value_1 = false then
       
-      return [ false, "cannot decide whether sources are equal" ];
+      return [ false, "sources are not equal" ];
       
     fi;
     
     value_2 := IsEqualForObjects( Range( morphism_1 ), Range( morphism_2 ) );
     
-    if value_2 = fail then
+    if value_2 = false then
       
-      return [ false, "cannot decide whether ranges are equal" ];
+      return [ false, "ranges are not equal" ];
       
     fi;
     
-    
-    if value_1 and value_2 then
-        
-        return [ true ];
-        
-    elif value_1 then
-        
-        return [ false, "ranges are not equal" ];
-        
-    else
-        
-        return [ false, "sources are not equal" ];
-        
-    fi;
+    return [ true ];
     
   end,
   return_type := "morphism" ),
@@ -1297,11 +1173,7 @@ UniversalMorphismFromCoproduct := rec(
         
         current_return := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether ranges of morphisms in given sink diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "ranges of morphisms must be equal in given sink diagram" ];
             
@@ -1331,11 +1203,7 @@ UniversalMorphismFromCoproductWithGivenCoproduct := rec(
         
         current_return := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether ranges of morphisms in given sink diagram are equal" ];
-            
-        elif current_return = false then
+        if current_return = false then
             
             return [ false, "ranges of morphisms must be equal in given sink diagram" ];
             
@@ -1373,11 +1241,7 @@ IsDominating := rec(
     
     is_equal_for_objects := IsEqualForObjects( Range( sub1 ), Range( sub2 ) );
     
-    if is_equal_for_objects = fail then
-        
-        return [ false, "cannot decide whether those are subobjects of the same object" ];
-    
-    elif is_equal_for_objects = false then
+    if is_equal_for_objects = false then
         
         return [ false, "subobjects of different objects are not comparable by dominates" ];
         
@@ -1398,11 +1262,7 @@ IsCodominating := rec(
     
     is_equal_for_objects := IsEqualForObjects( Source( factor1 ), Source( factor2 ) );
     
-    if is_equal_for_objects = fail then
-        
-        return [ false, "cannot decide whether those are factors of the same object" ];
-    
-    elif is_equal_for_objects = false then
+    if is_equal_for_objects = false then
         
         return [ false, "factors of different objects are not comparable by codominates" ];
         
@@ -1430,9 +1290,7 @@ Equalizer := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the equalizer diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the equalizer diagram must have equal sources" ];
         fi;
         
@@ -1444,9 +1302,7 @@ Equalizer := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the equalizer diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the equalizer diagram must have equal ranges" ];
         fi;
         
@@ -1518,9 +1374,7 @@ UniversalMorphismIntoEqualizer := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the equalizer diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the equalizer diagram must have equal sources" ];
         fi;
         
@@ -1532,9 +1386,7 @@ UniversalMorphismIntoEqualizer := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the equalizer diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the equalizer diagram must have equal ranges" ];
         fi;
         
@@ -1544,9 +1396,7 @@ UniversalMorphismIntoEqualizer := rec(
         
         current_value := IsEqualForObjects( Source( diagram[ current_morphism_position ] ), Range( tau ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether source and range are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": source and range are not equal" ) ];
         fi;
         
@@ -1585,9 +1435,7 @@ FiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1620,9 +1468,7 @@ ProjectionInFactorOfFiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1653,9 +1499,7 @@ ProjectionInFactorOfFiberProductWithGivenFiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1684,9 +1528,7 @@ MorphismFromFiberProductToSink := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1713,9 +1555,7 @@ MorphismFromFiberProductToSinkWithGivenFiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1748,9 +1588,7 @@ UniversalMorphismIntoFiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1762,9 +1600,7 @@ UniversalMorphismIntoFiberProduct := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the test source have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the test source do not have equal sources" ];
         fi;
         
@@ -1774,9 +1610,7 @@ UniversalMorphismIntoFiberProduct := rec(
         
         current_value := IsEqualForObjects( Source( diagram[ current_morphism_position ] ), Range( source[ current_morphism_position ] ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether source and range are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": source and range are not equal" ) ];
         fi;
         
@@ -1807,9 +1641,7 @@ UniversalMorphismIntoFiberProductWithGivenFiberProduct := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the fiber product diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber product diagram must have equal ranges" ];
         fi;
         
@@ -1821,9 +1653,7 @@ UniversalMorphismIntoFiberProductWithGivenFiberProduct := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), test_object );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the test source have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the test source do not have equal sources" ];
         fi;
         
@@ -1833,9 +1663,7 @@ UniversalMorphismIntoFiberProductWithGivenFiberProduct := rec(
         
         current_value := IsEqualForObjects( Source( diagram[ current_morphism_position ] ), Range( source[ current_morphism_position ] ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether source and range are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": source and range are not equal" ) ];
         fi;
         
@@ -1863,9 +1691,7 @@ Coequalizer := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the coequalizer diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the coequalizer diagram must have equal sources" ];
         fi;
         
@@ -1877,9 +1703,7 @@ Coequalizer := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the coequalizer diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the coequalizer diagram must have equal ranges" ];
         fi;
         
@@ -1951,9 +1775,7 @@ UniversalMorphismFromCoequalizer := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), base );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the coequalizer diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the coequalizer diagram must have equal sources" ];
         fi;
         
@@ -1965,9 +1787,7 @@ UniversalMorphismFromCoequalizer := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the coequalizer diagram have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the coequalizer diagram must have equal ranges" ];
         fi;
         
@@ -1977,9 +1797,7 @@ UniversalMorphismFromCoequalizer := rec(
         
         current_value := IsEqualForObjects( Range( diagram[ current_morphism_position ] ), Source( tau ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether range and source are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": range and source are not equal" ) ];
         fi;
         
@@ -2018,9 +1836,7 @@ Pushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the pushout diagram must have equal sources" ];
         fi;
         
@@ -2053,9 +1869,7 @@ InjectionOfCofactorOfPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the pushout diagram must have equal sources" ];
         fi;
         
@@ -2086,9 +1900,7 @@ InjectionOfCofactorOfPushoutWithGivenPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the pushout diagram must have equal sources" ];
         fi;
         
@@ -2117,9 +1929,7 @@ MorphismFromSourceToPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the pushout diagram must have equal sources" ];
         fi;
         
@@ -2146,9 +1956,7 @@ MorphismFromSourceToPushoutWithGivenPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the pushout diagram must have equal sources" ];
         fi;
         
@@ -2181,9 +1989,7 @@ UniversalMorphismFromPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber pushout must have equal sources" ];
         fi;
         
@@ -2195,9 +2001,7 @@ UniversalMorphismFromPushout := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the test sink have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the test sink do not have equal ranges" ];
         fi;
         
@@ -2207,9 +2011,7 @@ UniversalMorphismFromPushout := rec(
         
         current_value := IsEqualForObjects( Range( diagram[ current_morphism_position ] ), Source( sink[ current_morphism_position ] ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether source and range are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": source and range are not equal" ) ];
         fi;
         
@@ -2240,9 +2042,7 @@ UniversalMorphismFromPushoutWithGivenPushout := rec(
         
         current_value := IsEqualForObjects( Source( current_morphism ), cobase );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the pushout diagram have equal sources" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the fiber pushout must have equal sources" ];
         fi;
         
@@ -2254,9 +2054,7 @@ UniversalMorphismFromPushoutWithGivenPushout := rec(
         
         current_value := IsEqualForObjects( Range( current_morphism ), test_object );
         
-        if current_value = fail then
-            return [ false, "cannot decide whether the given morphisms of the test sink have equal ranges" ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, "the given morphisms of the test sink do not have equal ranges" ];
         fi;
         
@@ -2266,9 +2064,7 @@ UniversalMorphismFromPushoutWithGivenPushout := rec(
         
         current_value := IsEqualForObjects( Range( diagram[ current_morphism_position ] ), Source( sink[ current_morphism_position ] ) );
         
-        if current_value = fail then
-            return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": cannot decide whether source and range are equal" ) ];
-        elif current_value = false then
+        if current_value = false then
             return [ false, Concatenation( "in diagram position ", String( current_morphism_position ), ": source and range are not equal" ) ];
         fi;
         
@@ -2363,23 +2159,17 @@ UniversalMorphismIntoCoimage := rec(
     local value;
     
     value := IsEqualForObjects( Source( morphism ), Source( test_factorization[ 1 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( morphism ), Range( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether range of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "range of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( test_factorization[ 1 ] ), Source( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source and range of test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source and range of test factorization are not equal" ];
     fi;
     
@@ -2399,23 +2189,17 @@ UniversalMorphismIntoCoimageWithGivenCoimage := rec(
     local value;
     
     value := IsEqualForObjects( Source( morphism ), Source( test_factorization[ 1 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( morphism ), Range( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether range of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "range of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( test_factorization[ 1 ] ), Source( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source and range of test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source and range of test factorization are not equal" ];
     fi;
     
@@ -2542,12 +2326,6 @@ IsOne := rec(
     
     is_equal_for_objects := IsEqualForObjects( Source( morphism ), Range( morphism ) );
     
-    if is_equal_for_objects = fail then
-      
-      return [ false, "cannot decide whether morphism is the identity" ];
-      
-    fi;
-    
     if is_equal_for_objects = false then
         
         return [ false, "source and range of the given morphism are not equal" ];
@@ -2578,7 +2356,7 @@ IsIdempotent := rec(
     
     #do not use IsEndomorphism( morphism ) here because you don't know if
     #the user has given an own IsEndomorphism function
-    if not IsEqualForObjects( Source( morphism ), Range( morphism ) ) then 
+    if IsEqualForObjects( Source( morphism ), Range( morphism ) ) = false then 
       
       return [ false, "the given morphism has to be an endomorphism" ];
       
@@ -2673,23 +2451,17 @@ UniversalMorphismFromImage := rec(
     local value;
     
     value := IsEqualForObjects( Source( morphism ), Source( test_factorization[ 1 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( morphism ), Range( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether range of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "range of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( test_factorization[ 1 ] ), Source( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source and range of test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source and range of test factorization are not equal" ];
     fi;
     
@@ -2709,23 +2481,17 @@ UniversalMorphismFromImageWithGivenImageObject := rec(
     local value;
     
     value := IsEqualForObjects( Source( morphism ), Source( test_factorization[ 1 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( morphism ), Range( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether range of morphism and test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "range of morphism and test factorization are not equal" ];
     fi;
     
     value := IsEqualForObjects( Range( test_factorization[ 1 ] ), Source( test_factorization[ 2 ] ) );
-    if value = fail then
-        return [ false, "cannot decide whether source and range of test factorization are equal" ];
-    elif value = false then
+    if value = false then
         return [ false, "source and range of test factorization are not equal" ];
     fi;
     
@@ -2841,9 +2607,7 @@ HorizontalPreCompose := rec(
     local value;
     
     value := IsEqualForObjects( Range( Source( twocell_1 ) ), Source( Source( twocell_2 ) ) );
-    if value = fail then
-        return [ false, "cannot decide whether 2-cells are horizontally composable" ];
-    elif value = false then
+    if value = false then
         return [ false, "2-cells are not horizontally composable" ];
     fi;
     
@@ -2860,9 +2624,7 @@ HorizontalPostCompose := rec(
     local value;
     
     value := IsEqualForObjects( Range( Source( twocell_1 ) ), Source( Source( twocell_2 ) ) );
-    if value = fail then
-        return [ false, "cannot decide whether 2-cells are horizontally composable" ];
-    elif value = false then
+    if value = false then
         return [ false, "2-cells are not horizontally composable" ];
     fi;
     
@@ -2879,9 +2641,7 @@ VerticalPreCompose := rec(
     local value;
     
     value := IsEqualForMorphisms( Range( twocell_1 ), Source( twocell_2 ) );
-    if value = fail then
-        return [ false, "cannot decide whether 2-cells are vertically composable" ];
-    elif value = false then
+    if value = false then
         return [ false, "2-cells are not vertically composable" ];
     fi;
     
@@ -2898,9 +2658,7 @@ VerticalPostCompose := rec(
     local value;
     
     value := IsEqualForMorphisms( Range( twocell_1 ), Source( twocell_2 ) );
-    if value = fail then
-        return [ false, "cannot decide whether 2-cells are vertically composable" ];
-    elif value = false then
+    if value = false then
         return [ false, "2-cells are not vertically composable" ];
     fi;
     
@@ -3226,11 +2984,7 @@ MorphismBetweenDirectSums := rec(
               
               result := IsEqualForObjects( sources[i], Source( listlist[i][j] ) );
               
-              if result = fail then
-                  
-                  return [ false, Concatenation( "cannot decide whether the sources of the morphisms in the ", String(i), "-th row are equal" ) ];
-                  
-              elif result = false then
+              if result = false then
                   
                   return [ false, Concatenation( "the sources of the morphisms in the ", String(i), "-th row must be equal" ) ];
                   
@@ -3238,11 +2992,7 @@ MorphismBetweenDirectSums := rec(
               
               result := IsEqualForObjects( ranges[j], Range( listlist[i][j] ) );
               
-              if result = fail then
-                  
-                  return [ false, Concatenation( "cannot decide whether the ranges of the morphisms in the ", String(j), "-th column are equal" ) ];
-                  
-              elif result = false then
+              if result = false then
                   
                   return [ false, Concatenation( "the ranges of the morphisms in the ", String(j), "-th column must be equal" ) ];
                   
@@ -3425,7 +3175,7 @@ HomologyObject := rec(
   io_type := [ [ "alpha", "beta" ], [ "H" ] ],
   return_type := "object",
   pre_function := function( alpha, beta )
-      if not IsEqualForObjects( Range( alpha ), Source( beta ) ) then
+      if IsEqualForObjects( Range( alpha ), Source( beta ) ) = false then
             
             return [ false, "the range of the first morphism has to be equal to the source of the second morphism" ];
             
@@ -3456,25 +3206,25 @@ HomologyObjectFunctorialWithGivenHomologyObjects := rec(
       
       delta := L[5];
       
-      if not IsEqualForObjects( Range( alpha ), Source( beta ) ) then
+      if IsEqualForObjects( Range( alpha ), Source( beta ) ) = false then
             
             return [ false, "the range of the first morphism has to be equal to the source of the second morphism" ];
             
       fi;
       
-      if not IsEqualForObjects( Range( gamma ), Source( delta ) ) then
+      if IsEqualForObjects( Range( gamma ), Source( delta ) ) = false then
             
             return [ false, "the range of the fourth morphism has to be equal to the source of the fifth morphism" ];
             
       fi;
       
-      if not IsEqualForObjects( Source( epsilon ), Source( beta ) ) then
+      if IsEqualForObjects( Source( epsilon ), Source( beta ) ) = false then
             
             return [ false, "the source of the third morphism has to be equal to the source of the second morphism" ];
             
       fi;
       
-      if not IsEqualForObjects( Range( epsilon ), Range( gamma ) ) then
+      if IsEqualForObjects( Range( epsilon ), Range( gamma ) ) = false then
             
             return [ false, "the range of the third morphism has to be equal to the range of the fourth morphism" ];
             

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -34,7 +34,7 @@ BindGlobal( "TheTypeOfCapTerminalCategoryMorphism",
 
 InstallValue( CAP_INTERNAL_TERMINAL_CATEGORY,
               
-              CreateCapCategory( "TerminalCategory" ) );
+              CreateCapCategory( "TerminalCategory" : is_computable := false ) );
 
 SetFilterObj( CAP_INTERNAL_TERMINAL_CATEGORY, IsTerminalCategory );
 
@@ -93,6 +93,9 @@ BindGlobal( "INSTALL_TERMINAL_CATEGORY_FUNCTIONS",
             
   function( )
     local obj_function_list, obj_func, morphism_function_list, morphism_function, i;
+    
+    AddIsEqualForObjects( CAP_INTERNAL_TERMINAL_CATEGORY, ReturnFail ); # IsIdenticalObj is handled by the pre-function
+    AddIsEqualForMorphisms( CAP_INTERNAL_TERMINAL_CATEGORY, ReturnFail ); # IsIdenticalObj is handled by the pre-function
     
     obj_function_list := [ AddZeroObject,
                            AddKernelObject,

--- a/ComplexesAndFilteredObjectsForCAP/gap/CocomplexCategory.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/CocomplexCategory.gi
@@ -72,7 +72,7 @@ InstallMethod( CocomplexCategory,
     
     INSTALL_OPERATIONS_FOR_COCOMPLEX_CATEGORY( category );
     
-    Finalize( cocomplex_category );
+    Finalize( cocomplex_category : SuppressEqualitiesWarning := true );
     
     return cocomplex_category;
     
@@ -103,7 +103,7 @@ InstallMethod( ComplexCategory,
     
     INSTALL_OPERATIONS_FOR_COMPLEX_CATEGORY( category );
     
-    Finalize( complex_category );
+    Finalize( complex_category : SuppressEqualitiesWarning := true );
     
     return complex_category;
     

--- a/ComplexesAndFilteredObjectsForCAP/gap/FilteredObjects.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/FilteredObjects.gi
@@ -66,7 +66,7 @@ InstallMethod( CategoryOfAscendingFilteredObjects,
     
     INSTALL_OPERATIONS_FOR_ASCENDING_FILTERED_OBJECTS_CATEGORY( category );
     
-    Finalize( filtered_objects_category );
+    Finalize( filtered_objects_category : SuppressEqualitiesWarning := true );
     
     return filtered_objects_category;
     
@@ -91,7 +91,7 @@ InstallMethod( CategoryOfDescendingFilteredObjects,
     
     INSTALL_OPERATIONS_FOR_DESCENDING_FILTERED_OBJECTS_CATEGORY( category );
     
-    Finalize( filtered_objects_category );
+    Finalize( filtered_objects_category : SuppressEqualitiesWarning := true );
     
     return filtered_objects_category;
     

--- a/ComplexesAndFilteredObjectsForCAP/gap/ZFunctors.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/ZFunctors.gi
@@ -64,7 +64,7 @@ InstallMethod( ZFunctorCategory,
     
     INSTALL_OPERATIONS_FOR_ZFUNCTOR_CATEGORY( category );
     
-    Finalize( z_functor_category );
+    Finalize( z_functor_category : SuppressEqualitiesWarning := true );
     
     return z_functor_category;
     


### PR DESCRIPTION
Fixes #595.

The first commit removes the final derivations falling back to `ReturnFail` as discussed in #595. In contrast to the discussion in #595 I decided not to install another fallback, as I think the user should always be clear on his/her notion of equality. Thus, I added suitable sanity checks in `IsFinalized` instead, forcing the user to provide a notion of equality. With this, I noticed that `Cat` and `TerminalCategory` actually relied on the previous behaviour, so I adjusted them.

The second commit relaxes the pre functions as discussed in #595, and adds suitable warnings to the documentation. I deliberately only changed the documentation of the `AddIsEqual...` functions and kept the documentation of the `IsEqual...` functions as is, because I think of this as an expert feature which the normal user reading what `IsEqual...` does should not have to think about.

The last commit uses the new capabilities to give a more intricate notion of equality to the (Co)ActionsCategory in the non-computable case, which allows to disable the caching.