### PR TITLE
Fix bug in caching mechanism and add Object/MorphismConstructor to non-cached operations

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -21,7 +21,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.04-16", ## Sepp's version
   ## this line prevents merge conflicts
-  "2021.07-01", ## Fabian's version
+  "2021.07-02", ## Fabian's version
   ## this line prevents merge conflicts
   "2021.05-04", ## Kamal's version
 ] ),

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -67,6 +67,8 @@ DeclareGlobalVariable( "PROPAGATION_LIST_FOR_EQUAL_MORPHISMS" );
 #! The arguments are two objects $S$ and $T$ in a category,
 #! and a morphism datum $a$ (type and semantics of the morphism datum depend on the category).
 #! The output is a morphism in $\mathrm{Hom}(S,T)$ defined by $a$.
+#! Note that by default this CAP operation is not cached. You can change this behaviour
+#! by calling `SetCachingToWeak( C, "MorphismConstructor" )` resp. `SetCachingToCrisp( C, "MorphismConstructor" )`.
 #! @Returns a morphism in $\mathrm{Hom}(S,T)$
 #! @Arguments S, a, T
 DeclareOperation( "MorphismConstructor",
@@ -95,6 +97,8 @@ DeclareOperation( "AddMorphismConstructor",
 #! The argument is a CAP category morphism <A>mor</A>.
 #! The output is a datum which can be used to construct <A>mor</A>, that is,
 #! `IsEqualForMorphisms( `<A>mor</A>`, MorphismConstructor( Source( `<A>mor</A>` ), MorphismDatum( `<A>mor</A>` ), Range( `<A>mor</A>` ) ) )`.
+#! Note that by default this CAP operation is not cached. You can change this behaviour
+#! by calling `SetCachingToWeak( C, "MorphismDatum" )` resp. `SetCachingToCrisp( C, "MorphismDatum" )`.
 #! @Returns depends on the category
 #! @Arguments mor
 DeclareAttribute( "MorphismDatum",

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -399,6 +399,8 @@ DeclareGlobalFunction( "ObjectifyObjectForCAPWithAttributes" );
 #! The arguments are a category $C$ and an object datum $a$
 #! (type and semantics of the object datum depend on the category).
 #! The output is an object of $C$ defined by $a$.
+#! Note that by default this CAP operation is not cached. You can change this behaviour
+#! by calling `SetCachingToWeak( C, "ObjectConstructor" )` resp. `SetCachingToCrisp( C, "ObjectConstructor" )`.
 #! @Returns an object
 #! @Arguments C, a
 DeclareOperation( "ObjectConstructor",
@@ -427,6 +429,8 @@ DeclareOperation( "AddObjectConstructor",
 #! The argument is a CAP category object <A>obj</A>.
 #! The output is a datum which can be used to construct <A>obj</A>, that is,
 #! `IsEqualForObjects( `<A>obj</A>`, ObjectConstructor( CapCategory( `<A>obj</A>` ), ObjectDatum( `<A>obj</A>` ) ) )`.
+#! Note that by default this CAP operation is not cached. You can change this behaviour
+#! by calling `SetCachingToWeak( C, "ObjectDatum" )` resp. `SetCachingToCrisp( C, "ObjectDatum" )`.
 #! @Returns depends on the category
 #! @Arguments obj
 DeclareAttribute( "ObjectDatum",

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -17,7 +17,7 @@ Version := Maximum( [
   ## this line prevents merge conflicts
   "2020.05-17", ## Mohamed's version
   ## this line prevents merge conflicts
-  "2021.07-02", ## Fabian's version
+  "2021.07-03", ## Fabian's version
   ## this line prevents merge conflicts
   "2020.04-18", ## Kamal's version
 ] ),

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -37,6 +37,9 @@ InstallMethod( CategoryOfColumns,
         ),
     );
     
+    # this cache replaces the KeyDependentOperation caching when using ObjectConstructor directly instead of CategoryOfColumnsObject
+    SetCachingToWeak( category, "ObjectConstructor" );
+    
     SetFilterObj( category, IsCategoryOfColumns );
     
     if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -37,6 +37,9 @@ InstallMethod( CategoryOfRows,
         ),
     );
     
+    # this cache replaces the KeyDependentOperation caching when using ObjectConstructor directly instead of CategoryOfRowsObject
+    SetCachingToWeak( category, "ObjectConstructor" );
+    
     SetFilterObj( category, IsCategoryOfRows );
     
     if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -45,6 +45,9 @@ InstallGlobalFunction( MATRIX_CATEGORY,
         ),
     );
     
+    # this cache replaces the KeyDependentOperation caching when using ObjectConstructor directly instead of MatrixCategoryObject
+    SetCachingToWeak( category, "ObjectConstructor" );
+    
     SetFilterObj( category, IsMatrixCategory );
     
     AddObjectRepresentation( category, IsVectorSpaceObject and HasIsProjective and IsProjective );


### PR DESCRIPTION
Previously, calling `SetCachingOfCategoryWeak/Crisp` would enable the caches of IsWellDefinedFor* and Random* due to those not being included in the list in `SetCachingOfCategory`.

Fixes #695.

@kamalsaleh I have noticed that one can actually override the caching even if it is set to "never". In fact, there was a bug based on this, see above. So now I have chosen option 3 in #695 with an explicit remark in the documentation. Maybe you can report if this indeed resolves your issue :-)