### PR TITLE
Remove superfluous special cases in CategoryOfRows/Columns

### DIFF
--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -786,21 +786,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
         ##
         AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( category,
           function( alpha )
-            local underlying_matrix, nr_columns;
+            local underlying_matrix;
             
             underlying_matrix := UnderlyingMatrix( alpha );
             
-            nr_columns := NrColumns( underlying_matrix );
-            
-            if ( nr_columns = 0 ) or ( NrRows( underlying_matrix ) = 0 ) then
-                
-                return UniversalMorphismIntoZeroObject( DistinguishedObjectOfHomomorphismStructure( category ) );
-                
-            elif nr_columns > 1 then
-                
-                underlying_matrix := ConvertMatrixToColumn( underlying_matrix );
-                
-            fi;
+            underlying_matrix := ConvertMatrixToColumn( underlying_matrix );
             
             return CategoryOfColumnsMorphism(
                      DistinguishedObjectOfHomomorphismStructure( category ),
@@ -819,14 +809,8 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS,
             
             nr_rows := RankOfObject( B );
             
-            if nr_rows = 0 or nr_columns = 0 then
-                
-                return ZeroMorphism( A, B );
-                
-            fi;
-            
             underlying_matrix := UnderlyingMatrix( morphism );
-
+            
             underlying_matrix := ConvertColumnToMatrix( underlying_matrix, nr_rows, nr_columns );
             
             return CategoryOfColumnsMorphism( A, underlying_matrix, B );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -828,21 +828,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         ##
         AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( category,
           function( alpha )
-            local underlying_matrix, nr_rows;
+            local underlying_matrix;
             
             underlying_matrix := UnderlyingMatrix( alpha );
             
-            nr_rows := NrRows( underlying_matrix );
-            
-            if ( nr_rows = 0 ) or ( NrColumns( underlying_matrix ) = 0 ) then
-                
-                return UniversalMorphismIntoZeroObject( DistinguishedObjectOfHomomorphismStructure( category ) );
-                
-            elif nr_rows > 1 then
-                
-                underlying_matrix := ConvertMatrixToRow( underlying_matrix );
-                
-            fi;
+            underlying_matrix := ConvertMatrixToRow( underlying_matrix );
             
             return CategoryOfRowsMorphism(
                      DistinguishedObjectOfHomomorphismStructure( category ),
@@ -860,12 +850,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
             nr_rows := RankOfObject( A );
             
             nr_columns := RankOfObject( B );
-            
-            if nr_rows = 0 or nr_columns = 0 then
-                
-                return ZeroMorphism( A, B );
-                
-            fi;
             
             underlying_matrix := UnderlyingMatrix( morphism );
             


### PR DESCRIPTION
ConvertMatrixFrom/ToRow/Column should be able to handle empty matrices without problems.

@mohamed-barakat Can you confirm this statement?