### PR TITLE
Allow to exclude operations from being resolved

### DIFF
--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -35,6 +35,7 @@ The compilation process has two phases: the resolving phase and the rule phase.
 During the resolving phase, operations and global variables are resolved:
 * An operation is resolved by executing the function to be compiled with the JIT arguments to determine the arguments of the operation.
   These arguments are used to call `ApplicableMethod`, and methods annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION` are resolved.
+  This step is skipped if the operation is listed in `CAP_JIT_NON_RESOLVABLE_OPERATION_NAMES`.
 * CAP operations are handled separately: instead of using `ApplicableMethod`, the functions added to the category via `Add` functions
   are considered, and those do not have to be annotated with `CAP_JIT_RESOLVE_FUNCTION`. In particular, caching, pre functions, etc.
   are bypassed.
@@ -131,7 +132,10 @@ a global variable from the beginning on, or after global variables are resolved 
 Possibly you have adapt <Ref Func="CapJitResolvedGlobalVariables" /> to your setting.
 
 * Q: Why is my operation not resolved?
-A: The compiler must be able to get the arguments of the call of the operation from the JIT arguments.
+A: The operation might be listed in `CAP_JIT_NON_RESOLVABLE_OPERATION_NAMES`.
+If the operation is not a CAP operation and if there are no methods installed for the operation via
+`InstallMethodForCompilerForCAP` or `InstallOtherMethodForCompilerForCAP`,
+the compiler must be able to get the arguments of the call of the operation from the JIT arguments.
 Then the rules in the description of <Ref Func="CapJitResolvedOperations" /> apply.
 
 * Q: Why do I get the error "cannot find iteration key"?

--- a/CompilerForCAP/examples/PrecompileOppositeOfLinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/PrecompileOppositeOfLinearAlgebraForCAP.g
@@ -24,9 +24,6 @@ operations := Intersection(
     ListPrimitivelyInstalledOperationsOfCategory( MatrixCategory( QQ ) ),
     CAP_JIT_INTERNAL_SAFE_OPERATIONS
 );;
-# IsZeroForMorphisms tries to resolve IsZero and IsZero has a new
-# installation in GAP 4.12, so this causes slight differences in the output
-operations := Difference( operations, [ "IsZeroForMorphisms" ] );;
 # The output for Lift and Colift differs between GAP 4.11 and GAP 4.12, see
 # https://github.com/gap-system/gap/issues/4523
 operations := Difference( operations, [ "Lift", "Colift" ] );;

--- a/CompilerForCAP/gap/ResolveOperations.gd
+++ b/CompilerForCAP/gap/ResolveOperations.gd
@@ -17,7 +17,8 @@ DeclareGlobalFunction( "CapJitGetCapCategoryFromArguments" );
 #!   * Operations announced to the compiler via `InstallMethodForCompilerForCAP` or `InstallOtherMethodForCompilerForCAP`
 #!     (see the documentation of CAP) are resolved via the number of arguments.
 #!   * Other operations are resolved by considering applicable methods of the operation with regard to arguments infered
-#!     from <A>jit_args</A>. Only methods annotated with the pragma CAP_JIT_RESOLVE_FUNCTION are resolved.
+#!     from <A>jit_args</A>, except if the operation is listed in `CAP_JIT_NON_RESOLVABLE_OPERATION_NAMES`.
+#!     Only methods annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION` are resolved.
 #!
 #!   If the arguments of the operation cannot be infered from <A>jit_args</A>, the operation is not resolved.
 #! @Returns a record

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -3,6 +3,12 @@
 #
 # Implementations
 #
+BindGlobal( "CAP_JIT_NON_RESOLVABLE_OPERATION_NAMES", [
+    "DecideZeroColumns",
+    "DecideZeroRows",
+    "IsZero",
+] );
+
 InstallGlobalFunction( CapJitGetCapCategoryFromArguments, function ( arguments )
   local result;
     
@@ -90,7 +96,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree, jit_args )
                 
             fi;
             
-            if IsOperation( operation ) then
+            if IsOperation( operation ) and not operation_name in CAP_JIT_NON_RESOLVABLE_OPERATION_NAMES then
                 
                 return true;
                 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -347,6 +347,17 @@ end
     );
     
     ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat, arg2 )
+    return IsZero( UnderlyingMatrix( Opposite( arg2 ) ) );
+end
+########
+        
+    );
+    
+    ##
     AddIsZeroForObjects( cat,
         
 ########
@@ -469,8 +480,8 @@ function ( cat, objects, T, tau, P )
            ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
              ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Range, ObjectifyWithAttributes( rec(
              ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Opposite, ObjectifyWithAttributes( rec(
-             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( T ), Range, Opposite( P ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_22232_x )
-                  return UnderlyingMatrix( Opposite( logic_new_func_22232_x ) );
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( T ), Range, Opposite( P ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_22271_x )
+                  return UnderlyingMatrix( Opposite( logic_new_func_22271_x ) );
               end ) ) ) );
 end
 ########
@@ -501,8 +512,8 @@ function ( cat, objects, T, tau, P )
            ), MorphismType( cat ), CapCategory, cat, Source, ObjectifyWithAttributes( rec(
              ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( T ) ), Range, ObjectifyWithAttributes( rec(
              ), ObjectType( cat ), CapCategory, cat, Opposite, Opposite( P ) ), Opposite, ObjectifyWithAttributes( rec(
-             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( P ), Range, Opposite( T ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_22397_x )
-                  return UnderlyingMatrix( Opposite( logic_new_func_22397_x ) );
+             ), MorphismType( Opposite( cat ) ), CapCategory, Opposite( cat ), Source, Opposite( P ), Range, Opposite( T ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( Opposite( cat ) ), Dimension( Opposite( T ) ), List( tau, function ( logic_new_func_22436_x )
+                  return UnderlyingMatrix( Opposite( logic_new_func_22436_x ) );
               end ) ) ) );
 end
 ########


### PR DESCRIPTION
This only touches files in `CompilerForCAP`.