### PR TITLE
remove link to CAP_project subpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Welcome to the CAP project.
 
 Please take a look at our [manual](https://github.com/homalg-project/CAP_project/raw/master/Manual/CAPManual.pdf) for a first introduction to CAP.
 
-## Website
-
-Please visit our website: https://homalg-project.github.io/docs/CAP_project/
 <!-- BEGIN FOOTER -->
 ### Packages of [CAP_project](/../../):
 | Name | Description | Documentation |


### PR DESCRIPTION
as discussed with Fabian:

since the CAP_project subpage has now less information than README.md
it can be deleted for the time being