### PR TITLE
Demo: Using typed lists

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -96,6 +96,38 @@ DeclareCategory( "IsCapCategoryMorphism",
 DeclareCategory( "IsCapCategoryTwoCell",
                  IsCapCategoryCell );
 
+#! @Description
+#! The GAP category of lists of CAP category cells.
+#! Every typed list of objects, morphisms, or $2$-cells
+#! of a CAP category lies in this GAP category.
+#! @Arguments object
+DeclareCategory( "IsListOfCapCategoryCells",
+                 IsListWithAttributes );
+
+#! @Description
+#! The GAP category of lists of CAP category objects.
+#! Every typed list of objects of a CAP category lies in
+#! this GAP category.
+#! @Arguments object
+DeclareCategory( "IsListOfCapCategoryObjects",
+                 IsListOfCapCategoryCells );
+
+#! @Description
+#! The GAP category of lists of CAP category morphisms.
+#! Every typed list of morphisms of a CAP category lies in
+#! this GAP category.
+#! @Arguments object
+DeclareCategory( "IsListOfCapCategoryMorphisms",
+                 IsListOfCapCategoryCells );
+
+#! @Description
+#! The GAP category of lists of CAP category $2$-cells.
+#! Every typed list of $2$-cells of a CAP category lies in
+#! this GAP category.
+#! @Arguments object
+DeclareCategory( "IsListOfCapCategoryTwoCells",
+                 IsListOfCapCategoryCells );
+
 DeclareCategory( "IsCellOfSkeletalCategory",
                  IsCapCategoryCell );
 
@@ -230,6 +262,42 @@ DeclareAttribute( "MorphismFilter",
 #! @Arguments C
 #! @Returns a filter
 DeclareAttribute( "TwoCellFilter",
+                  IsCapCategory );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is a filter in which all typed lists of cells
+#! of $C$ shall lie.
+#! @Arguments C
+#! @Returns a filter
+DeclareAttribute( "ListOfCellsFilter",
+                  IsCapCategory );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is a filter in which all typed lists of objects
+#! of $C$ shall lie.
+#! @Arguments C
+#! @Returns a filter
+DeclareAttribute( "ListOfObjectsFilter",
+                  IsCapCategory );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is a filter in which all typed lists of morphisms
+#! of $C$ shall lie.
+#! @Arguments C
+#! @Returns a filter
+DeclareAttribute( "ListOfMorphismsFilter",
+                  IsCapCategory );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is a filter in which all typed lists of $2$-cells
+#! of $C$ shall lie.
+#! @Arguments C
+#! @Returns a filter
+DeclareAttribute( "ListOfTwoCellsFilter",
                   IsCapCategory );
 
 #! @Description

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -143,7 +143,7 @@ BindGlobal( "TheTypeOfCapCategories",
 InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
                        
   function( category )
-    local name, cell_filter, filter_name, filter;
+    local name, cell_filter, filter, list_of_cells_filter;
 
     name := Name( category );
     
@@ -153,9 +153,8 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
     
     SetFilterObj( category, filter );
     
-    filter_name := Concatenation( name, "CellFilter" );
-    
-    cell_filter := NewFilter( filter_name );
+    # cells
+    cell_filter := NewFilter( Concatenation( name, "CellFilter" ) );
     
     SetCellFilter( category, cell_filter );
     
@@ -170,6 +169,23 @@ InstallGlobalFunction( CREATE_CAP_CATEGORY_FILTERS,
     filter := NewCategory( Concatenation( name, "TwoCellFilter" ), cell_filter );
     
     SetTwoCellFilter( category, filter );
+    
+    # lists of cells
+    list_of_cells_filter := NewFilter( Concatenation( name, "ListOfCellsFilter" ) );
+    
+    SetListOfCellsFilter( category, cell_filter );
+    
+    filter := NewCategory( Concatenation( name, "ListOfObjectsFilter" ), list_of_cells_filter );
+    
+    SetListOfObjectsFilter( category, filter );
+    
+    filter := NewCategory( Concatenation( name, "ListOfMorphismsFilter" ), list_of_cells_filter );
+    
+    SetListOfMorphismsFilter( category, filter );
+    
+    filter := NewCategory( Concatenation( name, "ListOfTwoCellsFilter" ), list_of_cells_filter );
+    
+    SetListOfTwoCellsFilter( category, filter );
     
 end );
 

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -21,6 +21,9 @@ BindGlobal( "TheTypeOfCapCategoryMorphisms",
         NewType( TheFamilyOfCapCategoryMorphisms,
                 IsCapCategoryMorphismRep ) );
 
+BindGlobal( "TheFamilyOfListsOfCapCategoryMorphisms",
+        NewFamily( "TheFamilyOfListsOfCapCategoryMorphisms" ) );
+
 ######################################
 ##
 ## Properties logic
@@ -220,7 +223,7 @@ InstallMethod( IsEqualForCacheForMorphisms,
                
   IsEqualForCache );
 
-
+##
 InstallMethod( AddMorphismRepresentation,
                [ IsCapCategory, IsObject ],
                
@@ -231,6 +234,27 @@ InstallMethod( AddMorphismRepresentation,
     
 end );
 
+##
+BindGlobal( "ListOfMorphismsInCategory", function( list, category, attributes... )
+  local type;
+    
+    if IsBound( category!.list_of_morphisms_type ) then
+        
+        type := category!.list_of_morphisms_type;
+        
+    else
+        
+        type := NewType( TheFamilyOfListsOfCapCategoryMorphisms, IsListWithAttributesRep and ListOfMorphismsFilter( category ) and IsListOfCapCategoryMorphisms and HasCapCategory );
+        
+        category!.list_of_morphisms_type := type;
+        
+    fi;
+    
+    return CallFuncList( TypedListWithAttributes, Concatenation( [ list, type, CapCategory, category ], attributes ) );
+    
+end );
+
+##
 InstallMethod( RandomMorphismWithFixedSourceAndRange,
     [ IsCapCategoryObject, IsCapCategoryObject, IsInt ], RandomMorphismWithFixedSourceAndRangeByInteger );
 InstallMethod( RandomMorphismWithFixedSourceAndRange,

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -21,6 +21,9 @@ BindGlobal( "TheTypeOfCapCategoryObjects",
         NewType( TheFamilyOfCapCategoryObjects,
                 IsCapCategoryObjectRep ) );
 
+BindGlobal( "TheFamilyOfListsOfCapCategoryObjects",
+        NewFamily( "TheFamilyOfListsOfCapCategoryObjects" ) );
+
 #######################################
 ##
 ## Technical implications
@@ -209,6 +212,7 @@ InstallMethod( IsEqualForCacheForObjects,
                
   IsEqualForCache );
 
+##
 InstallMethod( AddObjectRepresentation,
                [ IsCapCategory, IsObject ],
                
@@ -216,6 +220,26 @@ InstallMethod( AddObjectRepresentation,
     
     category!.object_representation := representation;
     category!.object_type := NewType( TheFamilyOfCapCategoryObjects, representation and ObjectFilter( category ) and IsCapCategoryObjectRep and HasCapCategory );
+    
+end );
+
+##
+BindGlobal( "ListOfObjectsInCategory", function( list, category, attributes... )
+  local type;
+    
+    if IsBound( category!.list_of_objects_type ) then
+        
+        type := category!.list_of_objects_type;
+        
+    else
+        
+        type := NewType( TheFamilyOfListsOfCapCategoryObjects, IsListWithAttributesRep and ListOfObjectsFilter( category ) and IsListOfCapCategoryObjects and HasCapCategory );
+        
+        category!.list_of_objects_type := type;
+        
+    fi;
+    
+    return CallFuncList( TypedListWithAttributes, Concatenation( [ list, type, CapCategory, category ], attributes ) );
     
 end );
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2464,6 +2464,8 @@ AddDerivationToCAP( DirectProduct,
                                         
   function( object_product_list )
     
+    # TODO
+      
     return Source( ProjectionInFactorOfDirectProduct( object_product_list, 1 ) );
     
 end : Description := "DirectProduct as Source of ProjectionInFactorOfDirectProduct" );

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -325,6 +325,15 @@ InstallGlobalFunction( CapInternalInstallAdd,
                         CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg[ j ], category, function( ) return input_human_readable_identifier_getter( i, j ); end );
                     od;
                 end;
+            elif filter = "typed_list_of_objects" then
+                # TODO
+                input_sanity_check_functions[i] := ReturnTrue;
+            elif filter = "typed_list_of_morphisms" then
+                # TODO
+                input_sanity_check_functions[i] := ReturnTrue;
+            elif filter = "typed_list_of_twocells" then
+                # TODO
+                input_sanity_check_functions[i] := ReturnTrue;
             else
                 Display( Concatenation( "Warning: You should add an input sanity check for the following filter: ", String( filter ) ) );
             fi;

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -835,17 +835,15 @@ UniversalMorphismFromInitialObjectWithGivenInitialObject := rec(
 
 DirectProduct := rec(
   installation_name := "DirectProductOp",
-  argument_list := [ 1 ],
-  filter_list := [ "list_of_objects", "object" ],
+  filter_list := [ "typed_list_of_objects" ],
   number_of_diagram_arguments := 1,
   universal_type := "Limit",
   return_type := "object",
   dual_operation := "Coproduct" ),
 
 ProjectionInFactorOfDirectProduct := rec(
-  installation_name := "ProjectionInFactorOfDirectProductOp",
-  argument_list := [ 1, 2 ],
-  filter_list := [ "list_of_objects", IsInt, "object" ],
+  installation_name := "ProjectionInFactorOfDirectProduct",
+  filter_list := [ "typed_list_of_objects", IsInt ],
   io_type := [ [ "objects", "k" ], [ "P", "objects_k" ] ],
   number_of_diagram_arguments := 1,
   universal_object_position := "Source",
@@ -855,7 +853,7 @@ ProjectionInFactorOfDirectProduct := rec(
 
 ProjectionInFactorOfDirectProductWithGivenDirectProduct := rec(
   installation_name := "ProjectionInFactorOfDirectProductWithGivenDirectProduct",
-  filter_list := [ "list_of_objects", IsInt, "object" ],
+  filter_list := [ "typed_list_of_objects", IsInt, "object" ],
   io_type := [ [ "objects", "k", "P" ], [ "P", "objects_k" ] ],
   number_of_diagram_arguments := 1,
   universal_type := "Limit",
@@ -864,34 +862,33 @@ ProjectionInFactorOfDirectProductWithGivenDirectProduct := rec(
 
 UniversalMorphismIntoDirectProduct := rec(
   installation_name := "UniversalMorphismIntoDirectProductOp",
-  argument_list := [ 1, 2 ],
+  filter_list := [ "typed_list_of_objects", "typed_list_of_morphisms" ],
   io_type := [ [ "objects", "tau" ], [ "tau_1_source", "P" ] ],
   number_of_diagram_arguments := 1,
-  filter_list := [ "list_of_objects", "list_of_morphisms", "object" ],
   universal_object_position := "Range",
   universal_type := "Limit",
   dual_operation := "UniversalMorphismFromCoproduct",
   
-  pre_function := function( diagram, source, method_selection_object )
+  pre_function := function( diagram, source )
     local test_object, current_morphism, current_return;
     
-    test_object := Source( source[1] );
-    
-    for current_morphism in source{[2 .. Length( source ) ]} do
-        
-        current_return := IsEqualForObjects( Source( current_morphism ), test_object );
-        
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
-            
-            return [ false, "sources of morphisms must be equal in given source diagram" ];
-            
-        fi;
-        
-    od;
+    #test_object := Source( source[1] );
+    #
+    #for current_morphism in source{[2 .. Length( source ) ]} do
+    #    
+    #    current_return := IsEqualForObjects( Source( current_morphism ), test_object );
+    #    
+    #    if current_return = fail then
+    #        
+    #        return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
+    #        
+    #    elif current_return = false then
+    #        
+    #        return [ false, "sources of morphisms must be equal in given source diagram" ];
+    #        
+    #    fi;
+    #    
+    #od;
     
     return [ true ];
     
@@ -900,7 +897,7 @@ UniversalMorphismIntoDirectProduct := rec(
 
 UniversalMorphismIntoDirectProductWithGivenDirectProduct := rec(
   installation_name := "UniversalMorphismIntoDirectProductWithGivenDirectProduct",
-  filter_list := [ "list_of_objects", "list_of_morphisms", "object" ],
+  filter_list := [ "typed_list_of_objects", "typed_list_of_morphisms", "object" ],
   io_type := [ [ "objects", "tau", "P" ], [ "tau_1_source", "P" ] ],
   number_of_diagram_arguments := 1,
   universal_type := "Limit",
@@ -909,23 +906,23 @@ UniversalMorphismIntoDirectProductWithGivenDirectProduct := rec(
   pre_function := function( diagram, source, direct_product )
     local test_object, current_morphism, current_return;
     
-    test_object := Source( source[1] );
-    
-    for current_morphism in source{[2 .. Length( source ) ]} do
-        
-        current_return := IsEqualForObjects( Source( current_morphism ), test_object );
-        
-        if current_return = fail then
-            
-            return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
-            
-        elif current_return = false then
-            
-            return [ false, "sources of morphisms must be equal in given source diagram" ];
-            
-        fi;
-        
-    od;
+    #test_object := Source( source[1] );
+    #
+    #for current_morphism in source{[2 .. Length( source ) ]} do
+    #    
+    #    current_return := IsEqualForObjects( Source( current_morphism ), test_object );
+    #    
+    #    if current_return = fail then
+    #        
+    #        return [ false, "cannot decide whether sources of morphisms in given source diagram are equal" ];
+    #        
+    #    elif current_return = false then
+    #        
+    #        return [ false, "sources of morphisms must be equal in given source diagram" ];
+    #        
+    #    fi;
+    #    
+    #od;
     
     return [ true ];
     
@@ -3765,12 +3762,12 @@ SomeReductionBySplitEpiSummand_MorphismFromInputRange := rec(
 ) );
 
 InstallValue( CAP_INTERNAL_METHOD_NAME_RECORD_LIMITS, [
-rec(
-  object_specification := [ "varobject" ],
-  morphism_specification := [  ],
-  limit_object_name := "DirectProduct",
-  colimit_object_name := "Coproduct",
-),
+#rec(
+#  object_specification := [ "varobject" ],
+#  morphism_specification := [  ],
+#  limit_object_name := "DirectProduct",
+#  colimit_object_name := "Coproduct",
+#),
 
 rec(
   object_specification := [ "varobject" ],

--- a/CAP/gap/PreFunctions.gi
+++ b/CAP/gap/PreFunctions.gi
@@ -91,6 +91,13 @@ BindGlobal( "CAP_PREFUNCTION_UNIVERSAL_MORPHISM_INTO_BINARY_DIRECT_PRODUCT_TO_UN
   function( universal_morphism_into_binary_direct_product_func, category )
     return function( diagram, tau )
       local universal_morphism, i;
+
+        if IsEmpty( tau ) then
+            
+            # TODO: what to do if the terminal object is not computable?
+            return UniversalMorphismIntoTerminalObject( Source( tau ) );
+            
+        fi;
         
         # Direct product diagrams are supposed to have at least length 1
         universal_morphism := tau[ 1 ];

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -438,6 +438,24 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   list[ i ] := IsList;
               elif current_entry = "list_of_twocells" then
                   list[ i ] := IsList;
+              elif current_entry = "typed_list_of_objects" then
+                  if category <> false then
+                      list[ i ] := ListOfObjectsFilter( category ) and IsListOfCapCategoryObjects;
+                  else
+                      list[ i ] := IsListOfCapCategoryObjects;
+                  fi;
+              elif current_entry = "typed_list_of_morphisms" then
+                  if category <> false then
+                      list[ i ] := ListOfMorphismsFilter( category ) and IsListOfCapCategoryMorphisms;
+                  else
+                      list[ i ] := IsListOfCapCategoryMorphisms;
+                  fi;
+              elif current_entry = "typed_list_of_twocells" then
+                  if category <> false then
+                      list[ i ] := ListOfTwoCellsFilter( category ) and IsListOfCapCategoryTwoCells;
+                  else
+                      list[ i ] := IsListOfCapCategoryTwoCells;
+                  fi;
               else
                   Error( "filter type is not recognized, see the documentation for allowed values" );
               fi;
@@ -449,6 +467,8 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   current_filter := current_filter and j;
               od;
               list[ i ] := current_filter;
+          else
+              Error( "filter type is not recognized, see the documentation for allowed values" );
           fi;
           
       od;

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -2322,7 +2322,7 @@ DeclareOperation( "AddCoproductFunctorialWithGivenCoproducts",
 #! @Returns an object
 #! @Arguments D
 DeclareOperationWithCache( "DirectProductOp",
-                           [ IsList, IsCapCategoryObject ] );
+                           [ IsListOfCapCategoryObjects ] );
 
 #! @Description
 #! The arguments are a list of objects $D = ( P_1, \dots, P_n )$
@@ -2380,7 +2380,7 @@ DeclareGlobalFunction( "UniversalMorphismIntoDirectProduct" );
 #! @Returns a morphism in $\mathrm{Hom}(T, \prod_{i=1}^n P_i)$
 #! @Arguments D, tau, method_selection_object
 DeclareOperation( "UniversalMorphismIntoDirectProductOp",
-                  [ IsList, IsList, IsCapCategoryObject ] );
+                  [ IsListOfCapCategoryObjects, IsListOfCapCategoryMorphisms ] );
 
 #! @Description
 #! The arguments are a list of objects $D = ( P_1, \dots, P_n )$,

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -180,17 +180,55 @@ end );
 ####################################
 
 ##
+CAP_INTERNAL_ORIGINAL_DIRECT_PRODUCT_FUNCTION := DirectProduct;
+MakeReadWriteGlobal( "DirectProduct" );
+UnbindGlobal( "DirectProduct" );
+BindGlobal( "DirectProduct", function( arg... )
+    
+    if Length( arg ) = 1 and IsListOfCapCategoryObjects( arg[1] ) then
+        
+        return DirectProductOp( arg[1] );
+        
+    else
+        
+        return CallFuncList( CAP_INTERNAL_ORIGINAL_DIRECT_PRODUCT_FUNCTION, arg );
+        
+    fi;
+    
+end );
+
+##
+InstallOtherMethod( DirectProductOp,
+               [ IsList, IsCapCategoryObject ],
+  function( list, obj )
+    local cat;
+    
+    cat := CapCategory( obj );
+    
+    return DirectProductOp( ListOfObjectsInCategory( list, cat ) );
+    
+end );
+
+##
 InstallGlobalFunction( UniversalMorphismIntoDirectProduct,
 
   function( arg )
     local diagram;
     
     if Length( arg ) = 2
-       and IsList( arg[1] )
-       and IsList( arg[2] ) then
-       
-       return UniversalMorphismIntoDirectProductOp( arg[1], arg[2], arg[1][1] );
-       
+        and IsList( arg[1] )
+        and IsList( arg[2] ) then
+        
+        if IsListOfCapCategoryObjects( arg[1] ) and IsListOfCapCategoryMorphisms( arg[2] ) then
+            
+            return UniversalMorphismIntoDirectProductOp( arg[1], arg[2] );
+            
+        else
+            
+            return UniversalMorphismIntoDirectProductOp( ListOfObjectsInCategory( arg[1], CapCategory( arg[1][1] ) ), ListOfMorphismsInCategory( arg[2], CapCategory( arg[1][1] ), Source, Source( arg[2][1] ) ) );
+            
+        fi;
+        
     elif Length( arg ) = 1 and IsList( arg[ 1 ] ) then
         arg := arg[ 1 ];
     fi;
@@ -198,8 +236,18 @@ InstallGlobalFunction( UniversalMorphismIntoDirectProduct,
     ##convenience: UniversalMorphismIntoDirectProduct( test_projection_1, ..., test_projection_k )
     diagram := List( arg, Range );
     
-    return UniversalMorphismIntoDirectProductOp( diagram, arg, diagram[1] );
+    return UniversalMorphismIntoDirectProductOp( ListOfObjectsInCategory( diagram, CapCategory( diagram[1] ) ), ListOfMorphismsInCategory( arg, CapCategory( diagram[1] ), Source, Source( arg[1] ) ) );
   
+end );
+
+##
+InstallOtherMethod( UniversalMorphismIntoDirectProductWithGivenDirectProduct,
+               [ IsList, IsList, IsCapCategoryObject ],
+               
+  function( object_product_list, morphism_list, given_object )
+    
+    return UniversalMorphismIntoDirectProductWithGivenDirectProduct( ListOfObjectsInCategory( object_product_list, CapCategory( given_object ) ), ListOfMorphismsInCategory( morphism_list, CapCategory( given_object ), Source, Source( morphism_list[1] ) ), given_object );
+    
 end );
 
 ####################################
@@ -212,7 +260,17 @@ InstallMethod( ProjectionInFactorOfDirectProduct,
                
   function( object_product_list, projection_number )
     
-    return ProjectionInFactorOfDirectProductOp( object_product_list, projection_number, object_product_list[1] );
+    return ProjectionInFactorOfDirectProduct( ListOfObjectsInCategory( object_product_list, CapCategory( object_product_list[1] ) ), projection_number );
+    
+end );
+
+##
+InstallOtherMethod( ProjectionInFactorOfDirectProductWithGivenDirectProduct,
+               [ IsList, IsInt, IsCapCategoryObject ],
+               
+  function( object_product_list, projection_number, given_object )
+    
+    return ProjectionInFactorOfDirectProductWithGivenDirectProduct( ListOfObjectsInCategory( object_product_list, CapCategory( given_object ) ), projection_number, given_object );
     
 end );
 


### PR DESCRIPTION
First some context for @sebastianpos: The motivation behind this PR is simplifying things for CompilerForCAP. It is based on discussions with @mohamed-barakat. Feel free to chime in, but as I raise some points which I have not discussed with Mohamed, you can also wait until Mohamed and I agree on our preferred way forward if you like :D

This PR is a demo of how we could use typed lists with attributes (https://github.com/homalg-project/homalg_project/pull/391) to:
1. get rid of method selection objects/morphisms,
2. handle corner cases like empty limits (e.g. https://github.com/homalg-project/CAP_project/blob/master/FreydCategoriesForCAP/gap/AdditiveClosure.gi#L951) without if/else statements.

Both points would be especially useful for `CompilerForCAP`, but are also useful feats on their own, I think.

This PR shows how this could work out using `DirectProduct` as an example. See the last commit on https://github.com/zickgraf/FinSetsForCAP/tree/typed_lists for tests.

Notes:
1. This change would be completely transparent to the end user due to convenience functions in `UniversalObjects.gi`.
2. These convenience functions could be created automatically.
3. Since typed lists offer the same interface as normal lists, one would only have to touch existing categories if one really wants to support empty limits etc.
4. In the case of `DirectSum` and `DirectProduct` we have to wrap the existing GAP functions as they throw an error on empty lists.
5. Some derivations like deriving `DirectProduct` from `ProjectionInFactorOfDirectProduct` would not work anymore as they require a non-empty list.
6. On the other hand, we could now derive `ZeroObject` as the empty direct sum.
7. Example of the syntax for the universal morphism into the empty direct sum with given test object:
```
UniversalMorphismIntoDirectProductWithGivenDirectProduct( ListOfObjectsInCategory( [ ], cat ), ListOfMorphismsInCategory( [ ], cat, Source, test_object ), DirectProduct( ListOfObjectsInCategory( [ ], cat ) ) )
```

The syntax is obviously very verbose and I'm not sure this is what we actually want. Of course, mathematically we have a "list of morphisms with a common source `test_object`" in mind. But maybe we could make things simpler.


#### Idea 1
For method selection we do not really have to know if something is a list of objects/morphisms/lists etc. So we could only provide a single short constructor `ListInCat(egory?)` yielding a list of \<whatever\> in a given category.

#### Idea 2
We could only require that one passes typed lists when actually needed for method selection (e.g. not in the WithGiven case), and in this case only for the first argument (and of course for all arguments which need attributes).

#### Idea 3
Instead of using typed lists with attributes, we could
1. allow to pass the category as the first argument of any CAP operation,
2. pass the attributes as explicit arguments

(of course again transparent for the user via suitable convenience functions).
Then
```
UniversalMorphismIntoDirectProductWithGivenDirectProduct( cat, [ ], [ ], test_object, DirectProduct( cat, [ ] ) )
```
would be much more readable.

Passing the test_object as an additional argument could even make sense when combined with typed list:
1. The io_type could explicitely access the test_object.
2. The full specification simply involves the test_object, so we should pass it as an argument. (Context of this statement: There is a convenience function `UniversalMorphismIntoDirectProduct` where you do not have to pass the product diagram. But since the diagram is part of the specification, we only offer this as a convenience function and not for the actual implimentation. I think the same reasoning could be applied to the test_object).
3. This would work nicely with idea 2 (we would never need attributes and often the test_object would completely suffice as a method selection object).

I once discussed parts of idea 3 with Mohamed and I think he was against it, but I'm not sure we were aware of all the pros and cons of the concepts.