### PR TITLE
Deprecate setting the cache name manually

### DIFF
--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -146,9 +146,6 @@ The record can have the following components, used as described:
                                 Please note that true only makes sense if at least one argument and the output of the
                                 installed method is a cell.
 
-* cache_name (optional): The name of the cache which is used for the installed methods. If no cache name is given, the caching
-                         for the operation is deactivated completely.
-
 * return_type: The return type can either be a filter or one of the strings in the list below.
                For objects, morphisms and $2$-cells the correct <C>Add</C> function (see above) is
                used for the result of the computation. Otherwise, no <C>Add</C> function is used after all.
@@ -180,8 +177,6 @@ with an optional third parameter for the weight.
 @Section Enhancing the method name record
 
 The function CAP_INTERNAL_ENHANCE_NAME_RECORD can be applied to a method name record to make the following enhancements:
-
-* Cache check: If there is no cache_name, set it to the installation_name.
 
 * Function name: Set the component function_name to the entry name.
 

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -518,7 +518,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     
                     return result;
                     
-                end : Cache := GET_METHOD_CACHE( category, record.cache_name, Length( filter_list ) ) );
+                end : Cache := GET_METHOD_CACHE( category, function_name, Length( filter_list ) ) );
             
             else #category!.overhead = false
                 

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -41,8 +41,8 @@ InstallGlobalFunction( CapInternalInstallAdd,
   
   function( record )
     local function_name, install_name, add_name, pre_function, pre_function_full,
-          redirect_function, post_function, filter_list, caching,
-          cache_name, nr_arguments, add_function, replaced_filter_list,
+          redirect_function, post_function, filter_list,
+          add_function, replaced_filter_list,
           enhanced_filter_list, get_convenience_function;
     
     function_name := record.function_name;
@@ -84,14 +84,6 @@ InstallGlobalFunction( CapInternalInstallAdd,
     fi;
     
     filter_list := record.filter_list;
-    
-    if IsBound( record.cache_name ) then
-        caching := true;
-        cache_name := record.cache_name;
-        nr_arguments := Length( filter_list );
-    else
-        caching := false;
-    fi;
     
     if record.return_type = "object" then
         add_function := AddObject;
@@ -171,7 +163,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                    [ IsCapCategory, IsList, IsInt ],
       
       function( category, method_list, weight )
-        local install_func, replaced_filter_list, install_method, popper, needs_wrapping, i, set_primitive, is_derivation, is_final_derivation, without_given_name, with_given_name,
+        local install_func, replaced_filter_list, needs_wrapping, i, set_primitive, is_derivation, is_final_derivation, without_given_name, with_given_name,
               without_given_weight, with_given_weight, number_of_proposed_arguments, current_function_number,
               current_function_argument_number, current_additional_filter_list_length, filter, input_human_readable_identifier_getter, input_sanity_check_functions,
               output_human_readable_identifier_getter, output_sanity_check_function, cap_jit_compiled_function;
@@ -245,15 +237,6 @@ InstallGlobalFunction( CapInternalInstallAdd,
         fi;
         
         replaced_filter_list := CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS( filter_list, category );
-        
-        if caching = true then
-            install_method := InstallMethodWithCache;
-            PushOptions( rec( Cache := GET_METHOD_CACHE( category, cache_name, nr_arguments )  ) );
-            popper := true;
-        else
-            install_method := InstallMethod;
-            popper := false;
-        fi;
         
         ## Nr arguments sanity check
         
@@ -470,7 +453,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 
             elif category!.overhead then
             
-                install_method( ValueGlobal( install_name ),
+                InstallMethodWithCache( ValueGlobal( install_name ),
                                 new_filter_list,
                                 
                   function( arg )
@@ -535,7 +518,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     
                     return result;
                     
-                end );
+                end : Cache := GET_METHOD_CACHE( category, record.cache_name, Length( filter_list ) ) );
             
             else #category!.overhead = false
                 
@@ -573,10 +556,6 @@ InstallGlobalFunction( CapInternalInstallAdd,
             install_func( i[ 1 ], i[ 2 ] );
         od;
         
-        if popper then
-            PopOptions();
-        fi;
-        
         if set_primitive then
             AddPrimitiveOperation( category!.derivations_weight_list, function_name, weight );
             
@@ -585,8 +564,6 @@ InstallGlobalFunction( CapInternalInstallAdd,
             fi;
             
         fi;
-        
-        
         
     end );
     

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1048,14 +1048,12 @@ IsEqualForObjects := rec(
   
 IsEqualForCacheForObjects := rec(
   filter_list := [ "category", "object", "object" ],
-  cache_name := "IsEqualForCacheForObjects",
   dual_operation := "IsEqualForCacheForObjects",
   well_defined_todo := false,
   return_type := "bool" ),
 
 IsEqualForCacheForMorphisms := rec(
   filter_list := [ "category", "morphism", "morphism" ],
-  cache_name := "IsEqualForCacheForMorphisms",
   dual_operation := "IsEqualForCacheForMorphisms",
   well_defined_todo := false,
   return_type := "bool" ),
@@ -2290,7 +2288,6 @@ InverseMorphismFromCoimageToImageWithGivenObjects := rec(
 
 IsWellDefinedForMorphisms := rec(
   filter_list := [ "category", "morphism" ],
-  cache_name := "IsWellDefinedForMorphisms",
   well_defined_todo := false,
   dual_operation := "IsWellDefinedForMorphisms",
   
@@ -2321,7 +2318,6 @@ IsWellDefinedForMorphisms := rec(
 
 IsWellDefinedForObjects := rec(
   filter_list := [ "category", "object" ],
-  cache_name := "IsWellDefinedForObjects",
   well_defined_todo := false,
   dual_operation := "IsWellDefinedForObjects",
   return_type := "bool" ),
@@ -2726,7 +2722,6 @@ IdentityTwoCell := rec(
 
 IsWellDefinedForTwoCells := rec(
   filter_list := [ "category", "twocell" ],
-  cache_name := "IsWellDefinedForTwoCells",
   well_defined_todo := false,
   dual_operation := "IsWellDefinedForTwoCells",
   
@@ -3076,7 +3071,6 @@ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism := rec
 
 SolveLinearSystemInAbCategory := rec(
   filter_list := [ "category", IsList, IsList, "list_of_morphisms" ],
-  cache_name := "SolveLinearSystemInAbCategory",
   return_type := "list_of_morphisms_or_fail",
   pre_function := function( cat, left_coeffs, right_coeffs, rhs )
     
@@ -3125,7 +3119,6 @@ SolveLinearSystemInAbCategory := rec(
 MereExistenceOfSolutionOfLinearSystemInAbCategory := rec(
     ## TODO: Type-check of linear system
   filter_list := [ "category", IsList, IsList, "list_of_morphisms" ],
-  cache_name := "MereExistenceOfSolutionOfLinearSystemInAbCategory",
   return_type := "bool"
 ),
 
@@ -4085,7 +4078,7 @@ end );
 
 BindGlobal( "CAP_INTERNAL_CREATE_REDIRECTION",
   
-  function( with_given_name, object_function_name, object_arg_list, cache_name )
+  function( with_given_name, object_function_name, object_arg_list )
     local return_func, has_name, has_function, object_function, with_given_name_function, is_attribute, attribute_tester;
     
     object_function := ValueGlobal( object_function_name );
@@ -4103,7 +4096,7 @@ BindGlobal( "CAP_INTERNAL_CREATE_REDIRECTION",
             
             object_args := arg{ object_arg_list };
             
-            cache := GET_METHOD_CACHE( category, cache_name, Length( object_arg_list ) );
+            cache := GET_METHOD_CACHE( category, object_function_name, Length( object_arg_list ) );
             
             cache_value := CallFuncList( CacheValue, [ cache, object_args ] );
             
@@ -4140,7 +4133,7 @@ BindGlobal( "CAP_INTERNAL_CREATE_REDIRECTION",
                 
             else
                 
-                cache := GET_METHOD_CACHE( category, cache_name, Length( object_arg_list ) );
+                cache := GET_METHOD_CACHE( category, object_function_name, Length( object_arg_list ) );
                 
                 cache_value := CallFuncList( CacheValue, [ cache, object_args ] );
                 
@@ -4162,7 +4155,7 @@ end );
 
 BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
   
-  function( source_range_object, object_function_name, object_arg_list, object_cache_name )
+  function( source_range_object, object_function_name, object_arg_list )
     local object_getter, object_function, setter_function, is_attribute, cache_key_length;
     
     if source_range_object = "Source" then
@@ -4189,7 +4182,7 @@ BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
             Remove( arg );
             object := object_getter( result );
             
-            SET_VALUE_OF_CATEGORY_CACHE( category, object_cache_name, cache_key_length, arg{ object_arg_list }, object );
+            SET_VALUE_OF_CATEGORY_CACHE( category, object_function_name, cache_key_length, arg{ object_arg_list }, object );
             
         end;
         
@@ -4214,7 +4207,7 @@ BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
             Remove( arg );
             object := object_getter( result );
             
-            SET_VALUE_OF_CATEGORY_CACHE( category, object_cache_name, cache_key_length, arg{ object_arg_list }, object );
+            SET_VALUE_OF_CATEGORY_CACHE( category, object_function_name, cache_key_length, arg{ object_arg_list }, object );
             setter_function( object_args[ Length( object_args ) ], object );
             
         end;
@@ -4242,7 +4235,7 @@ end );
 InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
   function( record )
     local recnames, current_recname, current_rec, number_of_arguments, flattened_filter_list, position, without_given_name, object_name, functorial,
-          installation_name, object_arg_list, with_given_name, with_given_name_length, i, object_func;
+          installation_name, object_arg_list, with_given_name, with_given_name_length, i, object_function_name;
     
     recnames := RecNames( record );
     
@@ -4412,7 +4405,7 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
         
         if not IsBound( current_rec.cache_name ) then
             
-            current_rec.cache_name := current_rec.installation_name;
+            current_rec.cache_name := current_rec.function_name;
             
         fi;
         
@@ -4458,7 +4451,7 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
                 
                 object_name := with_given_name{[ with_given_name_length + 1 .. Length( with_given_name ) ]};
                 
-                object_func := record.( object_name ).installation_name;
+                object_function_name := record.( object_name ).function_name;
                 
                 if not IsBound( current_rec.number_of_diagram_arguments ) then
                     
@@ -4491,7 +4484,7 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
                         
                     else
                         
-                        current_rec.redirect_function := CAP_INTERNAL_CREATE_REDIRECTION( with_given_name, object_func, object_arg_list, object_func );
+                        current_rec.redirect_function := CAP_INTERNAL_CREATE_REDIRECTION( with_given_name, object_function_name, object_arg_list );
                         
                     fi;
                     
@@ -4510,7 +4503,7 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
                         
                     else
                         
-                        current_rec.post_function := CAP_INTERNAL_CREATE_POST_FUNCTION( current_rec.universal_object_position, object_func, object_arg_list, object_func );
+                        current_rec.post_function := CAP_INTERNAL_CREATE_POST_FUNCTION( current_rec.universal_object_position, object_function_name, object_arg_list );
                         
                     fi;
                     

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -4403,9 +4403,12 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
             
         fi;
         
-        if not IsBound( current_rec.cache_name ) then
+        if IsBound( current_rec.cache_name ) and current_rec.cache_name <> current_rec.function_name then
             
-            current_rec.cache_name := current_rec.function_name;
+            Display( Concatenation(
+                "WARNING: Manually setting cache_name is not supported anymore. The function name will be used instead. ",
+                "To avoid this warning, remove cache_name from the method record."
+            ) );
             
         fi;
         

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -4085,14 +4085,14 @@ end );
 
 BindGlobal( "CAP_INTERNAL_CREATE_REDIRECTION",
   
-  function( with_given_name, object_name, object_arg_list, cache_name )
+  function( with_given_name, object_function_name, object_arg_list, cache_name )
     local return_func, has_name, has_function, object_function, with_given_name_function, is_attribute, attribute_tester;
     
-    object_function := ValueGlobal( object_name );
+    object_function := ValueGlobal( object_function_name );
     
     with_given_name_function := ValueGlobal( with_given_name );
     
-    is_attribute := Tester( object_function ) <> false;
+    is_attribute := IsOperation( object_function ) and Tester( object_function ) <> false;
     
     if not is_attribute then
         
@@ -4163,7 +4163,7 @@ end );
 BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
   
   function( source_range_object, object_function_name, object_arg_list, object_cache_name )
-    local object_getter, setter_function, is_attribute, cache_key_length;
+    local object_getter, object_function, setter_function, is_attribute, cache_key_length;
     
     if source_range_object = "Source" then
         object_getter := Source;
@@ -4173,8 +4173,9 @@ BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
         Error( "the first argument of CAP_INTERNAL_CREATE_POST_FUNCTION must be 'Source' or 'Range'" );
     fi;
     
-    setter_function := Setter( ValueGlobal( object_function_name ) );
-    is_attribute := setter_function <> false;
+    object_function := ValueGlobal( object_function_name );
+    
+    is_attribute := IsOperation( object_function ) and Setter( object_function ) <> false;
     cache_key_length := Length( object_arg_list );
     
     if not is_attribute then
@@ -4199,6 +4200,8 @@ BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
             Error( "we can only handle attributes of the category or of a single object/morphism/twocell" );
             
         fi;
+        
+        setter_function := Setter( object_function );
         
         return function( arg )
           local category, object_args, result, object;


### PR DESCRIPTION
Thanks for merging the PR regarding `installation_name`! This PR does something similar for `cache_name`.

1. The first commit is again preparatory.
2. The second commit makes `cache_name` default to the function name instead of the installation name. I have not found any point in the code where this would break anything. The commit also adjusts CAP_INTERNAL_CREATE_REDIRECTION/CAP_INTERNAL_CREATE_POST_FUNCTION accordingly and deletes some obsolete cache names from the method record.
3. The third commit simplifies the cache installation. Since the cache name is (and already was) set automatically, caching is/was always active anyway, so I have removed the ability of having no cache in InstallAdds.gi.
4. The last commit finally deprecates setting the cache name to something other than the function name.

@sebastianpos Again, the commits are straight forward and I am confident that my changes work as intended, but since I  change/remove some bits of functionality I wait for your explicit OK :-)