### PR TITLE
Add CapJitPrecompileCategory

### DIFF
--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -233,6 +233,24 @@ DeclareAttribute( "TwoCellFilter",
                   IsCapCategory );
 
 #! @Description
+#! The argument is a category $C$.
+#! The output is the GAP type of objects of $C$.
+#! Only available after calling `AddObjectRepresentation`.
+#! @Arguments C
+#! @Returns a GAP type
+DeclareAttribute( "ObjectType",
+                  IsCapCategory );
+
+#! @Description
+#! The argument is a category $C$.
+#! The output is the GAP type of morphisms of $C$.
+#! Only available after calling `AddMorphismRepresentation`.
+#! @Arguments C
+#! @Returns a GAP type
+DeclareAttribute( "MorphismType",
+                  IsCapCategory );
+
+#! @Description
 #! The argument is a category $C$ which is expected to lie in the
 #! filter <C>IsLinearCategoryOverCommutativeRing</C>.
 #! The output is a commutative ring over which the category is linear.

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -255,6 +255,7 @@ InstallMethod( AddMorphismRepresentation,
     
     category!.morphism_representation := representation;
     category!.morphism_type := NewType( TheFamilyOfCapCategoryMorphisms, representation and MorphismFilter( category ) and IsCapCategoryMorphismRep and HasSource and HasRange and HasCapCategory );
+    SetMorphismType( category, category!.morphism_type );
     
 end );
 
@@ -286,7 +287,7 @@ InstallGlobalFunction( ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes,
     #% CAP_JIT_RESOLVE_FUNCTION
     
     arg_list := Concatenation( 
-        [ morphism, category!.morphism_type, CapCategory, category, Source, source, Range, range ], additional_arguments_list
+        [ morphism, MorphismType( category ), CapCategory, category, Source, source, Range, range ], additional_arguments_list
     );
     
     objectified_morphism := CallFuncList( ObjectifyWithAttributes, arg_list );

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -224,6 +224,7 @@ InstallMethod( AddObjectRepresentation,
     
     category!.object_representation := representation;
     category!.object_type := NewType( TheFamilyOfCapCategoryObjects, representation and ObjectFilter( category ) and IsCapCategoryObjectRep and HasCapCategory );
+    SetObjectType( category, category!.object_type );
     
 end );
 
@@ -241,7 +242,7 @@ InstallGlobalFunction( ObjectifyObjectForCAPWithAttributes,
     #% CAP_JIT_RESOLVE_FUNCTION
     
     arg_list := Concatenation(
-        [ object, category!.object_type, CapCategory, category ], additional_arguments_list
+        [ object, ObjectType( category ), CapCategory, category ], additional_arguments_list
     );
     
     return CallFuncList( ObjectifyWithAttributes, arg_list );

--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -80,6 +80,19 @@ If `enable_compilation` is set to `true`, any basic operation will be compiled w
 If `enable_compilation` is a list of strings, compilation will only happen if the function name
 of the basic operation appears in this list.
 
+@Section Giving hints to the compiler
+@SectionLabel CompilerHints
+
+You can give hints to the compiler to improve the result of the compilation. Compiler hints are attached to the category by making
+`category!.compiler_hints` a record with one or more of the following keys:
+* `category_attributes_names`: a list of names of attributes of the category. If a global variable in the compiled code has the same value
+                               as one of the given attributes of the category, the global variable is replaced by the attribute getter applied to the category.
+                               Background: During the compilation, the compiler resolves attributes occuring in the code and stores them in global variables
+                               called `CAP_JIT_INTERNAL_GLOBAL_VARIABLE_n` (for integers `n` starting from 1). If these variables cannot be replaced,
+                               the resulting code is only valid in the current session.
+
+Note: The compiler can only discover the hints if the category is the first argument of the function.
+
 @Section Stopping the compiler at a certain level
 
 You can use `StopCompilationAtCategory` to prevent the compiler from inlining and optimizing code of a given category.

--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -90,6 +90,11 @@ You can give hints to the compiler to improve the result of the compilation. Com
                                Background: During the compilation, the compiler resolves attributes occuring in the code and stores them in global variables
                                called `CAP_JIT_INTERNAL_GLOBAL_VARIABLE_n` (for integers `n` starting from 1). If these variables cannot be replaced,
                                the resulting code is only valid in the current session.
+* `source_and_range_attributes_from_morphism_attribute`: a record with keys `object_attribute_name`, `morphism_attribute_name`, `source_attribute_getter_name`,
+                                                         and `range_attribute_getter_name`. Replaces the attribute `object_attribute_name` of the source (resp. range)
+                                                         of a morphism by `source_attribute_getter_name` (resp. `range_attribute_getter_name`) applied to
+                                                         the attribute `morphism_attribute_name` of the morphism. Can be used if objects and morphisms can be
+                                                         easily created from the morphism datum anyway. Note: Some simple expressions like integers are NOT replaced.
 
 Note: The compiler can only discover the hints if the category is the first argument of the function.
 

--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -103,6 +103,10 @@ Note: The compiler can only discover the hints if the category is the first argu
 You can use `StopCompilationAtCategory` to prevent the compiler from inlining and optimizing code of a given category.
 You can revert this decision using `ContinueCompilationAtCategory`.
 
+@Section Precompiling categories
+
+You can compile categories and store the result in a file for later use.
+
 @Section Getting information about the compilation process
 
 You can increase the info level of `InfoCapJit` to get information about the compilation process.

--- a/CompilerForCAP/examples/CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL.g
+++ b/CompilerForCAP/examples/CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL.g
@@ -18,19 +18,20 @@ compiled_func := CapJitCompiledFunction(
     MyKernelLift,
     [ rows, ZeroMorphism( V, V ), IdentityMorphism( V ) ]
 );;
-tree := SYNTAX_TREE( compiled_func );;
-# check that the fail has been compiled away,
-# that is, we simply return a CAP morphism
-Length( tree.stats.statements ) = 1;
-#! true
-tree.stats.statements[1].type = "STAT_RETURN_OBJ";
-#! true
-StartsWith( tree.stats.statements[1].obj.type, "EXPR_FUNCCALL" );
-#! true
-tree.stats.statements[1].obj.funcref.type = "EXPR_REF_GVAR";
-#! true
-tree.stats.statements[1].obj.funcref.gvar = "ObjectifyWithAttributes";
-#! true
+Display( compiled_func );
+#! function ( cat, mor, test_morphism )
+#!     local cap_jit_morphism_attribute;
+#!     cap_jit_morphism_attribute 
+#!      := RightDivide( UnderlyingMatrix( test_morphism ), 
+#!        SyzygiesOfRows( UnderlyingMatrix( mor ) ) );
+#!     return ObjectifyWithAttributes( rec(
+#!            ), MorphismType( cat ), CapCategory, cat, Source, 
+#!        Source( test_morphism ), Range, ObjectifyWithAttributes( rec(
+#!              ), ObjectType( cat ), CapCategory, cat, Dimension, 
+#!          NrColumns( cap_jit_morphism_attribute ), UnderlyingFieldForHomalg, 
+#!          UnderlyingRing( cat ) ), UnderlyingFieldForHomalg, 
+#!        UnderlyingRing( cat ), UnderlyingMatrix, cap_jit_morphism_attribute );
+#! end
 
 func1 := function( x )
     #% CAP_JIT_RESOLVE_FUNCTION

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -2,7 +2,7 @@
 
 #! @Section Examples
 
-LoadPackage( "LinearAlgebra" );
+LoadPackage( "LinearAlgebraForCAP" );
 
 #! @Example
 

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -7,9 +7,7 @@ LoadPackage( "LinearAlgebraForCAP" );
 #! @Example
 
 Q := HomalgFieldOfRationals();;
-vec := MatrixCategory( Q :
-    enable_compilation := [ "MorphismBetweenDirectSums" ]
-);;
+vec := MatrixCategory( Q : enable_compilation := true );;
 
 V := VectorSpaceObject( 2, Q );;
 alpha := ZeroMorphism( V, V );;
@@ -66,6 +64,22 @@ Display( SYNTAX_TREE_CODE( tree2 ) );
 #!                 end ) ) );
 #!     fi;
 #!     return;
+#! end
+
+KernelEmbedding( alpha );;
+Display( Last( vec!.compiled_functions.KernelEmbedding ) );
+#! function ( cat, morphism )
+#!     local cap_jit_morphism_attribute;
+#!     cap_jit_morphism_attribute 
+#!      := SyzygiesOfRows( UnderlyingMatrix( morphism ) );
+#!     return ObjectifyWithAttributes( rec(
+#!            ), MorphismType( cat ), CapCategory, cat, Source, 
+#!        ObjectifyWithAttributes( rec(
+#!              ), ObjectType( cat ), CapCategory, cat, Dimension, 
+#!          NrRows( cap_jit_morphism_attribute ), UnderlyingFieldForHomalg, 
+#!          UnderlyingRing( cat ) ), Range, Source( morphism ), 
+#!        UnderlyingFieldForHomalg, UnderlyingRing( cat ), UnderlyingMatrix, 
+#!        cap_jit_morphism_attribute );
 #! end
 
 #! @EndExample

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -32,9 +32,8 @@ Display( SYNTAX_TREE_CODE( tree1 ) );
 #!         return ZeroMorphism( S, T );
 #!     else
 #!         return ObjectifyWithAttributes( rec(
-#!                ), CAP_JIT_INTERNAL_GLOBAL_VARIABLE_3, CapCategory, 
-#!            CAP_JIT_INTERNAL_GLOBAL_VARIABLE_1, Source, S, Range, T, 
-#!            UnderlyingFieldForHomalg, CAP_JIT_INTERNAL_GLOBAL_VARIABLE_2, 
+#!                ), MorphismType( cat ), CapCategory, cat, Source, S, Range, T, 
+#!            UnderlyingFieldForHomalg, UnderlyingRing( cat ), 
 #!            UnderlyingMatrix, 
 #!            UnionOfRows( List( morphism_matrix, function ( row )
 #!                     return UnionOfColumns( List( row, UnderlyingMatrix ) );
@@ -57,9 +56,8 @@ Display( SYNTAX_TREE_CODE( tree2 ) );
 #!         return ZeroMorphism( S, T );
 #!     else
 #!         return ObjectifyWithAttributes( rec(
-#!                ), CAP_JIT_INTERNAL_GLOBAL_VARIABLE_3, CapCategory, 
-#!            CAP_JIT_INTERNAL_GLOBAL_VARIABLE_1, Source, S, Range, T, 
-#!            UnderlyingFieldForHomalg, CAP_JIT_INTERNAL_GLOBAL_VARIABLE_2, 
+#!                ), MorphismType( cat ), CapCategory, cat, Source, S, Range, T, 
+#!            UnderlyingFieldForHomalg, UnderlyingRing( cat ), 
 #!            UnderlyingMatrix, 
 #!            UnionOfRows( List( morphism_matrix, function ( row )
 #!                     return UnionOfColumns( List( row, function ( s )

--- a/CompilerForCAP/examples/PrecompileLinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/PrecompileLinearAlgebraForCAP.g
@@ -1,0 +1,41 @@
+#! @Chapter Examples and tests
+
+#! @Section Examples
+
+LoadPackage( "LinearAlgebraForCAP" );
+
+#! @Example
+
+QQ := HomalgFieldOfRationals( );;
+
+# be careful not to use `MatrixCategory` because attributes are not supported
+category_constructor := field -> MATRIX_CATEGORY( field );;
+given_arguments := [ QQ ];;
+compiled_category_name := "MatrixCategoryPrecompiled";;
+package_name := "LinearAlgebraForCAP";;
+operations := [
+    "AdditionForMorphisms",
+    "PreCompose",
+    "KernelEmbedding",
+];;
+
+filepath := "precompiled_categories/MatrixCategoryPrecompiled.gi";;
+old_file_content := ReadFileFromPackageForHomalg( package_name, filepath );;
+
+CapJitPrecompileCategory(
+    category_constructor,
+    given_arguments,
+    package_name,
+    compiled_category_name :
+    operations := operations
+);
+
+new_file_content := ReadFileFromPackageForHomalg( package_name, filepath );;
+
+old_file_content = new_file_content;
+#! true
+
+MatrixCategoryPrecompiled( QQ );
+#! Category of matrices over Q
+
+#! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -191,6 +191,18 @@ InstallGlobalFunction( CapJitCompiledFunction, function ( func, jit_args )
         
     od;
     
+    if Length( jit_args ) > 0 and IsCapCategory( jit_args[1] ) then
+        
+        if debug then
+            compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+            Display( compiled_func );
+            Display( "apply CapJitAppliedCompilerHints" );
+        fi;
+        
+        tree := CapJitAppliedCompilerHints( tree, jit_args[1] );
+        
+    fi;
+    
     if debug then
         
         compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );

--- a/CompilerForCAP/gap/CompilerHints.gd
+++ b/CompilerForCAP/gap/CompilerHints.gd
@@ -19,3 +19,9 @@ DeclareGlobalFunction( "CapJitAppliedCompilerHints" );
 #! @Returns a record
 #! @Arguments tree, category
 DeclareGlobalFunction( "CapJitReplacedGlobalVariablesByCategoryAttributes" );
+
+#! @Description
+#!   Applies the compiler hint `source_and_range_attributes_from_morphism_attribute` (see <Ref Sect="Section_CompilerHints" />) to <A>tree</A>.
+#! @Returns a record
+#! @Arguments tree, category
+DeclareGlobalFunction( "CapJitReplacedSourceAndRangeAttributes" );

--- a/CompilerForCAP/gap/CompilerHints.gd
+++ b/CompilerForCAP/gap/CompilerHints.gd
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Declarations
+#
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Applies all compiler hints (see <Ref Sect="Section_CompilerHints" />) to <A>tree</A>.
+#! @Returns a record
+#! @Arguments tree, category
+DeclareGlobalFunction( "CapJitAppliedCompilerHints" );
+
+#! @Description
+#!   Applies the compiler hint `category_attribute_names` (see <Ref Sect="Section_CompilerHints" />) to <A>tree</A>.
+#!   Assumes that <A>category</A> is the first argument of the function defined by <A>tree</A>.
+#! @Returns a record
+#! @Arguments tree, category
+DeclareGlobalFunction( "CapJitReplacedGlobalVariablesByCategoryAttributes" );

--- a/CompilerForCAP/gap/CompilerHints.gi
+++ b/CompilerForCAP/gap/CompilerHints.gi
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Implementations
+#
+
+InstallGlobalFunction( CapJitAppliedCompilerHints, function ( tree, category )
+    
+    tree := CapJitReplacedGlobalVariablesByCategoryAttributes( tree, category );
+    
+    return tree;
+    
+end );
+
+InstallGlobalFunction( CapJitReplacedGlobalVariablesByCategoryAttributes, function ( tree, category )
+  local categories_in_tower, categories_in_tower_getters, category_attribute_values, category_attribute_values_getters, i, cat, cat_getter, attribute_names, value, pre_func, name;
+    
+    categories_in_tower := [ category ];
+    categories_in_tower_getters := [
+        rec(
+            type := "EXPR_REF_FVAR",
+            func_id := tree.id,
+            pos := 1,
+            initial_name := tree.nams[1],
+        )
+    ];
+    
+    category_attribute_values := [ ];
+    category_attribute_values_getters := [ ];
+    
+    i := 1;
+    
+    while i <= Length( categories_in_tower ) do
+        
+        cat := categories_in_tower[i];
+        cat_getter := categories_in_tower_getters[i];
+        
+        if IsBound( cat!.compiler_hints ) and IsBound( cat!.compiler_hints.category_attribute_names ) then
+            
+            attribute_names := cat!.compiler_hints.category_attribute_names;
+            
+        else
+            
+            attribute_names := [ ];
+            
+        fi;
+        
+        # add some attributes by default
+        
+        if HasObjectType( category ) then
+            
+            Add( attribute_names, "ObjectType" );
+            
+        fi;
+        
+        if HasMorphismType( category ) then
+            
+            Add( attribute_names, "MorphismType" );
+            
+        fi;
+        
+        if HasRangeCategoryOfHomomorphismStructure( category ) then
+            
+            Add( attribute_names, "RangeCategoryOfHomomorphismStructure" );
+            
+        fi;
+        
+        for name in attribute_names do
+            
+            value := ValueGlobal( name )( cat );
+            
+            if IsCapCategory( value ) and not ForAny( categories_in_tower, c -> IsIdenticalObj( c, value ) ) then
+                
+                Add( categories_in_tower, value );
+                Add( categories_in_tower_getters,
+                    rec(
+                        type := "EXPR_FUNCCALL",
+                        funcref := rec(
+                            type := "EXPR_REF_GVAR",
+                            gvar := name,
+                        ),
+                        args := [
+                            cat_getter
+                        ],
+                    )
+                );
+                
+            else
+                
+                Add( category_attribute_values, value );
+                Add( category_attribute_values_getters,
+                    rec(
+                        type := "EXPR_FUNCCALL",
+                        funcref := rec(
+                            type := "EXPR_REF_GVAR",
+                            gvar := name,
+                        ),
+                        args := [
+                            cat_getter
+                        ],
+                    )
+                );
+                
+            fi;
+            
+        od;
+        
+        i := i + 1;
+        
+    od;
+    
+    pre_func := function ( tree, additional_arguments )
+      local pos;
+        
+        if IsRecord( tree ) and tree.type = "EXPR_REF_GVAR" then
+            
+            # try to find the value of the global variable in categories_in_tower
+            pos := PositionProperty( categories_in_tower, c -> IsIdenticalObj( c, ValueGlobal( tree.gvar ) ) );
+            
+            if pos <> fail then
+                
+                return categories_in_tower_getters[pos];
+                
+            fi;
+            
+            # try to find the value of the global variable in category_attribute_values
+            pos := PositionProperty( category_attribute_values, v -> IsIdenticalObj( v, ValueGlobal( tree.gvar ) ) );
+            
+            if pos <> fail then
+                
+                return category_attribute_values_getters[pos];
+                
+            fi;
+            
+        fi;
+        
+        return tree;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );

--- a/CompilerForCAP/gap/CompilerHints.gi
+++ b/CompilerForCAP/gap/CompilerHints.gi
@@ -8,6 +8,8 @@ InstallGlobalFunction( CapJitAppliedCompilerHints, function ( tree, category )
     
     tree := CapJitReplacedGlobalVariablesByCategoryAttributes( tree, category );
     
+    tree := CapJitReplacedSourceAndRangeAttributes( tree, category );
+    
     return tree;
     
 end );
@@ -139,5 +141,147 @@ InstallGlobalFunction( CapJitReplacedGlobalVariablesByCategoryAttributes, functi
     end;
     
     return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    
+end );
+
+InstallGlobalFunction( CapJitReplacedSourceAndRangeAttributes, function ( tree, category )
+  local object_attribute_name, morphism_attribute_name, source_attribute_getter_name, range_attribute_getter_name, args, morphism_attribute_position, morphism_attribute_value, source_args, source_attribute_position, range_args, range_attribute_position;
+    
+    if not (IsBound( category!.compiler_hints ) and IsBound( category!.compiler_hints.source_and_range_attributes_from_morphism_attribute )) then
+        
+        return tree;
+        
+    fi;
+    
+    object_attribute_name := category!.compiler_hints.source_and_range_attributes_from_morphism_attribute.object_attribute_name;
+    morphism_attribute_name := category!.compiler_hints.source_and_range_attributes_from_morphism_attribute.morphism_attribute_name;
+    source_attribute_getter_name := category!.compiler_hints.source_and_range_attributes_from_morphism_attribute.source_attribute_getter_name;
+    range_attribute_getter_name := category!.compiler_hints.source_and_range_attributes_from_morphism_attribute.range_attribute_getter_name;
+    
+    if Length( tree.stats.statements ) = 1 and tree.stats.statements[1].type = "STAT_RETURN_OBJ" and CapJitIsCallToGlobalFunction( tree.stats.statements[1].obj, "ObjectifyWithAttributes" ) then
+        
+        args := tree.stats.statements[1].obj.args;
+        
+        if Length( args ) > 7 and args[5].type = "EXPR_REF_GVAR" and args[5].gvar = "Source" and args[7].type = "EXPR_REF_GVAR" and args[7].gvar = "Range" then
+            
+            # check if either Source or Range are constructed inplace
+            if CapJitIsCallToGlobalFunction( args[6], "ObjectifyWithAttributes" ) or CapJitIsCallToGlobalFunction( args[8], "ObjectifyWithAttributes" ) then
+                
+                morphism_attribute_position := PositionProperty( args, x -> x.type = "EXPR_REF_GVAR" and x.gvar = morphism_attribute_name );
+                
+                if morphism_attribute_position = fail then
+                    
+                    Error( "cannot find morphism attribute" );
+                    
+                fi;
+                
+                Assert( 0, morphism_attribute_position < Length( args ) );
+                
+                morphism_attribute_value := args[morphism_attribute_position + 1];
+                
+                tree.nams := Concatenation( tree.nams, [ "cap_jit_morphism_attribute" ] );
+                tree.nloc := tree.nloc + 1;
+                
+                tree.stats.statements := Concatenation(
+                    [
+                        rec(
+                            type := "STAT_ASS_FVAR",
+                            func_id := tree.id,
+                            pos := tree.narg + tree.nloc,
+                            initial_name := "cap_jit_morphism_attribute",
+                            rhs := morphism_attribute_value,
+                        )
+                    ],
+                    tree.stats.statements
+                );
+                
+                args[morphism_attribute_position + 1] := rec(
+                    type := "EXPR_REF_FVAR",
+                    func_id := tree.id,
+                    pos := tree.narg + tree.nloc,
+                    initial_name := "cap_jit_morphism_attribute",
+                );
+                
+                if CapJitIsCallToGlobalFunction( args[6], "ObjectifyWithAttributes" ) then
+                    
+                    source_args := args[6].args;
+                    
+                    source_attribute_position := PositionProperty( source_args, x -> x.type = "EXPR_REF_GVAR" and x.gvar = object_attribute_name );
+                    
+                    if source_attribute_position = fail then
+                        
+                        Error( "cannot find source attribute" );
+                        
+                    fi;
+                    
+                    Assert( 0, source_attribute_position < Length( source_args ) );
+                    
+                    # ignore simple expression, e.g. integers
+                    if not source_args[source_attribute_position + 1].type in [ "EXPR_INT", "EXPR_STRING", , "EXPR_CHAR", "EXPR_TRUE", "EXPR_FALSE", "EXPR_REF_GVAR", "EXPR_RANGE" ] then
+                        
+                        source_args[source_attribute_position + 1] := rec(
+                            type := "EXPR_FUNCCALL",
+                            funcref := rec(
+                                type := "EXPR_REF_GVAR",
+                                gvar := source_attribute_getter_name,
+                            ),
+                            args := [
+                                rec(
+                                    type := "EXPR_REF_FVAR",
+                                    func_id := tree.id,
+                                    pos := tree.narg + tree.nloc,
+                                    initial_name := "cap_jit_morphism_attribute",
+                                ),
+                            ],
+                        );
+                        
+                    fi;
+                    
+                fi;
+                        
+                if CapJitIsCallToGlobalFunction( args[8], "ObjectifyWithAttributes" ) then
+                    
+                    range_args := args[8].args;
+                    
+                    range_attribute_position := PositionProperty( range_args, x -> x.type = "EXPR_REF_GVAR" and x.gvar = object_attribute_name );
+                    
+                    if range_attribute_position = fail then
+                        
+                        Error( "cannot find range attribute" );
+                        
+                    fi;
+                    
+                    Assert( 0, range_attribute_position < Length( range_args ) );
+                    
+                    # ignore simple expression, e.g. integers
+                    if not range_args[range_attribute_position + 1].type in [ "EXPR_INT", "EXPR_STRING", , "EXPR_CHAR", "EXPR_TRUE", "EXPR_FALSE", "EXPR_REF_GVAR", "EXPR_RANGE" ] then
+                        
+                        range_args[range_attribute_position + 1] := rec(
+                            type := "EXPR_FUNCCALL",
+                            funcref := rec(
+                                type := "EXPR_REF_GVAR",
+                                gvar := range_attribute_getter_name,
+                            ),
+                            args := [
+                                rec(
+                                    type := "EXPR_REF_FVAR",
+                                    func_id := tree.id,
+                                    pos := tree.narg + tree.nloc,
+                                    initial_name := "cap_jit_morphism_attribute",
+                                ),
+                            ],
+                        );
+                        
+                    fi;
+                    
+                fi;
+                
+            fi;
+            
+        fi;
+        
+    fi;
+    
+    return tree;
     
 end );

--- a/CompilerForCAP/gap/PrecompileCategory.gd
+++ b/CompilerForCAP/gap/PrecompileCategory.gd
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Declarations
+#
+#! @Chapter Using the compiler
+
+#! @Section Precompiling categories
+
+#! @Description
+#!   Compiles operations of the CAP category returned by the function <A>category_constructor</A> applied to <A>given_arguments</A>.
+#!   The result is available via a global function called <A>compiled_category_name</A> which is written to the file <A>package_name</A>`/precompiled_categories/`<A>compiled_category_name</A>`.gi`.
+#!   The global function takes the same arguments as <A>category_constructor</A> and returns the category with the compiled functions installed as primitive operations.
+#!   If a list of operations is given via the option `operations`, only operations in this list are precompiled.
+#!   Else all installed operations of the category are precompiled.
+#!   Technical requirements:
+#!     * <A>category_constructor</A> must be a regular function, i.e. not an operation or a kernel function.
+#!     * <A>category_constructor</A> must support the options `FinalizeCategory` and `enable_compilation`.
+#!       WARNING: When using attributes you might run into errors because the options are only respected the first time you call the attribute getter.
+#!     * The compiler has to create a valid input for the operations which should be compiled. Currently, this leads to the following restrictions
+#!       (detailed errors are thrown if any of the restrictions is not met):
+#!       * Only categories with a zero object and zero morphisms can be compiled.
+#!       * Not all CAP operations are available for compilation.
+#!       * `WithGiven` operations can only be compiled if the object operation is computable.
+#! @Returns a record
+#! @Arguments category_constructor, given_arguments, package_name, compiled_category_name
+DeclareGlobalFunction( "CapJitPrecompileCategory" );

--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Implementations
+#
+InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_constructor, given_arguments, package_name, compiled_category_name )
+  local cat, obj, mor, safe_operations, operations, diff, output_string, package_info, parameters_string, current_string, object_name, index, compiled_func, function_string, filter_list, example_input, function_name, current_rec;
+    
+    if IsOperation( category_constructor ) or IsKernelFunction( category_constructor ) then
+        
+        Error( "category_constructor must be a regular function, i.e. not an operation or a kernel function" );
+        
+    fi;
+    
+    # check that category_constructor supports `FinalizeCategory` and `enable_compilation`
+    cat := CallFuncList( category_constructor, given_arguments : FinalizeCategory := false, enable_compilation := true );
+    
+    if HasIsFinalized( cat ) then
+        
+        Error( "the category constructor must support the option `FinalizeCategory`" );
+        
+    fi;
+    
+    Finalize( cat );
+    
+    if cat!.enable_compilation <> true then
+        
+        Error( "the category constructor must support the option `enable_compilation`" );
+        
+    fi;
+    
+    if not (CanCompute( cat, "ZeroObject" ) and CanCompute( cat, "ZeroMorphism" )) then
+        
+        Error( "Currently only categories with zero objects and morphisms can be precompiled." );
+        
+    fi;
+    
+    obj := ZeroObject( cat );
+    mor := ZeroMorphism( obj, obj );
+    
+    # operations for which our example input constructed below is a valid input
+    safe_operations := [
+        "AdditionForMorphisms",
+        "AdditiveInverseForMorphisms",
+        "AstrictionToCoimage",
+        "AstrictionToCoimageWithGivenCoimage",
+        "BasisOfExternalHom",
+        "CanonicalIdentificationFromCoimageToImageObject",
+        "CanonicalIdentificationFromImageObjectToCoimage",
+        "CoastrictionToImage",
+        "CoastrictionToImageWithGivenImageObject",
+        #"CoefficientsOfMorphismWithGivenBasisOfExternalHom",
+        "Coequalizer",
+        #"CoequalizerFunctorialWithGivenCoequalizers",
+        "Coimage",
+        "CoimageProjection",
+        "CoimageProjectionWithGivenCoimage",
+        "CokernelColift",
+        "CokernelColiftWithGivenCokernelObject",
+        "CokernelObject",
+        #"CokernelObjectFunctorialWithGivenCokernelObjects",
+        "CokernelProjection",
+        "CokernelProjectionWithGivenCokernelObject",
+        "Colift",
+        "ColiftAlongEpimorphism",
+        #"ComponentOfMorphismFromDirectSum",
+        #"ComponentOfMorphismIntoDirectSum",
+        "Coproduct",
+        #"CoproductFunctorialWithGivenCoproducts",
+        "DirectProduct",
+        #"DirectProductFunctorialWithGivenDirectProducts",
+        "DirectSum",
+        "DirectSumCodiagonalDifference",
+        "DirectSumDiagonalDifference",
+        #"DirectSumFunctorialWithGivenDirectSums",
+        "DirectSumProjectionInPushout",
+        "DistinguishedObjectOfHomomorphismStructure",
+        "EmbeddingOfEqualizer",
+        "EmbeddingOfEqualizerWithGivenEqualizer",
+        "EpimorphismFromSomeProjectiveObject",
+        "EpimorphismFromSomeProjectiveObjectWithGivenSomeProjectiveObject",
+        "Equalizer",
+        #"EqualizerFunctorialWithGivenEqualizers",
+        "FiberProduct",
+        "FiberProductEmbeddingInDirectSum",
+        #"FiberProductFunctorialWithGivenFiberProducts",
+        "HomologyObject",
+        #"HomologyObjectFunctorialWithGivenHomologyObjects",
+        #"HomomorphismStructureOnMorphismsWithGivenObjects",
+        "HomomorphismStructureOnObjects",
+        #"HorizontalPostCompose",
+        #"HorizontalPreCompose",
+        "IdentityMorphism",
+        #"IdentityTwoCell",
+        "ImageEmbedding",
+        "ImageEmbeddingWithGivenImageObject",
+        "ImageObject",
+        "InitialObject",
+        "InitialObjectFunctorial",
+        "InjectionOfCofactorOfCoproduct",
+        "InjectionOfCofactorOfCoproductWithGivenCoproduct",
+        "InjectionOfCofactorOfDirectSum",
+        "InjectionOfCofactorOfDirectSumWithGivenDirectSum",
+        "InjectionOfCofactorOfPushout",
+        "InjectionOfCofactorOfPushoutWithGivenPushout",
+        "InjectiveColift",
+        "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure",
+        #"InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
+        "InverseForMorphisms",
+        #"InverseMorphismFromCoimageToImageWithGivenObjects",
+        "IsAutomorphism",
+        #"IsCodominating",
+        "IsColiftable",
+        "IsColiftableAlongEpimorphism",
+        "IsCongruentForMorphisms",
+        #"IsDominating",
+        "IsEndomorphism",
+        "IsEpimorphism",
+        #"IsEqualAsFactorobjects",
+        #"IsEqualAsSubobjects",
+        "IsEqualForCacheForMorphisms",
+        "IsEqualForCacheForObjects",
+        "IsEqualForMorphisms",
+        "IsEqualForMorphismsOnMor",
+        "IsEqualForObjects",
+        "IsHomSetInhabited",
+        "IsIdempotent",
+        "IsIdenticalToIdentityMorphism",
+        "IsIdenticalToZeroMorphism",
+        "IsInitial",
+        "IsInjective",
+        "IsIsomorphism",
+        "IsLiftable",
+        "IsLiftableAlongMonomorphism",
+        "IsMonomorphism",
+        "IsOne",
+        "IsProjective",
+        "IsSplitEpimorphism",
+        "IsSplitMonomorphism",
+        "IsTerminal",
+        "IsWellDefinedForMorphisms",
+        "IsWellDefinedForObjects",
+        #"IsWellDefinedForTwoCells",
+        "IsZeroForMorphisms",
+        "IsZeroForObjects",
+        "IsomorphismFromCoequalizerOfCoproductDiagramToPushout",
+        "IsomorphismFromCoimageToCokernelOfKernel",
+        "IsomorphismFromCokernelOfDiagonalDifferenceToPushout",
+        "IsomorphismFromCokernelOfKernelToCoimage",
+        "IsomorphismFromCoproductToDirectSum",
+        "IsomorphismFromDirectProductToDirectSum",
+        "IsomorphismFromDirectSumToCoproduct",
+        "IsomorphismFromDirectSumToDirectProduct",
+        "IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct",
+        "IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram",
+        "IsomorphismFromFiberProductToKernelOfDiagonalDifference",
+        "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
+        "IsomorphismFromImageObjectToKernelOfCokernel",
+        "IsomorphismFromInitialObjectToZeroObject",
+        "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject",
+        "IsomorphismFromKernelOfCokernelToImageObject",
+        "IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct",
+        "IsomorphismFromPushoutToCoequalizerOfCoproductDiagram",
+        "IsomorphismFromPushoutToCokernelOfDiagonalDifference",
+        "IsomorphismFromTerminalObjectToZeroObject",
+        "IsomorphismFromZeroObjectToInitialObject",
+        "IsomorphismFromZeroObjectToTerminalObject",
+        "KernelEmbedding",
+        "KernelEmbeddingWithGivenKernelObject",
+        "KernelLift",
+        "KernelLiftWithGivenKernelObject",
+        "KernelObject",
+        #"KernelObjectFunctorialWithGivenKernelObjects",
+        "Lift",
+        "LiftAlongMonomorphism",
+        #"MereExistenceOfSolutionOfLinearSystemInAbCategory",
+        "MonomorphismIntoSomeInjectiveObject",
+        "MonomorphismIntoSomeInjectiveObjectWithGivenSomeInjectiveObject",
+        #"MorphismBetweenDirectSumsWithGivenDirectSums",
+        #"MorphismFromCoimageToImageWithGivenObjects",
+        "MorphismFromEqualizerToSink",
+        "MorphismFromEqualizerToSinkWithGivenEqualizer",
+        "MorphismFromFiberProductToSink",
+        "MorphismFromFiberProductToSinkWithGivenFiberProduct",
+        "MorphismFromKernelObjectToSink",
+        "MorphismFromKernelObjectToSinkWithGivenKernelObject",
+        "MorphismFromSourceToCoequalizer",
+        "MorphismFromSourceToCoequalizerWithGivenCoequalizer",
+        "MorphismFromSourceToCokernelObject",
+        "MorphismFromSourceToCokernelObjectWithGivenCokernelObject",
+        "MorphismFromSourceToPushout",
+        "MorphismFromSourceToPushoutWithGivenPushout",
+        #"MultiplyWithElementOfCommutativeRingForMorphisms",
+        "PostCompose",
+        "PreCompose",
+        "ProjectionInFactorOfDirectProduct",
+        "ProjectionInFactorOfDirectProductWithGivenDirectProduct",
+        "ProjectionInFactorOfDirectSum",
+        "ProjectionInFactorOfDirectSumWithGivenDirectSum",
+        "ProjectionInFactorOfFiberProduct",
+        "ProjectionInFactorOfFiberProductWithGivenFiberProduct",
+        "ProjectionOntoCoequalizer",
+        "ProjectionOntoCoequalizerWithGivenCoequalizer",
+        "ProjectiveLift",
+        "Pushout",
+        #"PushoutFunctorialWithGivenPushouts",
+        #"RandomMorphismByInteger",
+        #"RandomMorphismByList",
+        #"RandomMorphismWithFixedRangeByInteger",
+        #"RandomMorphismWithFixedRangeByList",
+        #"RandomMorphismWithFixedSourceAndRangeByInteger",
+        #"RandomMorphismWithFixedSourceAndRangeByList",
+        #"RandomMorphismWithFixedSourceByInteger",
+        #"RandomMorphismWithFixedSourceByList",
+        #"RandomObjectByInteger",
+        #"RandomObjectByList",
+        #"SimplifyEndo",
+        #"SimplifyEndo_IsoFromInputObject",
+        #"SimplifyEndo_IsoToInputObject",
+        #"SimplifyMorphism",
+        #"SimplifyObject",
+        #"SimplifyObject_IsoFromInputObject",
+        #"SimplifyObject_IsoToInputObject",
+        #"SimplifyRange",
+        #"SimplifyRange_IsoFromInputObject",
+        #"SimplifyRange_IsoToInputObject",
+        #"SimplifySource",
+        #"SimplifySourceAndRange",
+        #"SimplifySourceAndRange_IsoFromInputRange",
+        #"SimplifySourceAndRange_IsoFromInputSource",
+        #"SimplifySourceAndRange_IsoToInputRange",
+        #"SimplifySourceAndRange_IsoToInputSource",
+        #"SimplifySource_IsoFromInputObject",
+        #"SimplifySource_IsoToInputObject",
+        #"SolveLinearSystemInAbCategory",
+        "SomeInjectiveObject",
+        "SomeProjectiveObject",
+        #"SomeReductionBySplitEpiSummand",
+        #"SomeReductionBySplitEpiSummand_MorphismFromInputRange",
+        #"SomeReductionBySplitEpiSummand_MorphismToInputRange",
+        "SubtractionForMorphisms",
+        "TerminalObject",
+        "TerminalObjectFunctorial",
+        "UniversalMorphismFromCoequalizer",
+        "UniversalMorphismFromCoequalizerWithGivenCoequalizer",
+        "UniversalMorphismFromCoproduct",
+        "UniversalMorphismFromCoproductWithGivenCoproduct",
+        "UniversalMorphismFromDirectSum",
+        "UniversalMorphismFromDirectSumWithGivenDirectSum",
+        #"UniversalMorphismFromImage",
+        #"UniversalMorphismFromImageWithGivenImageObject",
+        "UniversalMorphismFromInitialObject",
+        "UniversalMorphismFromInitialObjectWithGivenInitialObject",
+        "UniversalMorphismFromPushout",
+        "UniversalMorphismFromPushoutWithGivenPushout",
+        "UniversalMorphismFromZeroObject",
+        "UniversalMorphismFromZeroObjectWithGivenZeroObject",
+        #"UniversalMorphismIntoCoimage",
+        #"UniversalMorphismIntoCoimageWithGivenCoimage",
+        "UniversalMorphismIntoDirectProduct",
+        "UniversalMorphismIntoDirectProductWithGivenDirectProduct",
+        "UniversalMorphismIntoDirectSum",
+        "UniversalMorphismIntoDirectSumWithGivenDirectSum",
+        "UniversalMorphismIntoEqualizer",
+        "UniversalMorphismIntoEqualizerWithGivenEqualizer",
+        "UniversalMorphismIntoFiberProduct",
+        "UniversalMorphismIntoFiberProductWithGivenFiberProduct",
+        "UniversalMorphismIntoTerminalObject",
+        "UniversalMorphismIntoTerminalObjectWithGivenTerminalObject",
+        "UniversalMorphismIntoZeroObject",
+        "UniversalMorphismIntoZeroObjectWithGivenZeroObject",
+        #"VerticalPostCompose",
+        #"VerticalPreCompose",
+        "ZeroMorphism",
+        "ZeroObject",
+        "ZeroObjectFunctorial",
+    ];
+    
+    if ValueOption( "operations" ) = fail then
+        
+        operations := Intersection( ListInstalledOperationsOfCategory( cat ), safe_operations );
+        
+    else
+        
+        operations := ValueOption( "operations" );
+        
+    fi;
+    
+    diff := Difference( operations, safe_operations );
+
+    if Length( diff ) > 0 then
+        
+        Error( "Cannot compile the following operations yet: ", diff );
+        
+    fi;
+    
+    diff := Difference( operations, ListInstalledOperationsOfCategory( cat ) );
+
+    if Length( diff ) > 0 then
+        
+        Error( "The following operations you want to have compiled are not computable in the given category: ", diff );
+        
+    fi;
+    
+    output_string := "";
+    
+    package_info := First( PackageInfo( package_name ) );
+    
+    if package_info = fail then
+        
+        Error( "could not find package info" );
+        
+    fi;
+    
+    parameters_string := JoinStringsWithSeparator( NamesLocalVariablesFunction( category_constructor ), ", " );
+    
+    current_string := Concatenation(
+        "# SPDX-License-Identifier: GPL-2.0-or-later\n",
+        "# ", package_name, ": ", package_info.Subtitle, "\n",
+        "#\n",
+        "# Implementations\n",
+        "#\n",
+        "BindGlobal( \"", compiled_category_name, "\", function ( ", parameters_string, " )\n",
+        "  local category_constructor, cat;\n",
+        "    \n",
+        "    category_constructor := \n",
+        "        \n",
+        "        \n",
+        "        ", CapJitPrettyPrintFunction( category_constructor ), ";\n",
+        "        \n",
+        "        \n",
+        "    \n",
+        "    cat := category_constructor( ", parameters_string, " : FinalizeCategory := false );\n"
+    );
+    output_string := Concatenation( output_string, current_string );
+    
+    for function_name in operations do
+        
+        current_rec := CAP_INTERNAL_METHOD_NAME_RECORD.(function_name);
+        
+        filter_list := current_rec.filter_list;
+        
+        # check if we can construct an example input
+        if not ForAll( filter_list, f -> f in [ "category", "object", "morphism", "list_of_objects", "list_of_morphisms", IsInt ] ) then
+            
+            Error( "cannot generate example input for the operation ", function_name );
+            
+        fi;
+        
+        example_input := List( filter_list, function ( filter )
+            
+            if filter = "category" then
+                
+                return cat;
+                
+            elif filter = "object" then
+                
+                return obj;
+                
+            elif filter = "morphism" then
+                
+                return mor;
+                
+            elif filter = "list_of_objects" then
+                
+                return [ obj ];
+                
+            elif filter = "list_of_morphisms" then
+                
+                return [ mor ];
+                
+            elif filter = IsInt then
+                
+                return 1;
+                
+            else
+                
+                Error( "this should never happen" );
+                
+            fi;
+            
+        end );
+        
+        if current_rec.is_with_given then
+            
+            # try to use object as last argument
+            
+            object_name := current_rec.with_given_object_name;
+            
+            if CanCompute( cat, object_name ) then
+                
+                example_input[Length( example_input )] := CallFuncList( ValueGlobal( object_name ), example_input{[ 1 .. current_rec.number_of_diagram_arguments + 1 ]} );
+                
+            else
+                
+                Error( "The category cannot compute the object operation of a WithGiven operation. This is not supported." );
+                
+            fi;
+            
+        fi;
+        
+        # trigger compilation
+        CallFuncList( ValueGlobal( function_name ), example_input );
+        
+        # find the last added function with no additional filters
+        index := Last( PositionsProperty( cat!.added_functions.(function_name), f -> Length( f[2] ) = 0 ) );
+        
+        if not IsBound( cat!.compiled_functions.(function_name)[index] ) then
+            
+            Error( "Could not find compiled function. Probably you have installed operations with additional filters and those are compiled instead of the general ones." );
+            
+        fi;
+        
+        compiled_func := cat!.compiled_functions.(function_name)[index];
+        
+        function_string := CapJitPrettyPrintFunction( compiled_func );
+        
+        if PositionSublist( function_string, "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_" ) <> fail then
+            
+            Error( "Could not get rid of all global functions. You should use category_hints.category_attribute_names." );
+            
+        fi;
+        
+        current_string := Concatenation(
+            "    \n",
+            "    ##\n",
+            "    Add", function_name, "( cat,\n",
+            "        \n",
+            "        \n",
+            "        ", function_string, "\n",
+            "        \n",
+            "        \n",
+            "    );\n"
+        );
+        output_string := Concatenation( output_string, current_string );
+        
+    od;
+    
+    current_string := Concatenation(
+        "    \n",
+        "    Finalize( cat );\n",
+        "    \n",
+        "    return cat;\n",
+        "    \n",
+        "end );\n"
+    );
+    output_string := Concatenation( output_string, current_string );
+    
+    WriteFileInPackageForHomalg( package_name, Concatenation( "precompiled_categories/", compiled_category_name, ".gi" ), output_string );
+    
+end );

--- a/CompilerForCAP/gap/Tools.gd
+++ b/CompilerForCAP/gap/Tools.gd
@@ -72,3 +72,10 @@ DeclareGlobalFunction( "CapJitGetNodeByPath" );
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitRemovedReturnFail" );
+
+#! @Description
+#!   Pretty prints the function <A>func</A> and returns the result.
+#!   <A>func</A> must be a regular function, i.e. not an operation or a kernel function.
+#! @Returns a string
+#! @Arguments func
+DeclareGlobalFunction( "CapJitPrettyPrintFunction" );

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -409,3 +409,33 @@ InstallGlobalFunction( CapJitRemovedReturnFail, function ( tree )
     return tree;
     
 end );
+
+InstallGlobalFunction( CapJitPrettyPrintFunction, function ( func )
+  local size_screen, function_string, string_stream;
+    
+    if IsOperation( func ) or IsKernelFunction( func ) then
+        
+        Error( "<func> must neither be an operation nor a kernel function" );
+        
+    fi;
+    
+    size_screen := SizeScreen( );
+    
+    # Lines which are exceeding SizeScreen and are thus wrapped using "\" are still valid GAP code,
+    # so this is purely cosmetic.
+    # We cannot use SetPrintFormattingStatus as that also prevents indentation.
+    SizeScreen( [ 4096 ] );
+    
+    function_string := "";
+    
+    string_stream := OutputTextString( function_string, false );
+    
+    PrintTo( string_stream, func );
+    
+    CloseStream( string_stream );
+    
+    SizeScreen( size_screen );
+    
+    return function_string;
+    
+end );

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -4,36 +4,36 @@
 # Reading the declaration part of the package.
 #
 
-ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gd");
+ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gd");
+ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/Tools.gd");
+ReadPackage( "CompilerForCAP", "gap/Tools.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gd");
+ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gd");
+ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gd");
+ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gd");
+ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineArguments.gd");
+ReadPackage( "CompilerForCAP", "gap/InlineArguments.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gd");
+ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gd");
+ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gd");
+ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gd");
+ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gd");
+ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gd");
+ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/Logic.gd");
+ReadPackage( "CompilerForCAP", "gap/Logic.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gd");
+ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gd" );
 
-ReadPackage( "CompilerForCAP", "gap/CompilerHints.gd");
+ReadPackage( "CompilerForCAP", "gap/CompilerHints.gd" );

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -35,3 +35,5 @@ ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gd");
 ReadPackage( "CompilerForCAP", "gap/Logic.gd");
 
 ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gd");
+
+ReadPackage( "CompilerForCAP", "gap/CompilerHints.gd");

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -37,3 +37,5 @@ ReadPackage( "CompilerForCAP", "gap/Logic.gd" );
 ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gd" );
 
 ReadPackage( "CompilerForCAP", "gap/CompilerHints.gd" );
+
+ReadPackage( "CompilerForCAP", "gap/PrecompileCategory.gd" );

--- a/CompilerForCAP/makefile
+++ b/CompilerForCAP/makefile
@@ -32,14 +32,14 @@ test-with-coverage: doc
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap --quitonbreak
 
 test-spacing:
-	grep -R "[^ []  " gap/*.gi && echo "Duplicate spaces found" && exit 1 || exit 0
+	grep -R "[^ []  " gap/*.gi | grep -v '\\n' && echo "Duplicate spaces found" && exit 1 || exit 0
 	grep -RE '[^ ] +$$' gap/* && echo "Trailing whitespace found" && exit 1 || exit 0
 	for filename in gap/*; do \
 		echo $$filename; \
 		echo "LoadPackage(\"CompilerForCAP\"); SizeScreen([4096]); func := ReadAsFunction(\"$$filename\"); FileString(\"gap_spacing\", PrintString(func));" | gap --quitonbreak --banner; \
 		echo -e "\033[0m"; \
-		cat "gap_spacing" | sed 's/^function ( ) //g' | sed 's/ return; end$$//g' | sed 's/;/;\n/g' > modified_gap_spacing; \
-		cat "$$filename" | grep -v "^ *[#]" | sed 's/^ *//' | grep -v "^$$" | tr "\n" " " | sed "s/;/;\n/g" | head -c -1 > modified_custom_spacing; \
+		cat "gap_spacing" | sed 's/^function ( ) //g' | sed 's/ return; end$$//g' | sed 's/;/;\n/g' | grep -v '\\n' > modified_gap_spacing; \
+		cat "$$filename" | grep -v "^ *[#]" | sed 's/^ *//' | grep -v "^$$" | grep -v '\\n' | tr "\n" " " | sed "s/;/;\n/g" | head -c -1 > modified_custom_spacing; \
 		diff modified_gap_spacing modified_custom_spacing > spacing_diff; \
 		diff modified_gap_spacing modified_custom_spacing --ignore-all-space --ignore-space-change --ignore-trailing-space --ignore-blank-lines > spacing_diff_no_blanks; \
 		diff spacing_diff_no_blanks spacing_diff || exit; \

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -35,3 +35,5 @@ ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gi");
 ReadPackage( "CompilerForCAP", "gap/Logic.gi");
 
 ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gi");
+
+ReadPackage( "CompilerForCAP", "gap/CompilerHints.gi");

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -37,3 +37,5 @@ ReadPackage( "CompilerForCAP", "gap/Logic.gi" );
 ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gi" );
 
 ReadPackage( "CompilerForCAP", "gap/CompilerHints.gi" );
+
+ReadPackage( "CompilerForCAP", "gap/PrecompileCategory.gi" );

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -4,36 +4,36 @@
 # Reading the implementation part of the package.
 #
 
-ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gi");
+ReadPackage( "CompilerForCAP", "gap/CompilerForCAP.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gi");
+ReadPackage( "CompilerForCAP", "gap/IterateOverTree.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/Tools.gi");
+ReadPackage( "CompilerForCAP", "gap/Tools.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gi");
+ReadPackage( "CompilerForCAP", "gap/EnhancedSyntaxTree.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gi");
+ReadPackage( "CompilerForCAP", "gap/PrettyPrintSyntaxTree.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gi");
+ReadPackage( "CompilerForCAP", "gap/GetValuesFromJitArgs.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gi");
+ReadPackage( "CompilerForCAP", "gap/ResolveOperations.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineArguments.gi");
+ReadPackage( "CompilerForCAP", "gap/InlineArguments.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gi");
+ReadPackage( "CompilerForCAP", "gap/DropUnusedVariables.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gi");
+ReadPackage( "CompilerForCAP", "gap/InlineVariableAssignments.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gi");
+ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gi");
+ReadPackage( "CompilerForCAP", "gap/DropHandledEdgeCases.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gi");
+ReadPackage( "CompilerForCAP", "gap/InlineSimpleFunctionCalls.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gi");
+ReadPackage( "CompilerForCAP", "gap/InlineFunctionCalls.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/Logic.gi");
+ReadPackage( "CompilerForCAP", "gap/Logic.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gi");
+ReadPackage( "CompilerForCAP", "gap/LogicTemplates.gi" );
 
-ReadPackage( "CompilerForCAP", "gap/CompilerHints.gi");
+ReadPackage( "CompilerForCAP", "gap/CompilerHints.gi" );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -23,6 +23,18 @@ InstallMethod( CategoryOfRows,
     
     category!.category_as_first_argument := true;
     
+    category!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingRing",
+        ],
+        source_and_range_attributes_from_morphism_attribute := rec(
+            object_attribute_name := "RankOfObject",
+            morphism_attribute_name := "UnderlyingMatrix",
+            source_attribute_getter_name := "NrRows",
+            range_attribute_getter_name := "NrColumns",
+        ),
+    );
+    
     SetFilterObj( category, IsCategoryOfRows );
 
     if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -33,6 +33,12 @@ InstallGlobalFunction( FREYD_CATEGORY,
     
     freyd_category!.category_as_first_argument := true;
     
+    freyd_category!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingCategory",
+        ],
+    );
+    
     SetFilterObj( freyd_category, IsFreydCategory );
     
     SetIsAdditiveCategory( freyd_category, true );

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
@@ -29,6 +29,9 @@ DeclareCategory( "IsMatrixCategory",
 DeclareAttribute( "MatrixCategory",
                   IsFieldForHomalg );
 
+# provide a constructor which is not an attribute
+DeclareGlobalFunction( "MATRIX_CATEGORY" );
+
 DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY" );
 
 ####################################

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -24,6 +24,12 @@ InstallMethod( MatrixCategory,
     
     category!.category_as_first_argument := true;
     
+    category!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingRing",
+        ],
+    );
+    
     SetFilterObj( category, IsMatrixCategory );
     
     AddObjectRepresentation( category, IsVectorSpaceObject and HasIsProjective and IsProjective );

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -28,6 +28,12 @@ InstallMethod( MatrixCategory,
         category_attribute_names := [
             "UnderlyingRing",
         ],
+        source_and_range_attributes_from_morphism_attribute := rec(
+            object_attribute_name := "Dimension",
+            morphism_attribute_name := "UnderlyingMatrix",
+            source_attribute_getter_name := "NrRows",
+            range_attribute_getter_name := "NrColumns",
+        ),
     );
     
     SetFilterObj( category, IsMatrixCategory );

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -18,6 +18,13 @@ InstallMethod( MatrixCategory,
                [ IsFieldForHomalg ],
                
   function( homalg_field )
+    
+    return MATRIX_CATEGORY( homalg_field );
+    
+end );
+
+InstallGlobalFunction( MATRIX_CATEGORY,
+  function( homalg_field )
     local category, to_be_finalized;
     
     category := CreateCapCategory( Concatenation( "Category of matrices over ", RingName( homalg_field ) ) );
@@ -295,7 +302,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     AddZeroObject( category,
       function( cat )
         
-        return VectorSpaceObject( 0, homalg_field );
+        return MatrixCategoryObject( cat, 0 );
         
     end );
     
@@ -328,7 +335,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
       
       dimension := Sum( List( object_list, object -> Dimension( object ) ) );
       
-      return VectorSpaceObject( dimension, homalg_field );
+      return MatrixCategoryObject( cat, dimension );
       
     end );
     
@@ -473,7 +480,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         homalg_matrix := UnderlyingMatrix( morphism );
         
-        return VectorSpaceObject( NrRows( homalg_matrix ) - RowRankOfMatrix( homalg_matrix ), homalg_field );
+        return MatrixCategoryObject( cat, NrRows( homalg_matrix ) - RowRankOfMatrix( homalg_matrix ) );
         
     end );
     
@@ -484,7 +491,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         kernel_emb := SyzygiesOfRows( UnderlyingMatrix( morphism ) );
         
-        kernel_object := VectorSpaceObject( NrRows( kernel_emb ), homalg_field );
+        kernel_object := MatrixCategoryObject( cat, NrRows( kernel_emb ) );
         
         return VectorSpaceMorphism( kernel_object, kernel_emb, Source( morphism ) );
         
@@ -516,7 +523,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         homalg_matrix := UnderlyingMatrix( morphism );
         
-        return VectorSpaceObject( NrColumns( homalg_matrix ) - RowRankOfMatrix( homalg_matrix ), homalg_field );
+        return MatrixCategoryObject( cat, NrColumns( homalg_matrix ) - RowRankOfMatrix( homalg_matrix ) );
         
     end );
     
@@ -527,7 +534,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         cokernel_proj := SyzygiesOfColumns( UnderlyingMatrix( morphism ) );
         
-        cokernel_obj := VectorSpaceObject( NrColumns( cokernel_proj ), homalg_field );
+        cokernel_obj := MatrixCategoryObject( cat, NrColumns( cokernel_proj ) );
         
         return VectorSpaceMorphism( Range( morphism ), cokernel_proj, cokernel_obj );
         
@@ -592,7 +599,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
       [ 
         [ function( cat, object_1, object_2 )
             
-            return VectorSpaceObject( Dimension( object_1 ) * Dimension( object_2 ), homalg_field );
+            return MatrixCategoryObject( cat, Dimension( object_1 ) * Dimension( object_2 ) );
             
           end,
           
@@ -633,7 +640,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
       
       function( cat )
         
-        return VectorSpaceObject( 1, homalg_field );
+        return MatrixCategoryObject( cat, 1 );
         
     end );
     
@@ -753,7 +760,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     AddHomomorphismStructureOnObjects( category,
       function( cat, object_1, object_2 )
         
-        return VectorSpaceObject( Dimension( object_1 ) * Dimension( object_2 ), homalg_field );
+        return MatrixCategoryObject( cat, Dimension( object_1 ) * Dimension( object_2 ) );
         
     end );
     
@@ -773,7 +780,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
     AddDistinguishedObjectOfHomomorphismStructure( category,
       function( cat )
         
-        return VectorSpaceObject( 1, homalg_field );
+        return MatrixCategoryObject( cat, 1 );
       
     end );
     
@@ -787,9 +794,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         new_matrix := ConvertMatrixToRow( matrix );
         
         return VectorSpaceMorphism(
-          VectorSpaceObject( 1, homalg_field ),
+          MatrixCategoryObject( cat, 1 ),
           new_matrix,
-          VectorSpaceObject( NrColumns( new_matrix ), homalg_field )
+          MatrixCategoryObject( cat, NrColumns( new_matrix ) )
         );
         
     end );

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gd
@@ -40,14 +40,13 @@ DeclareOperation( "VectorSpaceObject",
                   [ IsInt, IsFieldForHomalg ] );
 
 #! @Description
-#! The arguments are a homalg field $F$
+#! The arguments are a matrix category $cat$ over a field
 #! and a non-negative integer $d$.
-#! The output is an object in the category of
-#! matrices over $F$ of dimension $d$.
+#! The output is an object in $cat$ of dimension $d$.
 #! @Returns an object
-#! @Arguments F, d
+#! @Arguments cat, d
 KeyDependentOperation( "MatrixCategoryObject",
-                       IsFieldForHomalg, IsInt, ReturnTrue );
+                       IsMatrixCategory, IsInt, ReturnTrue );
 
 
 ####################################

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
@@ -19,31 +19,39 @@ InstallMethod( VectorSpaceObject,
                [ IsInt, IsFieldForHomalg ],
                 
   function( dimension, homalg_field )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
-    return MatrixCategoryObject( homalg_field, dimension );
+    return MatrixCategoryObject( MatrixCategory( homalg_field ), dimension );
     
 end );
 
 ##
 InstallMethod( MatrixCategoryObjectOp,
-               [ IsFieldForHomalg, IsInt ],
+               [ IsMatrixCategory, IsInt ],
                
-  function( homalg_field, dimension )
+  function( cat, dimension )
     local category;
     #% CAP_JIT_RESOLVE_FUNCTION
     
     if dimension < 0 then
-      
-      Error( "first argument must be a non-negative integer" );
-      
+        
+        Error( "the dimension must be a non-negative integer" );
+        
     fi;
     
-    category := MatrixCategory( homalg_field );
-    
-    return ObjectifyObjectForCAPWithAttributes( rec( ), category,
+    return ObjectifyObjectForCAPWithAttributes( rec( ), cat,
                                                 Dimension, dimension,
-                                                UnderlyingFieldForHomalg, homalg_field );
+                                                UnderlyingFieldForHomalg, UnderlyingRing( cat ) );
+    
+end );
+
+##
+# backwards compatibility
+InstallOtherMethod( MatrixCategoryObject,
+                    [ IsFieldForHomalg, IsInt ],
+                    
+  function( homalg_field, dimension )
+    
+    return MatrixCategoryObject( MatrixCategory( homalg_field ), dimension );
     
 end );
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# LinearAlgebraForCAP: Category of Matrices over a Field for CAP
+#
+# Implementations
+#
+BindGlobal( "MatrixCategoryPrecompiled", function ( field )
+  local category_constructor, cat;
+    
+    category_constructor := 
+        
+        
+        function ( field )
+    return MATRIX_CATEGORY( field );
+end;
+        
+        
+    
+    cat := category_constructor( field : FinalizeCategory := false );
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+        
+        function ( cat, morphism_1, morphism_2 )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, Source( morphism_1 ), Range, Range( morphism_2 ), UnderlyingFieldForHomalg, UnderlyingRing( cat ), UnderlyingMatrix, UnderlyingMatrix( morphism_1 ) + UnderlyingMatrix( morphism_2 ) );
+end
+        
+        
+    );
+    
+    ##
+    AddPreCompose( cat,
+        
+        
+        function ( cat, morphism_1, morphism_2 )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, Source( morphism_1 ), Range, Range( morphism_2 ), UnderlyingFieldForHomalg, UnderlyingRing( cat ), UnderlyingMatrix, UnderlyingMatrix( morphism_1 ) * UnderlyingMatrix( morphism_2 ) );
+end
+        
+        
+    );
+    
+    ##
+    AddKernelEmbedding( cat,
+        
+        
+        function ( cat, morphism )
+    local cap_jit_morphism_attribute;
+    cap_jit_morphism_attribute := SyzygiesOfRows( UnderlyingMatrix( morphism ) );
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Dimension, NrRows( cap_jit_morphism_attribute ), UnderlyingFieldForHomalg, UnderlyingRing( cat ) ), Range, Source( morphism ), UnderlyingFieldForHomalg, UnderlyingRing( cat ), UnderlyingMatrix, cap_jit_morphism_attribute );
+end
+        
+        
+    );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/LinearAlgebraForCAP/read.g
+++ b/LinearAlgebraForCAP/read.g
@@ -10,3 +10,5 @@ ReadPackage( "LinearAlgebraForCAP", "gap/MatrixCategoryObject.gi" );
 ReadPackage( "LinearAlgebraForCAP", "gap/MatrixCategoryMorphism.gi" );
 
 ReadPackage( "LinearAlgebraForCAP", "gap/DerivedMethodsForMatrixCategories.gi" );
+
+ReadPackage( "LinearAlgebraForCAP", "gap/precompiled_categories/MatrixCategoryPrecompiled.gi" );


### PR DESCRIPTION
This PR adds the ability to precompile categories for later use. The changes outside of the directory `CompilerForCAP` are straightforward and fully backwards compatible -> I will merge this PR without additional review if and when the CI is green.