### PR TITLE
Set IsProjective for free objects in various categories

### DIFF
--- a/CAP/examples/Homology.g
+++ b/CAP/examples/Homology.g
@@ -11,10 +11,8 @@ LoadPackage( "RingsForHomalg" );
 #! @Example
 ZZ := HomalgRingOfIntegersInSingular( );
 #! Z
-C1 := FreeLeftPresentation( 1, ZZ );
-#! <An object in Category of left presentations of Z>
-C2 := FreeLeftPresentation( 2, ZZ );
-#! <An object in Category of left presentations of Z>
+C1 := FreeLeftPresentation( 1, ZZ );;
+C2 := FreeLeftPresentation( 2, ZZ );;
 h1 := PresentationMorphism( C2, HomalgMatrix( [ [ 0 ], [ 4 ] ], ZZ ), C1 );
 #! <A morphism in Category of left presentations of Z>
 h2 := PresentationMorphism( C2, HomalgMatrix( [ [ 0 ], [ 2 ] ], ZZ ), C1 );

--- a/CAP/examples/SpectralSequencesTest.g
+++ b/CAP/examples/SpectralSequencesTest.g
@@ -13,16 +13,14 @@ R := QQ * "x,y";
 SetRecursionTrapInterval( 10000 );
 category := LeftPresentations( R );
 #! Category of left presentations of Q[x,y]
-S := FreeLeftPresentation( 1, R );
-#! <An object in Category of left presentations of Q[x,y]>
+S := FreeLeftPresentation( 1, R );;
 object_func := function( i ) return S; end;
 #! function( i ) ... end
 morphism_func := function( i ) return IdentityMorphism( S ); end;
 #! function( i ) ... end
 C0 := ZFunctorObjectExtendedByInitialAndIdentity( object_func, morphism_func, category, 0, 4 );
 #! <An object in Functors from integers into Category of left presentations of Q[x,y]>
-S2 := FreeLeftPresentation( 2, R );
-#! <An object in Category of left presentations of Q[x,y]>
+S2 := FreeLeftPresentation( 2, R );;
 C1 := ZFunctorObjectFromMorphismList( [ InjectionOfCofactorOfDirectSum( [ S2, S ], 1 ) ], 2 );
 #! <An object in Functors from integers into Category of left presentations of Q[x,y]>
 C1 := ZFunctorObjectExtendedByInitialAndIdentity( C1, 2, 3 );

--- a/FreydCategoriesForCAP/examples/RowsAndColsOverFields.g
+++ b/FreydCategoriesForCAP/examples/RowsAndColsOverFields.g
@@ -11,6 +11,8 @@ Q := HomalgFieldOfRationals();;
 RowsQ := CategoryOfRows( Q );;
 a := 3/RowsQ;;
 b := 4/RowsQ;;
+HasIsProjective( a ) and IsProjective( a );
+#! true
 homalg_matrix := HomalgMatrix( [ [ 1, 0, 0, 0 ],
                                   [ 0, 1, 0, -1 ],
                                   [ -1, 0, 2, 1 ] ], 3, 4, Q );;
@@ -72,6 +74,8 @@ Q := HomalgFieldOfRationals();;
 ColsQ := CategoryOfColumns( Q );;
 a := 3/ColsQ;;
 b := 4/ColsQ;;
+HasIsProjective( a ) and IsProjective( a );
+#! true
 homalg_matrix := HomalgMatrix( [ [ 1, 0, 0, 0 ],
                                   [ 0, 1, 0, -1 ],
                                   [ -1, 0, 2, 1 ] ], 3, 4, Q );;

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -44,12 +44,16 @@ InstallMethod( CategoryOfColumns,
     fi;
     
     if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring ) then
-      
-      SetIsAbelianCategory( category, true );
-      
+        
+        AddObjectRepresentation( category, IsCategoryOfColumnsObject and HasIsProjective and IsProjective );
+        
+        SetIsAbelianCategory( category, true );
+        
+    else
+        
+        AddObjectRepresentation( category, IsCategoryOfColumnsObject );
+        
     fi;
-    
-    AddObjectRepresentation( category, IsCategoryOfColumnsObject );
     
     AddMorphismRepresentation( category, IsCategoryOfColumnsMorphism and HasUnderlyingMatrix );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -44,12 +44,16 @@ InstallMethod( CategoryOfRows,
     fi;
     
     if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring )  then
-      
-      SetIsAbelianCategory( category, true );
-      
+        
+        AddObjectRepresentation( category, IsCategoryOfRowsObject and HasIsProjective and IsProjective );
+        
+        SetIsAbelianCategory( category, true );
+        
+    else
+        
+        AddObjectRepresentation( category, IsCategoryOfRowsObject );
+        
     fi;
-    
-    AddObjectRepresentation( category, IsCategoryOfRowsObject );
     
     AddMorphismRepresentation( category, IsCategoryOfRowsMorphism and HasUnderlyingMatrix );
     

--- a/LinearAlgebraForCAP/examples/Example.gi
+++ b/LinearAlgebraForCAP/examples/Example.gi
@@ -8,6 +8,8 @@ LoadPackage( "LinearAlgebraForCAP" );;
 Q := HomalgFieldOfRationals();;
 a := VectorSpaceObject( 3, Q );
 #! <A vector space object over Q of dimension 3>
+HasIsProjective( a ) and IsProjective( a );
+#! true
 vec := MatrixCategory( Q );;
 ap := 3/vec;;
 IsEqualForObjects( a, ap );

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -24,7 +24,7 @@ InstallMethod( MatrixCategory,
     
     SetFilterObj( category, IsMatrixCategory );
     
-    AddObjectRepresentation( category, IsVectorSpaceObject );
+    AddObjectRepresentation( category, IsVectorSpaceObject and HasIsProjective and IsProjective );
     
     AddMorphismRepresentation( category, IsVectorSpaceMorphism and HasUnderlyingFieldForHomalg and HasUnderlyingMatrix );
     

--- a/ModulePresentationsForCAP/examples/ProjectivityTest.g
+++ b/ModulePresentationsForCAP/examples/ProjectivityTest.g
@@ -9,6 +9,12 @@ LoadPackage( "RingsForHomalg" );
 #! @Example
 Q := HomalgFieldOfRationalsInSingular();;
 R := Q * "x";;
+F := FreeLeftPresentation( 2, Q );;
+HasIsProjective( F ) and IsProjective( F );
+#! true
+G := FreeRightPresentation( 2, Q );;
+HasIsProjective( G ) and IsProjective( G );
+#! true
 M := AsLeftPresentation( HomalgMatrix( "[ x, x ]", 1, 2, R ) );;
 IsProjective( M );
 #! false

--- a/ModulePresentationsForCAP/gap/ModulePresentationObject.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationObject.gi
@@ -73,6 +73,7 @@ InstallMethod( FreeLeftPresentation,
                [ IsInt, IsHomalgRing ],
                
   function( rank, homalg_ring )
+    local object;
     
     if rank < 0 then
       
@@ -80,7 +81,11 @@ InstallMethod( FreeLeftPresentation,
       
     fi;
     
-    return AsLeftPresentation( HomalgZeroMatrix( 0, rank, homalg_ring ) );
+    object := AsLeftPresentation( HomalgZeroMatrix( 0, rank, homalg_ring ) );
+    
+    SetIsProjective( object, true );
+    
+    return object;
     
 end );
 
@@ -89,6 +94,7 @@ InstallMethod( FreeRightPresentation,
                [ IsInt, IsHomalgRing ],
                
   function( rank, homalg_ring )
+    local object;
     
     if rank < 0 then
       
@@ -96,7 +102,11 @@ InstallMethod( FreeRightPresentation,
       
     fi;
     
-    return AsRightPresentation( HomalgZeroMatrix( rank, 0, homalg_ring ) );
+    object := AsRightPresentation( HomalgZeroMatrix( rank, 0, homalg_ring ) );
+    
+    SetIsProjective( object, true );
+    
+    return object;
     
 end );
 


### PR DESCRIPTION
This helps FreydCategory lift homomorphism structures for which the distinguished object is a free object in one of the modified categories.