### PR TITLE
Make OppositeCategory compilable

### DIFF
--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -400,6 +400,10 @@ InstallGlobalFunction( CapInternalInstallAdd,
             output_sanity_check_function := function( result )
                 CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( result, false, output_human_readable_identifier_getter );
             end;
+        elif record.return_type = "list_of_morphisms" then
+            output_sanity_check_function := function( result )
+                CAP_INTERNAL_ASSERT_IS_LIST_OF_MORPHISMS_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
+            end;
         elif record.return_type = "list_of_morphisms_or_fail" then
             output_sanity_check_function := function( result )
                 if result <> fail then

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -14,6 +14,7 @@ InstallValue( CAP_INTERNAL_VALID_RETURN_TYPES,
         "bool",
         "other_object",
         "other_morphism",
+        "list_of_morphisms",
         "list_of_morphisms_or_fail",
     ]
 #! @EndCode
@@ -2927,7 +2928,7 @@ MorphismBetweenDirectSumsWithGivenDirectSums := rec(
   dual_preprocessor_func := function( arg )
       local list;
       list := CAP_INTERNAL_OPPOSITE_RECURSIVE( arg );
-      return [ list[5], list[4], TransposedMat( list[3] ), list[2], list[1] ];
+      return [ list[1], list[6], list[5], TransposedMat( list[4] ), list[3], list[2] ];
   end
 ),
 
@@ -2950,8 +2951,8 @@ HomomorphismStructureOnMorphismsWithGivenObjects := rec(
   filter_list := [ "category", "other_object", "morphism", "morphism", "other_object" ],
   return_type := "other_morphism",
   dual_operation := "HomomorphismStructureOnMorphismsWithGivenObjects",
-  dual_preprocessor_func := function( source, alpha, beta, range )
-    return [ source, Opposite( beta ), Opposite( alpha ), range ];
+  dual_preprocessor_func := function( cat, source, alpha, beta, range )
+    return [ Opposite( cat ), source, Opposite( beta ), Opposite( alpha ), range ];
   end,
   dual_postprocessor_func := IdFunc
 ),
@@ -2973,8 +2974,8 @@ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism := rec
   filter_list := [ "category", "object", "object", "other_morphism" ],
   return_type := "morphism",
   dual_operation := "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
-  dual_preprocessor_func := function( A, B, morphism )
-    return [ Opposite( B ), Opposite( A ), morphism ];
+  dual_preprocessor_func := function( cat, A, B, morphism )
+    return [ Opposite( cat ), Opposite( B ), Opposite( A ), morphism ];
   end
 ),
 
@@ -3033,14 +3034,13 @@ MereExistenceOfSolutionOfLinearSystemInAbCategory := rec(
 
 BasisOfExternalHom := rec(
   filter_list := [ "category", "object", "object" ],
-  return_type := IsList,
+  return_type := "list_of_morphisms",
   dual_operation := "BasisOfExternalHom",
-  dual_arguments_reversed := true,
-  dual_postprocessor_func := CAP_INTERNAL_OPPOSITE_RECURSIVE,
+  dual_arguments_reversed := true
 ),
 
 CoefficientsOfMorphismWithGivenBasisOfExternalHom := rec(
-  filter_list := [ "category", "morphism", IsList ],
+  filter_list := [ "category", "morphism", "list_of_morphisms" ],
   return_type := IsList,
   dual_operation := "CoefficientsOfMorphismWithGivenBasisOfExternalHom",
   dual_postprocessor_func := IdFunc
@@ -3172,7 +3172,7 @@ HomologyObjectFunctorialWithGivenHomologyObjects := rec(
   dual_preprocessor_func := function( arg )
       local list;
       list := CAP_INTERNAL_OPPOSITE_RECURSIVE( arg );
-      return [ list[3], Reversed( list[2] ), list[1] ];
+      return [ list[1], list[4], Reversed( list[3] ), list[2] ];
   end
 ),
 
@@ -4179,6 +4179,10 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
         
         if IsBound( current_rec.post_function ) and NumberArgumentsFunction( current_rec.post_function ) >= 0 and NumberArgumentsFunction( current_rec.post_function ) <> number_of_arguments + 1 then
             Error( "the post function of <current_rec> has the wrong number of arguments" );
+        fi;
+        
+        if IsBound( current_rec.dual_preprocessor_func ) and NumberArgumentsFunction( current_rec.dual_preprocessor_func ) >= 0 and NumberArgumentsFunction( current_rec.dual_preprocessor_func ) <> number_of_arguments then
+            Error( "the dual preprocessor function of <current_rec> has the wrong number of arguments" );
         fi;
         
         if not ForAll( current_rec.filter_list, x -> IsFilter( x ) or IsString( x ) or (IsList( x ) and Length( x ) = 2 and IsString( x[1] ) and IsFilter( x[2] )) ) then

--- a/CompilerForCAP/examples/PrecompileLinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/PrecompileLinearAlgebraForCAP.g
@@ -41,6 +41,9 @@ operations := Difference( operations, [ "HomologyObject" ] );;
 operations := Difference( operations, [ "IsEqualForMorphismsOnMor" ] );;
 operations := Difference( operations, [ "IsIdenticalToIdentityMorphism" ] );;
 operations := Difference( operations, [ "IsIdenticalToZeroMorphism" ] );;
+# IsZeroForMorphisms tries to resolve IsZero and IsZero has a new
+# installation in GAP 4.12, so this causes slight differences in the output
+operations := Difference( operations, [ "IsZeroForMorphisms" ] );;
 
 filepath := "precompiled_categories/MatrixCategoryPrecompiled.gi";;
 old_file_content := ReadFileFromPackageForHomalg( package_name, filepath );;

--- a/CompilerForCAP/examples/PrecompileOppositeOfLinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/PrecompileOppositeOfLinearAlgebraForCAP.g
@@ -1,0 +1,54 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+LoadPackage( "LinearAlgebraForCAP" );
+
+#! @Example
+
+QQ := HomalgFieldOfRationals( );;
+
+# be careful not to use `MatrixCategory` because attributes are not supported
+category_constructor := function( field )
+    
+    return Opposite( MATRIX_CATEGORY(
+        field :
+        FinalizeCategory := true,
+        enable_compilation := false
+    ) ); end;;
+
+given_arguments := [ QQ ];;
+compiled_category_name := "OppositeOfMatrixCategoryPrecompiled";;
+package_name := "LinearAlgebraForCAP";;
+operations := Intersection(
+    ListPrimitivelyInstalledOperationsOfCategory( MatrixCategory( QQ ) ),
+    CAP_JIT_INTERNAL_SAFE_OPERATIONS
+);;
+# IsZeroForMorphisms tries to resolve IsZero and IsZero has a new
+# installation in GAP 4.12, so this causes slight differences in the output
+operations := Difference( operations, [ "IsZeroForMorphisms" ] );;
+
+filepath := "precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi";;
+old_file_content := ReadFileFromPackageForHomalg( package_name, filepath );;
+
+CapJitPrecompileCategory(
+    category_constructor,
+    given_arguments,
+    package_name,
+    compiled_category_name :
+    operations := operations
+);
+
+new_file_content := ReadFileFromPackageForHomalg( package_name, filepath );;
+
+old_file_content = new_file_content;
+#! true
+
+ReadPackage(
+    "LinearAlgebraForCAP",
+    "gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi"
+);;
+OppositeOfMatrixCategoryPrecompiled( QQ );
+#! Opposite of Category of matrices over Q
+
+#! @EndExample

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -629,17 +629,6 @@ end
     );
     
     ##
-    AddIsZeroForMorphisms( cat,
-        
-########
-function ( cat, morphism )
-    return IsZero( UnderlyingMatrix( morphism ) );
-end
-########
-        
-    );
-    
-    ##
     AddIsZeroForObjects( cat,
         
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -1,0 +1,605 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# LinearAlgebraForCAP: Category of Matrices over a Field for CAP
+#
+# Implementations
+#
+BindGlobal( "OppositeOfMatrixCategoryPrecompiled", function ( field )
+  local category_constructor, cat;
+    
+    category_constructor := 
+        
+        
+        function ( field )
+    return Opposite( MATRIX_CATEGORY( field : FinalizeCategory := true,
+          enable_compilation := false ) );
+end;
+        
+        
+    
+    cat := category_constructor( field : FinalizeCategory := false );
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat, a, b )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Range( Opposite( b ) ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Source( Opposite( a ) ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Source( Opposite( a ) ), Range, Range( Opposite( b ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( a ) ) + UnderlyingMatrix( Opposite( b ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat, a )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Range( Opposite( a ) ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Source( Opposite( a ) ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Source( Opposite( a ) ), Range, Range( Opposite( a ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, -1 * UnderlyingMatrix( Opposite( a ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddBasisOfExternalHom( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return List( [ 1 .. Dimension( Opposite( arg3 ) ) * Dimension( Opposite( arg2 ) ) ], function ( logic_new_func_3285_x )
+            return MorphismConstructor( cat, ObjectConstructor( cat, Range( VectorSpaceMorphism( Opposite( arg3 ), ConvertRowToMatrix( CertainRows( HomalgIdentityMatrix( Dimension( Opposite( arg3 ) ) * Dimension( Opposite( arg2 ) ), UnderlyingFieldForHomalg( Opposite( arg3 ) ) ), [ logic_new_func_3285_x ] ), Dimension( Opposite( arg3 ) ), Dimension( Opposite( arg2 ) ) ), Opposite( arg2 ) ) ) ), VectorSpaceMorphism( Opposite( arg3 ), ConvertRowToMatrix( CertainRows( HomalgIdentityMatrix( Dimension( Opposite( arg3 ) ) * Dimension( Opposite( arg2 ) ), UnderlyingFieldForHomalg( Opposite( arg3 ) ) ), [ logic_new_func_3285_x ] ), Dimension( Opposite( arg3 ) ), Dimension( Opposite( arg2 ) ) ), Opposite( arg2 ) ), ObjectConstructor( cat, Source( VectorSpaceMorphism( Opposite( arg3 ), ConvertRowToMatrix( CertainRows( HomalgIdentityMatrix( Dimension( Opposite( arg3 ) ) * Dimension( Opposite( arg2 ) ), UnderlyingFieldForHomalg( Opposite( arg3 ) ) ), [ logic_new_func_3285_x ] ), Dimension( Opposite( arg3 ) ), Dimension( Opposite( arg2 ) ) ), Opposite( arg2 ) ) ) ) );
+        end );
+end
+########
+        
+    );
+    
+    ##
+    AddCokernelObject( cat,
+        
+########
+function ( cat, arg2 )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberRows( UnderlyingMatrix( Opposite( arg2 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat, alpha )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Source( Opposite( alpha ) ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ), Range, Source( Opposite( alpha ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddColift( cat,
+        
+########
+function ( cat, alpha, beta )
+    local _UNUSED_dual_preprocessor_func, _UNUSED_prep_arg, _UNUSED_result, _UNUSED_inline_186__UNUSED_inline_arg_cat, _UNUSED_inline_186_inline_arg_alpha, _UNUSED_inline_186_inline_arg_beta, _UNUSED_inline_186_right_divide, inline_186_return_value;
+    if RightDivide( UnderlyingMatrix( Opposite( beta ) ), UnderlyingMatrix( Opposite( alpha ) ) ) = fail then
+        inline_186_return_value := fail;
+    else
+        inline_186_return_value := ObjectifyWithAttributes( rec(
+               ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Source( Opposite( beta ) ), Range, Source( Opposite( alpha ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( Opposite( beta ) ), UnderlyingMatrix( Opposite( alpha ) ) ) );
+    fi;
+    if inline_186_return_value = fail then
+        return fail;
+    else
+        return ObjectifyWithAttributes( rec(
+               ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+                 ), ObjectType( cat ), CapCategory, cat, Opposite, Range( inline_186_return_value ) ), Range, ObjectifyWithAttributes( rec(
+                 ), ObjectType( cat ), CapCategory, cat, Opposite, Source( inline_186_return_value ) ), Opposite, inline_186_return_value );
+    fi;
+    return;
+end
+########
+        
+    );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat, arg2 )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, Sum( List( arg2, function ( logic_new_func_3476_x )
+                  return Dimension( Opposite( logic_new_func_3476_x ) );
+              end ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddDistinguishedObjectOfHomomorphismStructure( cat,
+        
+########
+function ( cat )
+    return ID_FUNC( ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat, A )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( A ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( A ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( A ), Range, Opposite( A ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A ) ), UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddHomomorphismStructureOnObjects( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return ID_FUNC( ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, Dimension( Opposite( arg3 ) ) * Dimension( Opposite( arg2 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat, a )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( a ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( a ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( a ), Range, Opposite( a ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( a ) ), UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat, objects, k, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( objects[k] ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( P ), Range, Opposite( objects[k] ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( List( objects, Opposite ){[ 1 .. k - 1 ]}, function ( c )
+                    return Dimension( c );
+                end ), Dimension( Opposite( objects[k] ) ), UnderlyingRing( Opposite( cat ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects[k] ) ), UnderlyingRing( Opposite( cat ) ) ), HomalgZeroMatrix( Sum( List( objects, Opposite ){[ k + 1 .. Length( List( objects, Opposite ) ) ]}, function ( c )
+                    return Dimension( c );
+                end ), Dimension( Opposite( objects[k] ) ), UnderlyingRing( Opposite( cat ) ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
+        
+########
+function ( cat, arg2 )
+    return ID_FUNC( ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ), Range, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberColumns( ConvertMatrixToRow( UnderlyingMatrix( Opposite( arg2 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, ConvertMatrixToRow( UnderlyingMatrix( Opposite( arg2 ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return UnderlyingMatrix( Opposite( arg2 ) ) = UnderlyingMatrix( Opposite( arg3 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsEpimorphism( cat,
+        
+########
+function ( cat, arg2 )
+    return RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2 ) ) ) = Dimension( Source( Opposite( arg2 ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsEqualForCacheForMorphisms( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return IS_IDENTICAL_OBJ( Opposite( arg2 ), Opposite( arg3 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsEqualForCacheForObjects( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return IS_IDENTICAL_OBJ( Opposite( arg2 ), Opposite( arg3 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsEqualForObjects( cat,
+        
+########
+function ( cat, arg2, arg3 )
+    return Dimension( Opposite( arg2 ) ) = Dimension( Opposite( arg3 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsInjective( cat,
+        
+########
+function ( cat, arg2 )
+    return true;
+end
+########
+        
+    );
+    
+    ##
+    AddIsIsomorphism( cat,
+        
+########
+function ( cat, arg2 )
+    return Dimension( Range( Opposite( arg2 ) ) ) = Dimension( Source( Opposite( arg2 ) ) ) and ColumnRankOfMatrix( UnderlyingMatrix( Opposite( arg2 ) ) ) = Dimension( Range( Opposite( arg2 ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsMonomorphism( cat,
+        
+########
+function ( cat, arg2 )
+    return ColumnRankOfMatrix( UnderlyingMatrix( Opposite( arg2 ) ) ) = Dimension( Range( Opposite( arg2 ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddIsProjective( cat,
+        
+########
+function ( cat, arg2 )
+    return true;
+end
+########
+        
+    );
+    
+    ##
+    AddIsWellDefinedForMorphisms( cat,
+        
+########
+function ( cat, arg2 )
+    local _UNUSED_dual_preprocessor_func, _UNUSED_prep_arg, _UNUSED_result, _UNUSED_inline_236__UNUSED_inline_arg_cat, _UNUSED_inline_236_inline_arg_morphism, inline_236_return_value;
+    if not true then
+        inline_236_return_value := false;
+    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Source( Opposite( arg2 ) ) ), UnderlyingRing( Opposite( cat ) ) ) then
+        inline_236_return_value := false;
+    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2 ) ), UnderlyingRing( Opposite( cat ) ) ) then
+        inline_236_return_value := false;
+    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Range( Opposite( arg2 ) ) ), UnderlyingRing( Opposite( cat ) ) ) then
+        inline_236_return_value := false;
+    elif NumberRows( UnderlyingMatrix( Opposite( arg2 ) ) ) <> Dimension( Source( Opposite( arg2 ) ) ) then
+        inline_236_return_value := false;
+    elif NumberColumns( UnderlyingMatrix( Opposite( arg2 ) ) ) <> Dimension( Range( Opposite( arg2 ) ) ) then
+        inline_236_return_value := false;
+    else
+        inline_236_return_value := true;
+    fi;
+    return inline_236_return_value;
+end
+########
+        
+    );
+    
+    ##
+    AddIsWellDefinedForObjects( cat,
+        
+########
+function ( cat, arg2 )
+    local _UNUSED_dual_preprocessor_func, _UNUSED_prep_arg, _UNUSED_result, _UNUSED_inline_237__UNUSED_inline_arg_cat, _UNUSED_inline_237_inline_arg_object, inline_237_return_value;
+    if not true then
+        inline_237_return_value := false;
+    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2 ) ), UnderlyingRing( Opposite( cat ) ) ) then
+        inline_237_return_value := false;
+    elif Dimension( Opposite( arg2 ) ) < 0 then
+        inline_237_return_value := false;
+    else
+        inline_237_return_value := true;
+    fi;
+    return inline_237_return_value;
+end
+########
+        
+    );
+    
+    ##
+    AddIsZeroForObjects( cat,
+        
+########
+function ( cat, arg2 )
+    return Dimension( Opposite( arg2 ) ) = 0;
+end
+########
+        
+    );
+    
+    ##
+    AddKernelEmbedding( cat,
+        
+########
+function ( cat, alpha )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Range( Opposite( alpha ) ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Range( Opposite( alpha ) ), Range, ObjectifyWithAttributes( rec(
+               ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddKernelObject( cat,
+        
+########
+function ( cat, arg2 )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, NumberColumns( UnderlyingMatrix( Opposite( arg2 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddLift( cat,
+        
+########
+function ( cat, alpha, beta )
+    local _UNUSED_dual_preprocessor_func, _UNUSED_prep_arg, _UNUSED_result, _UNUSED_inline_251__UNUSED_inline_arg_cat, _UNUSED_inline_251_inline_arg_alpha, _UNUSED_inline_251_inline_arg_beta, _UNUSED_inline_251_left_divide, inline_251_return_value;
+    if LeftDivide( UnderlyingMatrix( Opposite( beta ) ), UnderlyingMatrix( Opposite( alpha ) ) ) = fail then
+        inline_251_return_value := fail;
+    else
+        inline_251_return_value := ObjectifyWithAttributes( rec(
+               ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Range( Opposite( beta ) ), Range, Range( Opposite( alpha ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( Opposite( beta ) ), UnderlyingMatrix( Opposite( alpha ) ) ) );
+    fi;
+    if inline_251_return_value = fail then
+        return fail;
+    else
+        return ObjectifyWithAttributes( rec(
+               ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+                 ), ObjectType( cat ), CapCategory, cat, Opposite, Range( inline_251_return_value ) ), Range, ObjectifyWithAttributes( rec(
+                 ), ObjectType( cat ), CapCategory, cat, Opposite, Source( inline_251_return_value ) ), Opposite, inline_251_return_value );
+    fi;
+    return;
+end
+########
+        
+    );
+    
+    ##
+    AddMonomorphismIntoSomeInjectiveObject( cat,
+        
+########
+function ( cat, A )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( A ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( A ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( A ), Range, Opposite( A ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A ) ), UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddPreCompose( cat,
+        
+########
+function ( cat, alpha, beta )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Range( Opposite( alpha ) ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Source( Opposite( beta ) ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Source( Opposite( beta ) ), Range, Range( Opposite( alpha ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( beta ) ) * UnderlyingMatrix( Opposite( alpha ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat, objects, k, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( objects[k] ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( objects[k] ), Range, Opposite( P ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( Opposite( objects[k] ) ), Sum( List( objects, Opposite ){[ 1 .. k - 1 ]}, function ( c )
+                    return Dimension( c );
+                end ), UnderlyingRing( Opposite( cat ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects[k] ) ), UnderlyingRing( Opposite( cat ) ) ), HomalgZeroMatrix( Dimension( Opposite( objects[k] ) ), Sum( List( objects, Opposite ){[ k + 1 .. Length( List( objects, Opposite ) ) ]}, function ( c )
+                    return Dimension( c );
+                end ), UnderlyingRing( Opposite( cat ) ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddSomeInjectiveObject( cat,
+        
+########
+function ( cat, arg2 )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( arg2 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddSomeProjectiveObject( cat,
+        
+########
+function ( cat, arg2 )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( arg2 ) );
+end
+########
+        
+    );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat, objects, T, tau, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( T ), Range, Opposite( P ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_4466_x )
+                  return UnderlyingMatrix( Opposite( logic_new_func_4466_x ) );
+              end ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat, T, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( T ), Range, Opposite( P ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( T ) ), 0, UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat, objects, T, tau, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( P ), Range, Opposite( T ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_4564_x )
+                  return UnderlyingMatrix( Opposite( logic_new_func_4564_x ) );
+              end ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat, T, P )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( P ), Range, Opposite( T ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( Opposite( T ) ), UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat, a, b )
+    return ObjectifyWithAttributes( rec(
+           ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( a ) ), Range, ObjectifyWithAttributes( rec(
+             ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( b ) ), Opposite, ObjectifyWithAttributes( rec(
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( b ), Range, Opposite( a ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( b ) ), Dimension( Opposite( a ) ), UnderlyingRing( Opposite( cat ) ) ) ) );
+end
+########
+        
+    );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat )
+    return ObjectifyWithAttributes( rec(
+           ), ObjectType( cat ), CapCategory, cat, Opposite, ObjectifyWithAttributes( rec(
+             ), ObjectType( Opposite( cat ) ), CapCategory, Opposite( cat ), Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ) ) );
+end
+########
+        
+    );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );


### PR DESCRIPTION
Major changes:

1. Pass the category as first argument to the dual preprocessor func.
2. Use `ObjectConstructor` and `MorphismConstructor`.
3. Do not rely on immediate methods. Instead, manually call `SetOpposite` where appropriate.
4. Create the added functions by building a string (see https://github.com/homalg-project/CAP_project/commit/6398eb826bfe77b9efc87cdd177caa6ac7c200df#diff-03476bc533805918f3fbc18e61f7d3e49bd101886a4f2ca292f6adf4d7b8a161R202 ff.) and applying `EvalString`. This makes the added functions readable and compilable. For example, the function created for `KernelLift` reads:
```
            function ( cat, alpha, T, tau )
              local dual_preprocessor_func, prep_arg, result, dual_postprocessor_func;
                
                
                
                result := KernelLift( Opposite( cat ), Opposite( alpha ), Opposite( T ), Opposite( tau ) );
                
                
                
                return MorphismConstructor( cat, ObjectConstructor( cat, Range( result ) ), result, ObjectConstructor( cat, Source( result ) ) );
                
            end
```
(the weird spacing and unused local variables are expected).

Note: The precompiled code in `OppositeOfMatrixCategoryPrecompiled.gi` is not meant to be used as is, but simply there for regression testing. In an upcoming PR, I will use `WrapperCategories` to generate usable precompiled code of opposite categories, e.g. CategoryOfColumns from CategoryOfRows.

@sebastianpos: Because the code is very generic, I don't think a review is required, but I would like to have your OK for the ideas explained above.