### PR TITLE
Link to README instead of website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
 ---
-redirect_to:
-  - https://homalg-project.github.io/docs/CAP_project/
+redirect_to: https://github.com/homalg-project/CAP_project#readme
 ---


### PR DESCRIPTION
changing the format from
```yml
redirect_to:
  - ...
```
to
```yml
redirect_to: ...
```
is intended.