### PR TITLE
Add test covering IsEqualForObjects in VectorSpacesAllMethods.g

### DIFF
--- a/CAP/examples/VectorSpacesIsWellDefined.g
+++ b/CAP/examples/VectorSpacesIsWellDefined.g
@@ -29,4 +29,6 @@ IsWellDefined( alpha );
 #! true
 IsWellDefined( g );
 #! true
+IsEqualForObjects( A, B );
+#! false
 #! @EndExample


### PR DESCRIPTION
Due to caching and garbage collection, the line is sometimes covered but not
always. Make sure it is always covered to prevent unexpected code coverage
drops.

For an example of an unexpected code coverage drop see #631.