### PR TITLE
Remove final derivations regarding equality

### DIFF
--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -351,7 +351,17 @@ InstallMethod( IsEqualForMorphisms,
     if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
         Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsEqualForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
+        
+        if IsIdenticalObj( morphism_1, morphism_2 ) then
+            
+            return true;
+            
+        else
+            
+            return fail;
+            
+        fi;
+        
     fi;
     
 end );
@@ -372,7 +382,17 @@ InstallMethod( IsCongruentForMorphisms,
     if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
         Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsCongruentForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
+        
+        if IsIdenticalObj( morphism_1, morphism_2 ) then
+            
+            return true;
+            
+        else
+            
+            return fail;
+            
+        fi;
+        
     fi;
     
 end );

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -59,7 +59,17 @@ InstallMethod( IsEqualForObjects,
     if not IsIdenticalObj( CapCategory( object_1 ), CapCategory( object_2 ) ) then
         Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" do not belong to the same CAP category" ) );
     else
-        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" belong to the same CAP category, but no specific method IsEqualForObjects is installed. Maybe you forgot to finalize the category?" ) );
+        
+        if IsIdenticalObj( object_1, object_2 ) then
+            
+            return true;
+            
+        else
+            
+            return fail;
+            
+        fi;
+        
     fi;
     
 end );

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -3404,32 +3404,6 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
 end : CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
       Description := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject as the identity of the homology object constructed as an image object" );
 
-
-## Final method for IsEqualForObjects
-##
-AddFinalDerivation( IsEqualForObjects,
-                    [ ],
-                    [ IsEqualForObjects ],
-                    
-  ReturnFail );
-
-## Final methods for IsEqual/IsEqualForMorphisms
-##
-AddFinalDerivation( IsCongruentForMorphisms,
-                    [ ],
-                    [ IsCongruentForMorphisms,
-                      IsEqualForMorphisms ],
-                      
-  ReturnFail : Description := "Only IsIdenticalObj for comparing" );
-
-##
-AddFinalDerivation( IsEqualForMorphisms,
-                    [ ],
-                    [ IsCongruentForMorphisms,
-                      IsEqualForMorphisms ],
-                      
-  ReturnFail : Description := "Only IsIdenticalObj for comparing" );
-
 ##
 AddFinalDerivation( IsCongruentForMorphisms,
                     [ [ IsEqualForMorphisms, 1 ] ],


### PR DESCRIPTION
This should be the solution with a fallback described in https://github.com/homalg-project/CAP_project/pull/612#issuecomment-722307457.

I do not think this is a good idea (that's why I open it as a draft): if a novice user does not provide `IsEqualFor...`, now instead of giving a warning, we provide an implicit fallback to something which is not even covered by the specification of `IsEqualFor...`.

My suggestion would be forcing the user to give a notion of equality (with an option to override this restraint) as I did in #612. But as I'm not affected by this (I hope I will never forget to provide an equality :D ), we can also merge this "as is" if you like.