### PR TITLE
Compute UnderlyingFieldForHomalg on demand

### DIFF
--- a/CompilerForCAP/examples/CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL.g
+++ b/CompilerForCAP/examples/CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL.g
@@ -27,10 +27,8 @@ Display( compiled_func );
 #!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
 #!            ), cat_1, Source( test_mor_1 ), 
 #!        ObjectifyObjectForCAPWithAttributes( rec(
-#!              ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), 
-#!          UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), 
-#!        UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, 
-#!        cap_jit_morphism_attribute_1 );
+#!              ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) )
+#!         , UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 #! end
 
 func1 := function( x )

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -34,8 +34,7 @@ Display( SYNTAX_TREE_CODE( tree1 ) );
 #!     local cap_jit_hoisted_expression_1_1;
 #!     cap_jit_hoisted_expression_1_1 := UnderlyingRing( cat_1 );
 #!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-#!            ), cat_1, S_1, T_1, UnderlyingFieldForHomalg, 
-#!        UnderlyingRing( cat_1 ), UnderlyingMatrix, 
+#!            ), cat_1, S_1, T_1, UnderlyingMatrix, 
 #!        UnionOfRows( UnderlyingRing( cat_1 ), Dimension( T_1 ), 
 #!          ListN( diagram_S_1, List( morphism_matrix_1, function ( row_2 )
 #!                   return List( row_2, UnderlyingMatrix );
@@ -56,8 +55,7 @@ Display( SYNTAX_TREE_CODE( tree2 ) );
 #!     local cap_jit_hoisted_expression_1_1;
 #!     cap_jit_hoisted_expression_1_1 := UnderlyingRing( cat_1 );
 #!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-#!            ), cat_1, S_1, T_1, UnderlyingFieldForHomalg, 
-#!        UnderlyingRing( cat_1 ), UnderlyingMatrix, 
+#!            ), cat_1, S_1, T_1,  UnderlyingMatrix, 
 #!        UnionOfRows( UnderlyingRing( cat_1 ), Dimension( T_1 ), 
 #!          ListN( diagram_S_1, morphism_matrix_1, 
 #!            function ( logic_new_func_x_2, logic_new_func_y_2 )
@@ -77,10 +75,8 @@ Display( Last( vec!.compiled_functions.KernelEmbedding ) );
 #!      := SyzygiesOfRows( UnderlyingMatrix( morphism_1 ) );
 #!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
 #!            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-#!              ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), 
-#!          UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), 
-#!        Source( morphism_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 )
-#!         , UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+#!              ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), 
+#!        Source( morphism_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 #! end
 
 #! @EndExample

--- a/CompilerForCAP/examples/do_not_resolve_CAP_operations_statically.g
+++ b/CompilerForCAP/examples/do_not_resolve_CAP_operations_statically.g
@@ -17,8 +17,7 @@ func := function ( cat, x )
 Display( CapJitCompiledFunction( { cat, x } -> func( cat, x ), [ vec ] ) );
 #! function ( cat_1, x_1 )
 #!     return ObjectifyObjectForCAPWithAttributes( rec(
-#!            ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, 
-#!        UnderlyingRing( cat_1 ) );
+#!            ), cat_1, Dimension, 0 );
 #! end
 
 #! @EndExample

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -50,9 +50,9 @@ InstallGlobalFunction( MATRIX_CATEGORY,
     
     SetFilterObj( category, IsMatrixCategory );
     
-    AddObjectRepresentation( category, IsVectorSpaceObject and HasIsProjective and IsProjective );
+    AddObjectRepresentation( category, IsVectorSpaceObject and HasDimension and HasIsProjective and IsProjective );
     
-    AddMorphismRepresentation( category, IsVectorSpaceMorphism and HasUnderlyingFieldForHomalg and HasUnderlyingMatrix );
+    AddMorphismRepresentation( category, IsVectorSpaceMorphism and HasUnderlyingMatrix );
     
     category!.field_for_matrix_category := homalg_field;
     
@@ -126,8 +126,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         fi;
         
         return ObjectifyObjectForCAPWithAttributes( rec( ), cat,
-                                                    Dimension, dimension,
-                                                    UnderlyingFieldForHomalg, UnderlyingRing( cat ) );
+                                                    Dimension, dimension );
         
     end );
     
@@ -170,7 +169,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat,
                                                source,
                                                range,
-                                               UnderlyingFieldForHomalg, UnderlyingRing( cat ),
                                                UnderlyingMatrix, homalg_matrix
         );
         
@@ -202,10 +200,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
 
           return false;
 
-        elif not IsIdenticalObj( UnderlyingFieldForHomalg( object ), category!.field_for_matrix_category ) then
-
-          return false;
-
         elif Dimension( object ) < 0 then
 
           return false;
@@ -230,21 +224,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
           return false;
 
         elif not IsIdenticalObj( category, CapCategory( Range( morphism ) ) ) then
-
-          return false;
-
-        elif not IsIdenticalObj( UnderlyingFieldForHomalg( Source( morphism ) ),
-                                 category!.field_for_matrix_category ) then
-
-          return false;
-
-        elif not IsIdenticalObj( UnderlyingFieldForHomalg( morphism ),
-                                 category!.field_for_matrix_category ) then
-
-          return false;
-
-        elif not IsIdenticalObj( UnderlyingFieldForHomalg( Range( morphism ) ),
-                                 category!.field_for_matrix_category ) then
 
           return false;
 
@@ -994,7 +973,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
         
         t := Dimension( T );
         
-        identity := HomalgIdentityMatrix( s * t, UnderlyingFieldForHomalg( S ) );
+        identity := HomalgIdentityMatrix( s * t, UnderlyingRing( cat ) );
         
         matrices := List( [ 1 .. s * t ], i -> ConvertRowToMatrix( CertainRows( identity, [ i ] ), s, t ) );
         

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
@@ -39,7 +39,7 @@ InstallMethod( VectorSpaceMorphism,
   function( source, element_list, range )
     local field, homalg_matrix;
     
-    field := UnderlyingFieldForHomalg( source );
+    field := UnderlyingRing( CapCategory( source ) );
     
     homalg_matrix := HomalgMatrix( element_list, Dimension( source ), Dimension( range ), field );
     
@@ -65,6 +65,22 @@ InstallOtherMethodForCompilerForCAP( VectorSpaceMorphism,
   function( cat, source, homalg_matrix, range )
     
     return MorphismConstructor( cat, source, homalg_matrix, range );
+    
+end );
+
+####################################
+##
+## Attributes
+##
+####################################
+
+##
+InstallMethod( UnderlyingFieldForHomalg,
+               [ IsVectorSpaceMorphism ],
+               
+  function( morphism )
+    
+    return UnderlyingRing( CapCategory( morphism ) );
     
 end );
 

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
@@ -48,6 +48,22 @@ end );
 
 ####################################
 ##
+## Attributes
+##
+####################################
+
+##
+InstallMethod( UnderlyingFieldForHomalg,
+               [ IsVectorSpaceObject ],
+               
+  function( object )
+    
+    return UnderlyingRing( CapCategory( object ) );
+    
+end );
+
+####################################
+##
 ## View
 ##
 ####################################
@@ -58,7 +74,7 @@ InstallMethod( String,
   function( vector_space_object )
     
     return Concatenation( "A vector space object over ",
-                          RingName( UnderlyingFieldForHomalg( vector_space_object ) ),
+                          RingName( UnderlyingRing( CapCategory( vector_space_object ) ) ),
                           " of dimension ", String( Dimension( vector_space_object ) ) );
     
 end );

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -11,7 +11,7 @@ BindGlobal( "ADD_FUNCTIONS_FOR_MatrixCategoryPrecompiled", function ( cat )
 ########
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( a_1 ), Range( b_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+           ), cat_1, Source( a_1 ), Range( b_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
 end
 ########
         
@@ -23,7 +23,7 @@ end
 ########
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, -1 * UnderlyingMatrix( a_1 ) );
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, -1 * UnderlyingMatrix( a_1 ) );
 end
 ########
         
@@ -34,14 +34,13 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1, cap_jit_hoisted_expression_4_1;
-    cap_jit_hoisted_expression_1_1 := HomalgIdentityMatrix( Dimension( arg2_1 ) * Dimension( arg3_1 ), UnderlyingFieldForHomalg( arg2_1 ) );
+    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1;
+    cap_jit_hoisted_expression_1_1 := HomalgIdentityMatrix( Dimension( arg2_1 ) * Dimension( arg3_1 ), UnderlyingRing( cat_1 ) );
     cap_jit_hoisted_expression_2_1 := Dimension( arg2_1 );
     cap_jit_hoisted_expression_3_1 := Dimension( arg3_1 );
-    cap_jit_hoisted_expression_4_1 := UnderlyingRing( cat_1 );
     return List( [ 1 .. Dimension( arg2_1 ) * Dimension( arg3_1 ) ], function ( logic_new_func_x_2 )
             return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-                   ), cat_1, arg2_1, arg3_1, UnderlyingFieldForHomalg, cap_jit_hoisted_expression_4_1, UnderlyingMatrix, ConvertRowToMatrix( CertainRows( cap_jit_hoisted_expression_1_1, [ logic_new_func_x_2 ] ), cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1 ) );
+                   ), cat_1, arg2_1, arg3_1, UnderlyingMatrix, ConvertRowToMatrix( CertainRows( cap_jit_hoisted_expression_1_1, [ logic_new_func_x_2 ] ), cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1 ) );
         end );
 end
 ########
@@ -57,7 +56,7 @@ function ( cat_1, alpha_1, T_1, tau_1 )
     cap_jit_morphism_attribute_1 := LeftDivide( SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( tau_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Range( tau_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Range( tau_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -72,7 +71,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
     cap_jit_morphism_attribute_1 := LeftDivide( SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( tau_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Range( tau_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Range( tau_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -84,7 +83,7 @@ end
 ########
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, NumberColumns( UnderlyingMatrix( arg2_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( arg2_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+           ), cat_1, Dimension, NumberColumns( UnderlyingMatrix( arg2_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( arg2_1 ) ) );
 end
 ########
         
@@ -99,7 +98,7 @@ function ( cat_1, alpha_1 )
     cap_jit_morphism_attribute_1 := SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -114,7 +113,7 @@ function ( cat_1, alpha_1, P_1 )
     cap_jit_morphism_attribute_1 := SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -126,7 +125,7 @@ end
 ########
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Range( alpha_1 ), Range( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
+           ), cat_1, Range( alpha_1 ), Range( beta_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
 end
 ########
         
@@ -138,7 +137,7 @@ end
 ########
 function ( cat_1, epsilon_1, tau_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Range( epsilon_1 ), Range( tau_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( epsilon_1 ), UnderlyingMatrix( tau_1 ) ) );
+           ), cat_1, Range( epsilon_1 ), Range( tau_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( epsilon_1 ), UnderlyingMatrix( tau_1 ) ) );
 end
 ########
         
@@ -152,7 +151,7 @@ function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Dimension, Sum( List( arg2_1, function ( object_2 )
                 return Dimension( object_2 );
-            end ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+            end ) ) );
 end
 ########
         
@@ -164,7 +163,7 @@ end
 ########
 function ( cat_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+           ), cat_1, Dimension, 1 );
 end
 ########
         
@@ -176,7 +175,7 @@ end
 ########
 function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, A_1, A_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, A_1, A_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -188,7 +187,7 @@ end
 ########
 function ( cat_1, A_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, A_1, A_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, A_1, A_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -203,8 +202,8 @@ function ( cat_1, alpha_1, beta_1 )
     cap_jit_morphism_attribute_1 := KroneckerMat( TransposedMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( beta_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -216,7 +215,7 @@ end
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, source_1, range_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, KroneckerMat( TransposedMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( beta_1 ) ) );
+           ), cat_1, source_1, range_1, UnderlyingMatrix, KroneckerMat( TransposedMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( beta_1 ) ) );
 end
 ########
         
@@ -228,7 +227,7 @@ end
 ########
 function ( cat_1, arg2_1, arg3_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, Dimension( arg2_1 ) * Dimension( arg3_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+           ), cat_1, Dimension, Dimension( arg2_1 ) * Dimension( arg3_1 ) );
 end
 ########
         
@@ -240,7 +239,7 @@ end
 ########
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, a_1, a_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( a_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( a_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -259,7 +258,7 @@ function ( cat_1, objects_1, k_1 )
             end ), UnderlyingRing( cat_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, objects_1[k_1], ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -271,7 +270,7 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, objects_1[k_1], P_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( objects_1[k_1] ), Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( objects_1[k_1] ), Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                   return Dimension( c_2 );
               end ), UnderlyingRing( cat_1 ) ), HomalgIdentityMatrix( Dimension( objects_1[k_1] ), UnderlyingRing( cat_1 ) ), HomalgZeroMatrix( Dimension( objects_1[k_1] ), Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                   return Dimension( c_2 );
@@ -287,7 +286,7 @@ end
 ########
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Range( alpha_1 ), Range( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
+           ), cat_1, Range( alpha_1 ), Range( beta_1 ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
 end
 ########
         
@@ -302,8 +301,8 @@ function ( cat_1, alpha_1 )
     cap_jit_morphism_attribute_1 := ConvertMatrixToRow( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, 1 ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -318,8 +317,8 @@ function ( cat_1, source_1, alpha_1, range_1 )
     cap_jit_morphism_attribute_1 := ConvertMatrixToRow( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, 1 ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -331,7 +330,7 @@ end
 ########
 function ( cat_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Range( alpha_1 ), Source( alpha_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, RightDivide( HomalgIdentityMatrix( Dimension( Range( alpha_1 ) ), UnderlyingRing( cat_1 ) ), UnderlyingMatrix( alpha_1 ) ) );
+           ), cat_1, Range( alpha_1 ), Source( alpha_1 ), UnderlyingMatrix, RightDivide( HomalgIdentityMatrix( Dimension( Range( alpha_1 ) ), UnderlyingRing( cat_1 ) ), UnderlyingMatrix( alpha_1 ) ) );
 end
 ########
         
@@ -586,12 +585,6 @@ end
 function ( cat_1, arg2_1 )
     if not true then
         return false;
-    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Source( arg2_1 ) ), UnderlyingRing( cat_1 ) ) then
-        return false;
-    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( arg2_1 ), UnderlyingRing( cat_1 ) ) then
-        return false;
-    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Range( arg2_1 ) ), UnderlyingRing( cat_1 ) ) then
-        return false;
     elif NumberRows( UnderlyingMatrix( arg2_1 ) ) <> Dimension( Source( arg2_1 ) ) then
         return false;
     elif NumberColumns( UnderlyingMatrix( arg2_1 ) ) <> Dimension( Range( arg2_1 ) ) then
@@ -611,8 +604,6 @@ end
 ########
 function ( cat_1, arg2_1 )
     if not true then
-        return false;
-    elif not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( arg2_1 ), UnderlyingRing( cat_1 ) ) then
         return false;
     elif Dimension( arg2_1 ) < 0 then
         return false;
@@ -645,7 +636,7 @@ function ( cat_1, alpha_1 )
     cap_jit_morphism_attribute_1 := SyzygiesOfRows( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Source( alpha_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Source( alpha_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -660,7 +651,7 @@ function ( cat_1, alpha_1, P_1 )
     cap_jit_morphism_attribute_1 := SyzygiesOfRows( UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Source( alpha_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Source( alpha_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -675,7 +666,7 @@ function ( cat_1, alpha_1, T_1, tau_1 )
     cap_jit_morphism_attribute_1 := RightDivide( UnderlyingMatrix( tau_1 ), SyzygiesOfRows( UnderlyingMatrix( alpha_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( tau_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -690,7 +681,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
     cap_jit_morphism_attribute_1 := RightDivide( UnderlyingMatrix( tau_1 ), SyzygiesOfRows( UnderlyingMatrix( alpha_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( tau_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -702,7 +693,7 @@ end
 ########
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, NumberRows( UnderlyingMatrix( arg2_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( arg2_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+           ), cat_1, Dimension, NumberRows( UnderlyingMatrix( arg2_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( arg2_1 ) ) );
 end
 ########
         
@@ -714,7 +705,7 @@ end
 ########
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( alpha_1 ), Source( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
+           ), cat_1, Source( alpha_1 ), Source( beta_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
 end
 ########
         
@@ -726,7 +717,7 @@ end
 ########
 function ( cat_1, iota_1, tau_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( tau_1 ), Source( iota_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( tau_1 ), UnderlyingMatrix( iota_1 ) ) );
+           ), cat_1, Source( tau_1 ), Source( iota_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( tau_1 ), UnderlyingMatrix( iota_1 ) ) );
 end
 ########
         
@@ -738,7 +729,7 @@ end
 ########
 function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, A_1, A_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, A_1, A_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -750,7 +741,7 @@ end
 ########
 function ( cat_1, A_1, I_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, A_1, A_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, A_1, A_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( A_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -765,7 +756,7 @@ function ( cat_1, alpha_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( NumberRows( UnderlyingMatrix( alpha_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( alpha_1 ) ), Dimension( Range( alpha_1 ) ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Range( alpha_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Range( alpha_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -780,7 +771,7 @@ function ( cat_1, alpha_1, P_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( NumberRows( UnderlyingMatrix( alpha_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( alpha_1 ) ), Dimension( Range( alpha_1 ) ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), Range( alpha_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), Range( alpha_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -795,7 +786,7 @@ function ( cat_1, alpha_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( Dimension( Source( alpha_1 ) ), NumberColumns( UnderlyingMatrix( alpha_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -810,7 +801,7 @@ function ( cat_1, alpha_1, P_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( Dimension( Source( alpha_1 ) ), NumberColumns( UnderlyingMatrix( alpha_1 ) ) - RowRankOfMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -822,7 +813,7 @@ end
 ########
 function ( cat_1, beta_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( alpha_1 ), Range( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnderlyingMatrix( alpha_1 ) * UnderlyingMatrix( beta_1 ) );
+           ), cat_1, Source( alpha_1 ), Range( beta_1 ), UnderlyingMatrix, UnderlyingMatrix( alpha_1 ) * UnderlyingMatrix( beta_1 ) );
 end
 ########
         
@@ -834,7 +825,7 @@ end
 ########
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( alpha_1 ), Range( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnderlyingMatrix( alpha_1 ) * UnderlyingMatrix( beta_1 ) );
+           ), cat_1, Source( alpha_1 ), Range( beta_1 ), UnderlyingMatrix, UnderlyingMatrix( alpha_1 ) * UnderlyingMatrix( beta_1 ) );
 end
 ########
         
@@ -853,7 +844,7 @@ function ( cat_1, objects_1, k_1 )
             end ), Dimension( objects_1[k_1] ), UnderlyingRing( cat_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), objects_1[k_1], UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), objects_1[k_1], UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -865,7 +856,7 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, P_1, objects_1[k_1], UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                   return Dimension( c_2 );
               end ), Dimension( objects_1[k_1] ), UnderlyingRing( cat_1 ) ), HomalgIdentityMatrix( Dimension( objects_1[k_1] ), UnderlyingRing( cat_1 ) ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                   return Dimension( c_2 );
@@ -881,7 +872,7 @@ end
 ########
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( alpha_1 ), Source( beta_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
+           ), cat_1, Source( alpha_1 ), Source( beta_1 ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( alpha_1 ), UnderlyingMatrix( beta_1 ) ) );
 end
 ########
         
@@ -915,7 +906,7 @@ end
 ########
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( a_1 ), Range( b_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + -1 * UnderlyingMatrix( b_1 ) );
+           ), cat_1, Source( a_1 ), Range( b_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + -1 * UnderlyingMatrix( b_1 ) );
 end
 ########
         
@@ -932,7 +923,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
           end ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), T_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrRows( cap_jit_morphism_attribute_1 ) ), T_1, UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -944,7 +935,7 @@ end
 ########
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, P_1, T_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), Dimension( T_1 ), List( tau_1, function ( s_2 )
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), Dimension( T_1 ), List( tau_1, function ( s_2 )
                 return UnderlyingMatrix( s_2 );
             end ) ) );
 end
@@ -961,7 +952,7 @@ function ( cat_1, T_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( 0, Dimension( T_1 ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), T_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, 0 ), T_1, UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -973,7 +964,7 @@ end
 ########
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, P_1, T_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( T_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( T_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -990,7 +981,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
           end ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, NrColumns( cap_jit_morphism_attribute_1 ) ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -1002,7 +993,7 @@ end
 ########
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, T_1, P_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), Dimension( T_1 ), List( tau_1, function ( s_2 )
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), Dimension( T_1 ), List( tau_1, function ( s_2 )
                 return UnderlyingMatrix( s_2 );
             end ) ) );
 end
@@ -1019,7 +1010,7 @@ function ( cat_1, T_1 )
     cap_jit_morphism_attribute_1 := HomalgZeroMatrix( Dimension( T_1 ), 0, UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, 0 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -1031,7 +1022,7 @@ end
 ########
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, T_1, P_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( T_1 ), 0, UnderlyingRing( cat_1 ) ) );
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( Dimension( T_1 ), 0, UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -1043,7 +1034,7 @@ end
 ########
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, a_1, b_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( a_1 ), Dimension( b_1 ), UnderlyingRing( cat_1 ) ) );
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( Dimension( a_1 ), Dimension( b_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         
@@ -1055,7 +1046,7 @@ end
 ########
 function ( cat_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) );
+           ), cat_1, Dimension, 0 );
 end
 ########
         
@@ -1070,8 +1061,8 @@ function ( cat_1 )
     cap_jit_morphism_attribute_1 := HomalgIdentityMatrix( 0, UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
+             ), cat_1, Dimension, 0 ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, 0 ), UnderlyingMatrix, cap_jit_morphism_attribute_1 );
 end
 ########
         
@@ -1083,7 +1074,7 @@ end
 ########
 function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, P_1, Pp_1, UnderlyingFieldForHomalg, UnderlyingRing( cat_1 ), UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( L_1, function ( mor_2 )
+           ), cat_1, P_1, Pp_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( L_1, function ( mor_2 )
                 return UnderlyingMatrix( mor_2 );
             end ) ) );
 end

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -12,7 +12,7 @@ BindGlobal( "ADD_FUNCTIONS_FOR_OppositeOfMatrixCategoryPrecompiled", function ( 
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( a_1 ), Range( a_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( b_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( a_1 ) ) + UnderlyingMatrix( Opposite( b_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( b_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( a_1 ) ) + UnderlyingMatrix( Opposite( b_1 ) ) ) );
 end
 ########
         
@@ -25,7 +25,7 @@ end
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( a_1 ), Range( a_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( a_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, -1 * UnderlyingMatrix( Opposite( a_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( a_1 ) ), UnderlyingMatrix, -1 * UnderlyingMatrix( Opposite( a_1 ) ) ) );
 end
 ########
         
@@ -36,22 +36,21 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1, cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1, cap_jit_hoisted_expression_7_1, cap_jit_hoisted_expression_8_1, cap_jit_hoisted_expression_9_1;
-    cap_jit_hoisted_expression_1_1 := HomalgIdentityMatrix( Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingFieldForHomalg( Opposite( arg3_1 ) ) );
+    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1, cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1, cap_jit_hoisted_expression_7_1, cap_jit_hoisted_expression_8_1;
+    cap_jit_hoisted_expression_1_1 := HomalgIdentityMatrix( Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
     cap_jit_hoisted_expression_2_1 := Dimension( Opposite( arg3_1 ) );
     cap_jit_hoisted_expression_3_1 := Dimension( Opposite( arg2_1 ) );
     cap_jit_hoisted_expression_4_1 := OppositeCategory( cat_1 );
     cap_jit_hoisted_expression_5_1 := Opposite( arg3_1 );
     cap_jit_hoisted_expression_6_1 := Opposite( arg2_1 );
-    cap_jit_hoisted_expression_7_1 := UnderlyingRing( OppositeCategory( cat_1 ) );
-    cap_jit_hoisted_expression_8_1 := ObjectifyObjectForCAPWithAttributes( rec(
+    cap_jit_hoisted_expression_7_1 := ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, Opposite( arg2_1 ) );
-    cap_jit_hoisted_expression_9_1 := ObjectifyObjectForCAPWithAttributes( rec(
+    cap_jit_hoisted_expression_8_1 := ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, Opposite( arg3_1 ) );
     return List( [ 1 .. Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ) ], function ( logic_new_func_x_2 )
             return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-                   ), cat_1, cap_jit_hoisted_expression_8_1, cap_jit_hoisted_expression_9_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-                     ), cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1, UnderlyingFieldForHomalg, cap_jit_hoisted_expression_7_1, UnderlyingMatrix, ConvertRowToMatrix( CertainRows( cap_jit_hoisted_expression_1_1, [ logic_new_func_x_2 ] ), cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1 ) ) );
+                   ), cat_1, cap_jit_hoisted_expression_7_1, cap_jit_hoisted_expression_8_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+                     ), cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1, UnderlyingMatrix, ConvertRowToMatrix( CertainRows( cap_jit_hoisted_expression_1_1, [ logic_new_func_x_2 ] ), cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1 ) ) );
         end );
 end
 ########
@@ -65,7 +64,7 @@ end
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Dimension, NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ) ) );
 end
 ########
         
@@ -79,9 +78,9 @@ function ( cat_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
              ), OppositeCategory( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) ), Source( Opposite( alpha_1 ) ), UnderlyingMatrix, SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -94,7 +93,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), Range( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Source( Opposite( alpha_1 ) ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -109,7 +108,7 @@ function ( cat_1, arg2_1 )
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
              ), OppositeCategory( cat_1 ), Dimension, Sum( List( arg2_1, function ( logic_new_func_x_2 )
                   return Dimension( Opposite( logic_new_func_x_2 ) );
-              end ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+              end ) ) ) );
 end
 ########
         
@@ -121,7 +120,7 @@ end
 ########
 function ( cat_1 )
     return ID_FUNC( ObjectifyObjectForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, 1 ) );
 end
 ########
         
@@ -135,7 +134,7 @@ function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, Opposite( A_1 ) ), A_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -158,7 +157,7 @@ end
 ########
 function ( cat_1, arg2_1, arg3_1 )
     return ID_FUNC( ObjectifyObjectForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Dimension, Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ) ) );
 end
 ########
         
@@ -171,7 +170,7 @@ end
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, a_1, a_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( a_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( a_1 ), Opposite( a_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -184,7 +183,7 @@ end
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, objects_1[k_1], P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( objects_1[k_1] ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( objects_1[k_1] ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ 1 .. k_1 - 1 ]}, function ( c_2 )
                     return Dimension( c_2 );
@@ -205,8 +204,8 @@ end
 function ( cat_1, alpha_1 )
     return ID_FUNC( ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
              ), OppositeCategory( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+               ), OppositeCategory( cat_1 ), Dimension, 1 ), ObjectifyObjectForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) ), UnderlyingMatrix, ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -338,25 +337,16 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1, cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1;
+    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1;
     cap_jit_hoisted_expression_1_1 := not true;
-    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Source( Opposite( arg2_1 ) ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
-    cap_jit_hoisted_expression_3_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
-    cap_jit_hoisted_expression_4_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Range( Opposite( arg2_1 ) ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
-    cap_jit_hoisted_expression_5_1 := NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Source( Opposite( arg2_1 ) ) );
-    cap_jit_hoisted_expression_6_1 := NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Range( Opposite( arg2_1 ) ) );
+    cap_jit_hoisted_expression_2_1 := NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Source( Opposite( arg2_1 ) ) );
+    cap_jit_hoisted_expression_3_1 := NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Range( Opposite( arg2_1 ) ) );
     return function (  )
             if cap_jit_hoisted_expression_1_1 then
                 return false;
             elif cap_jit_hoisted_expression_2_1 then
                 return false;
             elif cap_jit_hoisted_expression_3_1 then
-                return false;
-            elif cap_jit_hoisted_expression_4_1 then
-                return false;
-            elif cap_jit_hoisted_expression_5_1 then
-                return false;
-            elif cap_jit_hoisted_expression_6_1 then
                 return false;
             else
                 return true;
@@ -373,16 +363,13 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1;
+    local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1;
     cap_jit_hoisted_expression_1_1 := not true;
-    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
-    cap_jit_hoisted_expression_3_1 := Dimension( Opposite( arg2_1 ) ) < 0;
+    cap_jit_hoisted_expression_2_1 := Dimension( Opposite( arg2_1 ) ) < 0;
     return function (  )
             if cap_jit_hoisted_expression_1_1 then
                 return false;
             elif cap_jit_hoisted_expression_2_1 then
-                return false;
-            elif cap_jit_hoisted_expression_3_1 then
                 return false;
             else
                 return true;
@@ -424,9 +411,9 @@ function ( cat_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ), Source( alpha_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) ) ), Source( alpha_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
              ), OppositeCategory( cat_1 ), Range( Opposite( alpha_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) ), UnderlyingMatrix, SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -439,7 +426,7 @@ end
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Dimension, NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ) ) );
 end
 ########
         
@@ -452,7 +439,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), Source( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Range( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Range( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -466,7 +453,7 @@ function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, A_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, Opposite( A_1 ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -479,7 +466,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), Range( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( beta_1 ) ) * UnderlyingMatrix( Opposite( alpha_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( beta_1 ) ) * UnderlyingMatrix( Opposite( alpha_1 ) ) ) );
 end
 ########
         
@@ -492,7 +479,7 @@ end
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, objects_1[k_1], Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( objects_1[k_1] ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( objects_1[k_1] ), Opposite( P_1 ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ 1 .. k_1 - 1 ]}, function ( c_2 )
                     return Dimension( c_2 );
@@ -537,7 +524,7 @@ end
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, T_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
                   return UnderlyingMatrix( Opposite( logic_new_func_x_2 ) );
               end ) ) ) );
 end
@@ -552,7 +539,7 @@ end
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, T_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( T_1 ) ), 0, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( T_1 ) ), 0, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -565,7 +552,7 @@ end
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
                   return UnderlyingMatrix( Opposite( logic_new_func_x_2 ) );
               end ) ) ) );
 end
@@ -580,7 +567,7 @@ end
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( Opposite( T_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( Opposite( T_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -593,7 +580,7 @@ end
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, a_1, b_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( b_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( b_1 ) ), Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( b_1 ), Opposite( a_1 ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( b_1 ) ), Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -606,7 +593,7 @@ end
 function ( cat_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, 0 ) );
 end
 ########
         


### PR DESCRIPTION
LinearAlgebraForCAP always attaches the field to objects and morphisms via the attribute `UnderlyingFieldForHomalg`. I guess this has historical reasons. This PR removes the attribute from the constructors and instead computes the value via a separate method on demand. This has two advantages for the compiler:
1. Compiled code is shorter and thus better to read/debug.
2. The compiler immediately knows what the defining attributes of objects and morphisms are, i.e. `Dimension` and `UnderlyingMatrix`, simply because there is no other attribute :D

It also should speed up the construction of objects and morphisms.

@sebastianpos I await you okay, in case there is some big reason why the field is always attached to objects and morphisms :-)