### PR TITLE
Do not increase level of InfoPackageLoading in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
           cd ..
           git clone --depth 1 https://github.com/homalg-project/homalg_project.git
           cd CAP_project
-          echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           TERM=dumb make ci-test
           bash <(curl -s https://codecov.io/bash)
 workflows:


### PR DESCRIPTION
Since some time we catch errors and warnings during package loading in
a different way.

This simply fixes an CI error in CircleCI, so I will merge this PR without additional review if and when the CI succeeds.