### PR TITLE
print missing newline in Display method

### DIFF
--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
@@ -94,7 +94,7 @@ InstallMethod( Display,
                
   function( vector_space_object )
     
-    Print( String( vector_space_object ) );
+    Print( String( vector_space_object ), "\n" );
     
 end );
 


### PR DESCRIPTION
In Jupyter notebooks the missing newline causes the output to be delayed to the next cell