### PR TITLE
Use Object/MorphismConstructor to simplify hom structure in QuiverRows

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.08-02",
+Version := "2021.08-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 


### PR DESCRIPTION
At @kamalsaleh's request we keep MatrixCategory as the default Hom-structure of Quiver Rows.

----

Old description: Always use CategoryOfRows as range of the Hom-structure of QuiverRows

and allow to override it using the option `range_of_HomStructure`.

As a preparation, I introduce InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure**WithGivenObjects**.

@sebastianpos: I think the changes are straightforward but I would wait for a general "okay" from you :-)