### PR TITLE
Fix DistinguishedObjectOfHomomorphismStructure in FreydCategory

### DIFF
--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -1016,7 +1016,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
               function( alpha, beta ) return AsFreydCategoryMorphism( HomomorphismStructureOnMorphisms( alpha, beta ) ); end;
             
             distinguished_object_of_homomorphism_structure := 
-              cat -> AsFreydCategoryObject( DistinguishedObjectOfHomomorphismStructure( range_category ) );
+              cat -> AsFreydCategoryObject( DistinguishedObjectOfHomomorphismStructure( cat ) );
             
             interpret_homomorphism_as_morphism_from_dinstinguished_object_to_homomorphism_structure :=
               alpha -> AsFreydCategoryMorphism(
@@ -1136,7 +1136,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
             AddDistinguishedObjectOfHomomorphismStructure( category,
               function( )
                 
-                return distinguished_object_of_homomorphism_structure( range_category );
+                return distinguished_object_of_homomorphism_structure( underlying_category );
                 
             end );
             


### PR DESCRIPTION
I think this was not noticed before because until now in all examples relevant for `FreydCategory` we had
* `underlying_category = range_category` or
* `RangeCategoryOfHomomorphismStructure( range_category ) = range_category`

and in both cases we have
```
DistinguishedObjectOfHomomorphismStructure( range_category ) = DistinguishedObjectOfHomomorphismStructure( underlying_category )
```

That's also the reason why I could not add a test for this (I have an example in my code but it does not make sense to add that code as a test).