### PR TITLE
Partially revert "Fix some pre functions"

### DIFF
--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1492,7 +1492,9 @@ EmbeddingOfEqualizerWithGivenEqualizer := rec(
   io_type := [ [ "morphisms", "P" ], [ "P", "morphisms_1_source" ] ],
   number_of_diagram_arguments := 1,
   universal_type := "Limit",
-  dual_operation := "ProjectionOntoCoequalizerWithGivenCoequalizer" ),
+  dual_operation := "ProjectionOntoCoequalizerWithGivenCoequalizer",
+  
+  pre_function := ~.Equalizer.pre_function ),
 
 MorphismFromEqualizerToSink := rec(
   installation_name := "MorphismFromEqualizerToSinkOp",
@@ -1923,7 +1925,9 @@ ProjectionOntoCoequalizerWithGivenCoequalizer := rec(
   io_type := [ [ "morphisms", "P" ], [ "morphisms_1_range", "P" ] ],
   number_of_diagram_arguments := 1,
   universal_type := "Colimit",
-  dual_operation := "EmbeddingOfEqualizerWithGivenEqualizer" ),
+  dual_operation := "EmbeddingOfEqualizerWithGivenEqualizer",
+  
+  pre_function := ~.Coequalizer.pre_function ),
 
 MorphismFromSourceToCoequalizer := rec(
   installation_name := "MorphismFromSourceToCoequalizerOp",


### PR DESCRIPTION
This partially reverts commit ef4ca57ea17a9c15b5251cb088916eec266020dc.

The automatic derivation of pre functions for WithGiven pairs does not take
method selection objects into account and thus generates pre functions with
the wrong number of arguments in these two cases. The old version works
because the WithGiven object is used as the method selection object in
(Co)Equalizer.pre_function, which breaks semantics but technically works.

I have not noticed this problem before because I only tested this as part
of #649 where method selection objects are gone and thus the automatic
derivation of pre functions for WithGiven pairs is actually correct.