### PR TITLE
Call CAP operations in MonoidalCategories with category as first argument

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.08-03",
+Version := "2021.08-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -1292,7 +1292,7 @@ DeclareOperation( "PreCompose",
 #! This is a convenience method.
 #! The argument is a list of morphisms
 #! $L = ( \alpha_1: a_1 \rightarrow a_2, \alpha_2: a_2 \rightarrow a_3, \dots, \alpha_n: a_n \rightarrow a_{n+1} )$.
-#! The output is the composition 
+#! The output is the composition
 #! $\alpha_{n} \circ ( \alpha_{n-1} \circ ( \dots ( \alpha_2 \circ \alpha_1 ) ) )$.
 #! @Returns a morphism in $\mathrm{Hom}(a_1, a_{n+1})$
 #! @Arguments L
@@ -1318,6 +1318,17 @@ DeclareOperation( "AddPreCompose",
 DeclareOperation( "AddPreCompose",
                   [ IsCapCategory, IsList ] );
 
+#! @Description
+#! This is a convenience method.
+#! The arguments are a category $C$ and a list of morphisms
+#! $L = ( \alpha_1: a_1 \rightarrow a_2, \alpha_2: a_2 \rightarrow a_3, \dots, \alpha_n: a_n \rightarrow a_{n+1} )$ in $C$.
+#! The output is the composition
+#! $\alpha_{n} \circ ( \alpha_{n-1} \circ ( \dots ( \alpha_2 \circ \alpha_1 ) ) )$.
+#! @Returns a morphism in $\mathrm{Hom}(a_1, a_{n+1})$
+#! @Arguments C, L
+DeclareOperation( "PreComposeList",
+                  [ IsCapCategory, IsList ] );
+
 
 #! @Description
 #! The arguments are two morphisms $\beta: b \rightarrow c$, $\alpha: a \rightarrow b$.
@@ -1331,7 +1342,7 @@ DeclareOperation( "PostCompose",
 #! This is a convenience method.
 #! The argument is a list of morphisms
 #! $L = ( \alpha_n: a_n \rightarrow a_{n+1}, \alpha_{n-1}: a_{n-1} \rightarrow a_n, \dots, \alpha_1: a_1 \rightarrow a_2 )$.
-#! The output is the composition 
+#! The output is the composition
 #! $((\alpha_{n} \circ  \alpha_{n-1}) \circ \dots  \alpha_2) \circ \alpha_1$.
 #! @Returns a morphism in $\mathrm{Hom}(a_1, a_{n+1})$
 #! @Arguments L
@@ -1355,6 +1366,17 @@ DeclareOperation( "AddPostCompose",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddPostCompose",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! This is a convenience method.
+#! The arguments are a category $C$ and a list of morphisms
+#! $L = ( \alpha_n: a_n \rightarrow a_{n+1}, \alpha_{n-1}: a_{n-1} \rightarrow a_n, \dots, \alpha_1: a_1 \rightarrow a_2 )$.
+#! The output is the composition
+#! $((\alpha_{n} \circ  \alpha_{n-1}) \circ \dots  \alpha_2) \circ \alpha_1$.
+#! @Returns a morphism in $\mathrm{Hom}(a_1, a_{n+1})$
+#! @Arguments C, L
+DeclareOperation( "PostComposeList",
                   [ IsCapCategory, IsList ] );
 
 

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -475,25 +475,24 @@ InstallMethod( PreCompose,
                [ IsList ],
                
   function( morphism_list )
-    local length, result_morphism, i;
     
-    length := Length( morphism_list );
-    
-    if length = 0 then
-      
-      Error( "non-empty list expected" );
-      
+    if IsEmpty( morphism_list ) then
+        
+        Error( "non-empty list expected" );
+        
     fi;
     
-    result_morphism := morphism_list[1];
+    return PreComposeList( CapCategory( morphism_list[1] ), morphism_list );
     
-    for i in [ 2 .. length ] do
-      
-      result_morphism := PreCompose( result_morphism, morphism_list[i] );
-      
-    od;
+end );
+
+##
+InstallMethodForCompilerForCAP( PreComposeList,
+                                [ IsCapCategory, IsList ],
+                                
+  function( cat, morphism_list )
     
-    return result_morphism;
+    return Iterated( morphism_list, { alpha, beta } -> PreCompose( cat, alpha, beta ) );
     
 end );
 
@@ -502,25 +501,24 @@ InstallMethod( PostCompose,
                [ IsList ],
                
   function( morphism_list )
-    local length, result_morphism, i;
     
-    length := Length( morphism_list );
-    
-    if length = 0 then
-      
-      Error( "non-empty list expected" );
-      
+    if IsEmpty( morphism_list ) then
+        
+        Error( "non-empty list expected" );
+        
     fi;
     
-    result_morphism := morphism_list[1];
+    return PostComposeList( CapCategory( morphism_list[1] ), morphism_list );
     
-    for i in [ 2 .. length ] do
-      
-      result_morphism := PostCompose( result_morphism, morphism_list[i] );
-      
-    od;
+end );
+
+##
+InstallMethodForCompilerForCAP( PostComposeList,
+                                [ IsCapCategory, IsList ],
+                                
+  function( cat, morphism_list )
     
-    return result_morphism;
+    return Iterated( morphism_list, { beta, alpha } -> PostCompose( cat, beta, alpha ) );
     
 end );
 

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,8 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2021.08-01",
-
+Version := "2021.08-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -120,7 +119,7 @@ Dependencies := rec(
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
                    [ "ToolsForHomalg", ">= 2018.05.22" ],
-                   [ "CAP", ">= 2021.08-03" ],
+                   [ "CAP", ">= 2021.08-04" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/MonoidalCategories/gap/AdditiveMonoidalCategories.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategories.gi
@@ -4,9 +4,9 @@ AddDerivationToCAP( LeftDistributivityExpanding,
   function( cat, object, summands_list )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object, DirectSum( summands_list ) );
+    source_and_range := TensorProductOnObjects( cat, object, DirectSum( cat, summands_list ) );
     
-    return LeftDistributivityExpandingWithGivenObjects(
+    return LeftDistributivityExpandingWithGivenObjects( cat,
              source_and_range,
              object, summands_list,
              source_and_range
@@ -21,9 +21,9 @@ AddDerivationToCAP( LeftDistributivityFactoring,
   function( cat, object, summands_list )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object, DirectSum( summands_list ) );
+    source_and_range := TensorProductOnObjects( cat, object, DirectSum( cat, summands_list ) );
     
-    return LeftDistributivityFactoringWithGivenObjects(
+    return LeftDistributivityFactoringWithGivenObjects( cat,
              source_and_range,
              object, summands_list,
              source_and_range
@@ -38,9 +38,9 @@ AddDerivationToCAP( RightDistributivityExpanding,
   function( cat, summands_list, object )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( DirectSum( summands_list ), object );
+    source_and_range := TensorProductOnObjects( cat, DirectSum( cat, summands_list ), object );
     
-    return RightDistributivityExpandingWithGivenObjects(
+    return RightDistributivityExpandingWithGivenObjects( cat,
              source_and_range,
              summands_list, object,
              source_and_range
@@ -55,9 +55,9 @@ AddDerivationToCAP( RightDistributivityFactoring,
   function( cat, summands_list, object )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( DirectSum( summands_list ), object );
+    source_and_range := TensorProductOnObjects( cat, DirectSum( cat, summands_list ), object );
     
-    return RightDistributivityFactoringWithGivenObjects(
+    return RightDistributivityFactoringWithGivenObjects( cat,
              source_and_range,
              summands_list, object,
              source_and_range

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesDerivedMethods.gi
@@ -6,15 +6,15 @@ AddDerivationToCAP( LeftDistributivityExpandingWithGivenObjects,
     
     nr_summands := Size( summands );
     
-    id := IdentityMorphism( object );
+    id := IdentityMorphism( cat, object );
     
-    projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSum( summands, i ) );
+    projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSum( cat, summands, i ) );
     
-    projection_list := List( projection_list, mor -> TensorProductOnMorphisms( id, mor ) );
+    projection_list := List( projection_list, mor -> TensorProductOnMorphisms( cat, id, mor ) );
     
-    diagram := List( summands, summand -> TensorProductOnObjects( object, summand ) );
+    diagram := List( summands, summand -> TensorProductOnObjects( cat, object, summand ) );
     
-    return UniversalMorphismIntoDirectSum( diagram, projection_list );
+    return UniversalMorphismIntoDirectSum( cat, diagram, projection_list );
     
 end : CategoryFilter := IsMonoidalCategory and IsAdditiveCategory,
       Description := "LeftDistributivityExpandingWithGivenObjects using the universal property of the direct sum" );
@@ -27,15 +27,15 @@ AddDerivationToCAP( LeftDistributivityFactoringWithGivenObjects,
     
     nr_summands := Size( summands );
     
-    id := IdentityMorphism( object );
+    id := IdentityMorphism( cat, object );
     
-    injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSum( summands, i ) );
+    injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSum( cat, summands, i ) );
     
-    injection_list := List( injection_list, mor -> TensorProductOnMorphisms( id, mor ) );
+    injection_list := List( injection_list, mor -> TensorProductOnMorphisms( cat, id, mor ) );
     
-    diagram := List( summands, summand -> TensorProductOnObjects( object, summand ) );
+    diagram := List( summands, summand -> TensorProductOnObjects( cat, object, summand ) );
     
-    return UniversalMorphismFromDirectSum( diagram, injection_list );
+    return UniversalMorphismFromDirectSum( cat, diagram, injection_list );
     
 end : CategoryFilter := IsMonoidalCategory and IsAdditiveCategory,
       Description := "LeftDistributivityFactoringWithGivenObjects using the universal property of the direct sum" );
@@ -48,15 +48,15 @@ AddDerivationToCAP( RightDistributivityExpandingWithGivenObjects,
     
     nr_summands := Size( summands );
     
-    id := IdentityMorphism( object );
+    id := IdentityMorphism( cat, object );
     
-    projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSum( summands, i ) );
+    projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSum( cat, summands, i ) );
     
-    projection_list := List( projection_list, mor -> TensorProductOnMorphisms( mor, id ) );
+    projection_list := List( projection_list, mor -> TensorProductOnMorphisms( cat, mor, id ) );
     
-    diagram := List( summands, summand -> TensorProductOnObjects( summand, object ) );
+    diagram := List( summands, summand -> TensorProductOnObjects( cat, summand, object ) );
     
-    return UniversalMorphismIntoDirectSum( diagram, projection_list );
+    return UniversalMorphismIntoDirectSum( cat, diagram, projection_list );
     
 end : CategoryFilter := IsMonoidalCategory and IsAdditiveCategory,
       Description := "RightDistributivityExpandingWithGivenObjects using the universal property of the direct sum" );
@@ -69,15 +69,15 @@ AddDerivationToCAP( RightDistributivityFactoringWithGivenObjects,
     
     nr_summands := Size( summands );
     
-    id := IdentityMorphism( object );
+    id := IdentityMorphism( cat, object );
     
-    injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSum( summands, i ) );
+    injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSum( cat, summands, i ) );
     
-    injection_list := List( injection_list, mor -> TensorProductOnMorphisms( mor, id ) );
+    injection_list := List( injection_list, mor -> TensorProductOnMorphisms( cat, mor, id ) );
     
-    diagram := List( summands, summand -> TensorProductOnObjects( summand, object ) );
+    diagram := List( summands, summand -> TensorProductOnObjects( cat, summand, object ) );
     
-    return UniversalMorphismFromDirectSum( diagram, injection_list );
+    return UniversalMorphismFromDirectSum( cat, diagram, injection_list );
     
 end : CategoryFilter := IsMonoidalCategory and IsAdditiveCategory,
       Description := "RightDistributivityFactoringWithGivenObjects using the universal property of the direct sum" );

--- a/MonoidalCategories/gap/BraidedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategories.gi
@@ -4,9 +4,9 @@ AddDerivationToCAP( Braiding,
   function( cat, object_1, object_2 )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object_1, object_2 );
+    source_and_range := TensorProductOnObjects( cat, object_1, object_2 );
     
-    return BraidingWithGivenTensorProducts( source_and_range, object_1, object_2, source_and_range );
+    return BraidingWithGivenTensorProducts( cat, source_and_range, object_1, object_2, source_and_range );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -17,9 +17,9 @@ AddDerivationToCAP( BraidingInverse,
   function( cat, object_1, object_2 )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object_1, object_2 );
+    source_and_range := TensorProductOnObjects( cat, object_1, object_2 );
     
-    return BraidingInverseWithGivenTensorProducts( source_and_range, object_1, object_2, source_and_range );
+    return BraidingInverseWithGivenTensorProducts( cat, source_and_range, object_1, object_2, source_and_range );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );

--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesDerivedMethods.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( BraidingInverseWithGivenTensorProducts,
                   
   function( cat, object_2_tensored_object_1, object_1, object_2, object_1_tensored_object_2 )
     ##TODO: Use BraidingWithGiven
-    return Inverse( Braiding( object_1, object_2 ) );
+    return InverseForMorphisms( cat, Braiding( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsBraidedMonoidalCategory,
       Description := "BraidingInverseWithGivenTensorProducts as the inverse of the braiding" );
@@ -13,7 +13,7 @@ AddDerivationToCAP( BraidingWithGivenTensorProducts,
                   
   function( cat, object_1_tensored_object_2, object_1, object_2, object_2_tensored_object_1 )
     ##TODO: Use BraidingInverseWithGiven
-    return Inverse( BraidingInverse( object_1, object_2 ) );
+    return InverseForMorphisms( cat, BraidingInverse( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsBraidedMonoidalCategory,
       Description := "BraidingWithGivenTensorProducts as the inverse of BraidingInverse" );

--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesMethodRecord.gi
@@ -3,8 +3,8 @@ InstallValue( BRAIDED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD, rec(
 Braiding := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "s", "r" ] ],
-  output_source_getter_string := "TensorProductOnObjects( a, b )",
-  output_range_getter_string := "TensorProductOnObjects( b, a )",
+  output_source_getter_string := "TensorProductOnObjects( cat, a, b )",
+  output_range_getter_string := "TensorProductOnObjects( cat, b, a )",
   with_given_object_position := "both",
   return_type := "morphism" ),
 
@@ -16,8 +16,8 @@ BraidingWithGivenTensorProducts := rec(
 BraidingInverse := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "s", "r" ] ],
-  output_source_getter_string := "TensorProductOnObjects( b, a )",
-  output_range_getter_string := "TensorProductOnObjects( a, b )",
+  output_source_getter_string := "TensorProductOnObjects( cat, b, a )",
+  output_range_getter_string := "TensorProductOnObjects( cat, a, b )",
   with_given_object_position := "both",
   return_type := "morphism" ),
 

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( IsomorphismFromInternalHomToObject,
 
   function( cat, object )
     
-    return IsomorphismFromInternalHomToObjectWithGivenInternalHom( object, object );
+    return IsomorphismFromInternalHomToObjectWithGivenInternalHom( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -13,7 +13,7 @@ AddDerivationToCAP( IsomorphismFromObjectToInternalHom,
 
   function( cat, object )
     
-    return IsomorphismFromObjectToInternalHomWithGivenInternalHom( object, object );
+    return IsomorphismFromObjectToInternalHomWithGivenInternalHom( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
@@ -18,11 +18,8 @@ AddFinalDerivation( IsomorphismFromDualToInternalHom,
                       MorphismFromTensorProductToInternalHomWithGivenObjects ],
                  
   function( cat, object )
-    local category;
     
-    category := CapCategory( object );
-    
-    return IdentityMorphism( InternalHomOnObjects( object, TensorUnit( category ) ) );
+    return IdentityMorphism( cat, InternalHomOnObjects( cat, object, TensorUnit( cat ) ) );
     
 end : CategoryFilter := IsClosedMonoidalCategory,
       Description := "IsomorphismFromDualToInternalHom as the identity of Hom(a,1)" );
@@ -42,11 +39,8 @@ AddFinalDerivation( IsomorphismFromInternalHomToDual,
                       MorphismFromTensorProductToInternalHomWithGivenObjects ],
                  
   function( cat, object )
-    local category;
     
-    category := CapCategory( object );
-    
-    return IdentityMorphism( InternalHomOnObjects( object, TensorUnit( category ) ) );
+    return IdentityMorphism( cat, InternalHomOnObjects( cat, object, TensorUnit( cat ) ) );
     
 end : CategoryFilter := IsClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToDual as the identity of Hom(a,1)" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( IsomorphismFromInternalCoHomToObject,
 
   function( cat, object )
 
-    return IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom( object, object );
+    return IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom( cat, object, object );
 
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -13,7 +13,7 @@ AddDerivationToCAP( IsomorphismFromObjectToInternalCoHom,
 
   function( cat, object )
 
-    return IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom( object, object );
+    return IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom( cat, object, object );
 
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
@@ -18,12 +18,9 @@ AddFinalDerivation( IsomorphismFromCoDualToInternalCoHom,
                       MorphismFromInternalCoHomToTensorProductWithGivenObjects
                       ],
   function( cat, object )
-    local category;
-
-    category := CapCategory( object );
-
-    return IdentityMorphism( InternalCoHomOnObjects( TensorUnit( category ), object ) );
-
+    
+    return IdentityMorphism( cat, InternalCoHomOnObjects( cat, TensorUnit( cat ), object ) );
+    
 end : CategoryFilter := IsCoclosedMonoidalCategory,
       Description := "IsomorphismFromCoDualToInternalCoHom as the identity of coHom(1,a)" );
 
@@ -43,11 +40,8 @@ AddFinalDerivation( IsomorphismFromInternalCoHomToCoDual,
                       ],
 
   function( cat, object )
-    local category;
-
-    category := CapCategory( object );
-
-    return IdentityMorphism( InternalCoHomOnObjects( TensorUnit( category ), object ) );
-
+    
+    return IdentityMorphism( cat, InternalCoHomOnObjects( cat, TensorUnit( cat ), object ) );
+    
 end : CategoryFilter := IsCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToCoDual as the identity of coHom(1,a)" );

--- a/MonoidalCategories/gap/MonoidalCategories.gi
+++ b/MonoidalCategories/gap/MonoidalCategories.gi
@@ -16,9 +16,9 @@ AddDerivationToCAP( AssociatorRightToLeft,
   function( cat, object_1, object_2, object_3 )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object_1, TensorProductOnObjects( object_2, object_3 ) );
+    source_and_range := TensorProductOnObjects( cat, object_1, TensorProductOnObjects( cat, object_2, object_3 ) );
     
-    return AssociatorRightToLeftWithGivenTensorProducts( 
+    return AssociatorRightToLeftWithGivenTensorProducts( cat,
              source_and_range,
              object_1, object_2, object_3,
              source_and_range
@@ -33,9 +33,9 @@ AddDerivationToCAP( AssociatorLeftToRight,
   function( cat, object_1, object_2, object_3 )
     local source_and_range;
     
-    source_and_range := TensorProductOnObjects( object_1, TensorProductOnObjects( object_2, object_3 ) );
+    source_and_range := TensorProductOnObjects( cat, object_1, TensorProductOnObjects( cat, object_2, object_3 ) );
     
-    return AssociatorLeftToRightWithGivenTensorProducts( 
+    return AssociatorLeftToRightWithGivenTensorProducts( cat,
              source_and_range,
              object_1, object_2, object_3,
              source_and_range
@@ -49,7 +49,7 @@ AddDerivationToCAP( LeftUnitor,
 
   function( cat, object )
     
-    return LeftUnitorWithGivenTensorProduct( object, object );
+    return LeftUnitorWithGivenTensorProduct( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -59,7 +59,7 @@ AddDerivationToCAP( LeftUnitorInverse,
 
   function( cat, object )
     
-    return LeftUnitorInverseWithGivenTensorProduct( object, object );
+    return LeftUnitorInverseWithGivenTensorProduct( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -69,7 +69,7 @@ AddDerivationToCAP( RightUnitor,
 
   function( cat, object )
     
-    return RightUnitorWithGivenTensorProduct( object, object );
+    return RightUnitorWithGivenTensorProduct( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );
@@ -79,7 +79,7 @@ AddDerivationToCAP( RightUnitorInverse,
 
   function( cat, object )
     
-    return RightUnitorInverseWithGivenTensorProduct( object, object );
+    return RightUnitorInverseWithGivenTensorProduct( cat, object, object );
     
 end : CategoryFilter := IsSkeletalCategory,
       Description := "calling the WithGiven operation in a skeletal setting" );

--- a/MonoidalCategories/gap/MonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesDerivedMethods.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( AssociatorLeftToRightWithGivenTensorProducts,
                     
   function( cat, left_associated_object, object_1, object_2, object_3, right_associated_object )
     
-    return Inverse( AssociatorRightToLeftWithGivenTensorProducts(
+    return InverseForMorphisms( cat, AssociatorRightToLeftWithGivenTensorProducts( cat,
                       right_associated_object,
                       object_1, object_2, object_3,
                       left_associated_object )
@@ -16,7 +16,7 @@ AddDerivationToCAP( AssociatorRightToLeftWithGivenTensorProducts,
                     
   function( cat, right_associated_object, object_1, object_2, object_3, left_associated_object )
     
-    return Inverse( AssociatorLeftToRightWithGivenTensorProducts(
+    return InverseForMorphisms( cat, AssociatorLeftToRightWithGivenTensorProducts( cat,
                       left_associated_object,
                       object_1, object_2, object_3,
                       right_associated_object )
@@ -29,7 +29,7 @@ AddDerivationToCAP( LeftUnitorWithGivenTensorProduct,
                   
   function( cat, object, unit_tensored_object )
     
-    return Inverse( LeftUnitorInverseWithGivenTensorProduct( object, unit_tensored_object ) );
+    return InverseForMorphisms( cat, LeftUnitorInverseWithGivenTensorProduct( cat, object, unit_tensored_object ) );
     
 end : Description := "LeftUnitorWithGivenTensorProduct as the inverse of LeftUnitorInverseWithGivenTensorProduct" );
 
@@ -38,7 +38,7 @@ AddDerivationToCAP( LeftUnitorInverseWithGivenTensorProduct,
                   
   function( cat, object, unit_tensored_object )
     
-    return Inverse( LeftUnitorWithGivenTensorProduct( object, unit_tensored_object ) );
+    return InverseForMorphisms( cat, LeftUnitorWithGivenTensorProduct( cat, object, unit_tensored_object ) );
     
 end : Description := "LeftUnitorInverseWithGivenTensorProduct as the inverse of LeftUnitorWithGivenTensorProduct" );
 
@@ -47,7 +47,7 @@ AddDerivationToCAP( RightUnitorWithGivenTensorProduct,
                   
   function( cat, object, object_tensored_unit )
     
-    return Inverse( RightUnitorInverseWithGivenTensorProduct( object, object_tensored_unit ) );
+    return InverseForMorphisms( cat, RightUnitorInverseWithGivenTensorProduct( cat, object, object_tensored_unit ) );
     
 end : Description := "RightUnitorWithGivenTensorProduct as the inverse of RightUnitorInverseWithGivenTensorProduct" );
 
@@ -56,7 +56,7 @@ AddDerivationToCAP( RightUnitorInverseWithGivenTensorProduct,
                   
   function( cat, object, object_tensored_unit )
     
-    return Inverse( RightUnitorWithGivenTensorProduct( object, object_tensored_unit ) );
+    return InverseForMorphisms( cat, RightUnitorWithGivenTensorProduct( cat, object, object_tensored_unit ) );
     
 end : Description := "RightUnitorInverseWithGivenTensorProduct as the inverse of RightUnitorWithGivenTensorProduct" );
 
@@ -65,7 +65,7 @@ AddDerivationToCAP( AssociatorLeftToRightWithGivenTensorProducts,
                     
   function( cat, left_associated_object, object_1, object_2, object_3, right_associated_object )
     
-    return IdentityMorphism( left_associated_object );
+    return IdentityMorphism( cat, left_associated_object );
     
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "AssociatorLeftToRightWithGivenTensorProducts as the identity morphism" );
@@ -75,7 +75,7 @@ AddDerivationToCAP( AssociatorRightToLeftWithGivenTensorProducts,
                     
   function( cat, right_associated_object, object_1, object_2, object_3, left_associated_object )
     
-    return IdentityMorphism( right_associated_object );
+    return IdentityMorphism( cat, right_associated_object );
     
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "AssociatorRightToLeft as the identity morphism" );
@@ -85,7 +85,7 @@ AddDerivationToCAP( LeftUnitorWithGivenTensorProduct,
                     
   function( cat, object, unit_tensored_object )
     
-    return IdentityMorphism( object );
+    return IdentityMorphism( cat, object );
       
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "LeftUnitorWithGivenTensorProduct as the identity morphism" );
@@ -95,7 +95,7 @@ AddDerivationToCAP( LeftUnitorInverseWithGivenTensorProduct,
                   
   function( cat, object, unit_tensored_object )
     
-    return IdentityMorphism( object );
+    return IdentityMorphism( cat, object );
     
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "LeftUnitorInverseWithGivenTensorProduct as the identity morphism" );
@@ -105,7 +105,7 @@ AddDerivationToCAP( RightUnitorWithGivenTensorProduct,
                     
   function( cat, object, object_tensored_unit )
     
-    return IdentityMorphism( object );
+    return IdentityMorphism( cat, object );
     
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "RightUnitorWithGivenTensorProduct as the identity morphism" );
@@ -115,7 +115,7 @@ AddDerivationToCAP( RightUnitorInverseWithGivenTensorProduct,
                     
   function( cat, object, object_tensored_unit )
     
-    return IdentityMorphism( object );
+    return IdentityMorphism( cat, object );
     
 end : CategoryFilter := IsStrictMonoidalCategory,
       Description := "RightUnitorInverseWithGivenTensorProduct as the identity morphism" );

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( InternalHomOnObjects,
                   
   function( cat, object_1, object_2 )
     
-    return Source( IsomorphismFromInternalHomToTensorProduct( object_1, object_2 ) );
+    return Source( IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalHomOnObjects as the source of IsomorphismFromInternalHomToTensorProduct" );
@@ -13,7 +13,7 @@ AddDerivationToCAP( InternalHomOnObjects,
                   
   function( cat, object_1, object_2 )
     
-    return Range( IsomorphismFromTensorProductToInternalHom( object_1, object_2 ) );
+    return Range( IsomorphismFromTensorProductToInternalHom( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalHomOnObjects as the range of IsomorphismFromTensorProductToInternalHom" );
@@ -24,12 +24,12 @@ AddDerivationToCAP( InternalHomOnMorphismsWithGivenInternalHoms,
   function( cat, internal_hom_source, morphism_1, morphism_2, internal_hom_range )
     local dual_morphism;
     
-    dual_morphism := DualOnMorphisms( morphism_1 );
+    dual_morphism := DualOnMorphisms( cat, morphism_1 );
     
-    return PreCompose( [
-             IsomorphismFromInternalHomToTensorProduct( Range( morphism_1 ), Source( morphism_2 ) ),
-             TensorProductOnMorphisms( dual_morphism, morphism_2 ),
-             IsomorphismFromTensorProductToInternalHom( Source( morphism_1 ), Range( morphism_2 ) )
+    return PreComposeList( cat, [
+             IsomorphismFromInternalHomToTensorProduct( cat, Range( morphism_1 ), Source( morphism_2 ) ),
+             TensorProductOnMorphisms( cat, dual_morphism, morphism_2 ),
+             IsomorphismFromTensorProductToInternalHom( cat, Source( morphism_1 ), Range( morphism_2 ) )
            ] );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
@@ -40,7 +40,7 @@ AddDerivationToCAP( MorphismFromBidualWithGivenBidual,
                   
   function( cat, object, bidual )
     
-    return Inverse( MorphismToBidualWithGivenBidual( object, bidual ) );
+    return InverseForMorphisms( cat, MorphismToBidualWithGivenBidual( cat, object, bidual ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromBidualWithGivenBidual as the inverse of MorphismToBidualWithGivenBidual" );
@@ -50,7 +50,7 @@ AddDerivationToCAP( MorphismToBidualWithGivenBidual,
                   
   function( cat, object, bidual )
     
-    return Inverse( MorphismFromBidualWithGivenBidual( object, bidual ) );
+    return InverseForMorphisms( cat, MorphismFromBidualWithGivenBidual( cat, object, bidual ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismToBidualWithGivenBidual as the inverse of MorphismFromBidualWithGivenBidual" );
@@ -61,22 +61,22 @@ AddDerivationToCAP( EvaluationMorphismWithGivenSource,
   function( cat, object_1, object_2, internal_hom_tensored_object_1 )
     local morphism;
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms( 
-                    IsomorphismFromInternalHomToTensorProduct( object_1, object_2 ),
-                    IdentityMorphism( object_1 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat, 
+                    IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( DualOnObjects( object_1 ), object_2 ),
-                    IdentityMorphism( object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, DualOnObjects( cat, object_1 ), object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                     
-                  AssociatorLeftToRight( object_2, DualOnObjects( object_1 ), object_1 ),
+                  AssociatorLeftToRight( cat, object_2, DualOnObjects( cat, object_1 ), object_1 ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( object_2 ),
-                    EvaluationForDual( object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, object_2 ),
+                    EvaluationForDual( cat, object_1 ) ),
                     
-                  RightUnitor( object_2 )
+                  RightUnitor( cat, object_2 )
                 ] );
       
     return morphism;
@@ -90,18 +90,18 @@ AddDerivationToCAP( EvaluationMorphismWithGivenSource,
   function( cat, object_1, object_2, internal_hom_tensored_object_1 )
     local morphism;
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms( 
-                    IsomorphismFromInternalHomToTensorProduct( object_1, object_2 ),
-                    IdentityMorphism( object_1 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat, 
+                    IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( DualOnObjects( object_1 ), object_2 ),
-                    IdentityMorphism( object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, DualOnObjects( cat, object_1 ), object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                     
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( object_2 ),
-                    EvaluationForDual( object_1 ) )
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, object_2 ),
+                    EvaluationForDual( cat, object_1 ) )
                 ] );
                     
     return morphism;
@@ -115,30 +115,30 @@ AddDerivationToCAP( CoevaluationMorphismWithGivenRange,
   function( cat, object_1, object_2, internal_hom )
     local morphism, dual_2, id_1;
     
-    dual_2 := DualOnObjects( object_2 );
+    dual_2 := DualOnObjects( cat, object_2 );
     
-    id_1 := IdentityMorphism( object_1 );
+    id_1 := IdentityMorphism( cat, object_1 );
     
-    morphism := PreCompose( [
-                  LeftUnitorInverse( object_1 ),
+    morphism := PreComposeList( cat, [
+                  LeftUnitorInverse( cat, object_1 ),
                     
-                  TensorProductOnMorphisms(
-                    CoevaluationForDual( object_2 ),
+                  TensorProductOnMorphisms( cat,
+                    CoevaluationForDual( cat, object_2 ),
                     id_1 ),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( object_2, dual_2 ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, object_2, dual_2 ),
                     id_1 ),
                     
-                  AssociatorLeftToRight( dual_2, object_2, object_1 ),
+                  AssociatorLeftToRight( cat, dual_2, object_2, object_1 ),
                     
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( dual_2 ),
-                    Braiding( object_2, object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, dual_2 ),
+                    Braiding( cat, object_2, object_1 ) ),
                     
-                  IsomorphismFromTensorProductToInternalHom(
+                  IsomorphismFromTensorProductToInternalHom( cat,
                     object_2,
-                    TensorProductOnObjects( object_1, object_2 ) )
+                    TensorProductOnObjects( cat, object_1, object_2 ) )
                 ] );
                     
     return morphism;
@@ -152,26 +152,26 @@ AddDerivationToCAP( CoevaluationMorphismWithGivenRange,
   function( cat, object_1, object_2, internal_hom )
     local morphism, dual_2, id_1;
     
-    dual_2 := DualOnObjects( object_2 );
+    dual_2 := DualOnObjects( cat, object_2 );
     
-    id_1 := IdentityMorphism( object_1 );
+    id_1 := IdentityMorphism( cat, object_1 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    CoevaluationForDual( object_2 ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    CoevaluationForDual( cat, object_2 ),
                     id_1 ),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( object_2, dual_2 ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, object_2, dual_2 ),
                     id_1 ),
                     
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( dual_2 ),
-                    Braiding( object_2, object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, dual_2 ),
+                    Braiding( cat, object_2, object_1 ) ),
                     
-                  IsomorphismFromTensorProductToInternalHom(
+                  IsomorphismFromTensorProductToInternalHom( cat,
                     object_2,
-                    TensorProductOnObjects( object_1, object_2 ) )
+                    TensorProductOnObjects( cat, object_1, object_2 ) )
                 ] );
     
     return morphism;
@@ -184,7 +184,7 @@ AddDerivationToCAP( MorphismFromTensorProductToInternalHomWithGivenObjects,
                   
   function( cat, tensor_object, object_1, object_2, internal_hom )
     
-    return IsomorphismFromTensorProductToInternalHom( object_1, object_2 );
+    return IsomorphismFromTensorProductToInternalHom( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromTensorProductToInternalHomWithGivenObjects using IsomorphismFromTensorProductToInternalHom" );
@@ -194,7 +194,7 @@ AddDerivationToCAP( MorphismFromInternalHomToTensorProductWithGivenObjects,
                   
   function( cat, tensor_object, object_1, object_2, internal_hom )
     
-    return IsomorphismFromInternalHomToTensorProduct( object_1, object_2 );
+    return IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromInternalHomToTensorProductWithGivenObjects using IsomorphismFromInternalHomToTensorProduct" );
@@ -204,7 +204,7 @@ AddDerivationToCAP( IsomorphismFromInternalHomToTensorProduct,
                     
   function( cat, object_1, object_2 )
     
-    return MorphismFromInternalHomToTensorProduct( object_1, object_2 );
+    return MorphismFromInternalHomToTensorProduct( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToTensorProduct using MorphismFromInternalHomToTensorProduct" );
@@ -214,7 +214,7 @@ AddDerivationToCAP( IsomorphismFromTensorProductToInternalHom,
                     
   function( cat, object_1, object_2 )
     
-    return MorphismFromTensorProductToInternalHom( object_1, object_2 );
+    return MorphismFromTensorProductToInternalHom( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalHom using MorphismFromTensorProductToInternalHom" );
@@ -225,12 +225,12 @@ AddDerivationToCAP( CoevaluationForDualWithGivenTensorProduct,
   function( cat, unit, object, tensor_object )
     local morphism;
     
-    morphism := IdentityMorphism( object );
+    morphism := IdentityMorphism( cat, object );
     
-    morphism := PreCompose( [
-                  LambdaIntroduction( morphism ),
-                  IsomorphismFromInternalHomToTensorProduct( object, object ),
-                  Braiding( DualOnObjects( object ), object )
+    morphism := PreComposeList( cat, [
+                  LambdaIntroduction( cat, morphism ),
+                  IsomorphismFromInternalHomToTensorProduct( cat, object, object ),
+                  Braiding( cat, DualOnObjects( cat, object ), object )
                 ] );
                             
     return morphism;
@@ -246,10 +246,10 @@ AddDerivationToCAP( TraceMap,
     
     object := Source( morphism );
     
-    result_morphism := PreCompose( [
-                         LambdaIntroduction( morphism ),
-                         IsomorphismFromInternalHomToTensorProduct( object, object ),
-                         EvaluationForDual( object )
+    result_morphism := PreComposeList( cat, [
+                         LambdaIntroduction( cat, morphism ),
+                         IsomorphismFromInternalHomToTensorProduct( cat, object, object ),
+                         EvaluationForDual( cat, object )
                        ] );
     
     return result_morphism;
@@ -262,7 +262,7 @@ AddDerivationToCAP( RankMorphism,
                     
   function( cat, object )
     
-    return TraceMap( IdentityMorphism( object ) );
+    return TraceMap( cat, IdentityMorphism( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "Rank of an object as the trace of its identity" );
@@ -272,7 +272,7 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismInverseWithGive
                     
   function( cat, source, list, range )
     
-    return Inverse( TensorProductInternalHomCompatibilityMorphismWithGivenObjects( source, list, range ) );
+    return InverseForMorphisms( cat, TensorProductInternalHomCompatibilityMorphismWithGivenObjects( cat, source, list, range ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects as the inverse of TensorProductInternalHomCompatibilityMorphismWithGivenObjects" );
@@ -305,7 +305,7 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalHom,
                     
   function( cat, object_1, object_2 )
     
-    return IdentityMorphism( TensorProductOnObjects( DualOnObjects( object_1 ), object_2 ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, object_1 ), object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalHom as the identity of (Dual(a) tensored b)" );
@@ -332,7 +332,7 @@ AddFinalDerivation( IsomorphismFromInternalHomToTensorProduct,
                     
   function( cat, object_1, object_2 )
     
-    return IdentityMorphism( TensorProductOnObjects( DualOnObjects( object_1 ), object_2 ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, object_1 ), object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToTensorProduct as the identity of (Dual(a) tensored b)" );
@@ -362,7 +362,7 @@ AddFinalDerivation( IsomorphismFromInternalHomToDual,
                     
   function( cat, object )
     
-    return IdentityMorphism( DualOnObjects( object ) );
+    return IdentityMorphism( cat, DualOnObjects( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToDual as the identity of the Dual" );
@@ -389,7 +389,7 @@ AddFinalDerivation( IsomorphismFromDualToInternalHom,
                     
   function( cat, object )
     
-    return IdentityMorphism( DualOnObjects( object ) );
+    return IdentityMorphism( cat, DualOnObjects( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromDualToInternalHom as the identity of the Dual" );

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( InternalCoHomOnObjects,
                   
   function( cat, object_1, object_2 )
     
-    return Source( IsomorphismFromInternalCoHomToTensorProduct( object_1, object_2 ) );
+    return Source( IsomorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "InternalCoHomOnObjects as the source of IsomorphismFromInternalCoHomToTensorProduct" );
@@ -13,7 +13,7 @@ AddDerivationToCAP( InternalCoHomOnObjects,
                   
   function( cat, object_1, object_2 )
     
-    return Range( IsomorphismFromTensorProductToInternalCoHom( object_1, object_2 ) );
+    return Range( IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalCoHomOnObjects as the range of IsomorphismFromTensorProductToInternalCoHom" );
@@ -24,12 +24,12 @@ AddDerivationToCAP( InternalCoHomOnMorphismsWithGivenInternalCoHoms,
   function( cat, internal_cohom_source, morphism_1, morphism_2, internal_cohom_range )
     local codual_morphism;
     
-    codual_morphism := CoDualOnMorphisms( morphism_2 );
+    codual_morphism := CoDualOnMorphisms( cat, morphism_2 );
     
-    return PreCompose( [
-             IsomorphismFromInternalCoHomToTensorProduct( Source( morphism_1 ), Range( morphism_2 ) ),
-             TensorProductOnMorphisms( morphism_1, codual_morphism ),
-             IsomorphismFromTensorProductToInternalCoHom( Range( morphism_1 ), Source( morphism_2 ) ) 
+    return PreComposeList( cat, [
+             IsomorphismFromInternalCoHomToTensorProduct( cat, Source( morphism_1 ), Range( morphism_2 ) ),
+             TensorProductOnMorphisms( cat, morphism_1, codual_morphism ),
+             IsomorphismFromTensorProductToInternalCoHom( cat, Range( morphism_1 ), Source( morphism_2 ) ) 
            ] );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
@@ -40,7 +40,7 @@ AddDerivationToCAP( MorphismToCoBidualWithGivenCoBidual,
                   
   function( cat, object, cobidual )
     
-    return Inverse( MorphismFromCoBidualWithGivenCoBidual( object, cobidual ) );
+    return InverseForMorphisms( cat, MorphismFromCoBidualWithGivenCoBidual( cat, object, cobidual ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "MorphismToCoBidualWithGivenCoBidual as the inverse of MorphismFromCoBidualWithGivenCoBidual" );
@@ -50,7 +50,7 @@ AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
                   
   function( cat, object, cobidual )
     
-    return Inverse( MorphismToCoBidualWithGivenCoBidual( object, cobidual ) );
+    return InverseForMorphisms( cat, MorphismToCoBidualWithGivenCoBidual( cat, object, cobidual ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "MorphismFromCoBidualWithGivenCoBidual as the inverse of MorphismToCoBidualWithGivenCoBidual" );
@@ -61,22 +61,22 @@ AddDerivationToCAP( CoclosedEvaluationMorphismWithGivenRange,
   function( cat, object_1, object_2, object_2_tensored_internal_cohom )
     local morphism;
     
-    morphism := PreCompose( [
-                  LeftUnitorInverse( object_1 ),
+    morphism := PreComposeList( cat, [
+                  LeftUnitorInverse( cat, object_1 ),
                   
-                  TensorProductOnMorphisms(
-                    CoclosedEvaluationForCoDual( object_2 ),
-                    IdentityMorphism( object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    CoclosedEvaluationForCoDual( cat, object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                   
-                  AssociatorLeftToRight( object_2, CoDualOnObjects( object_2 ), object_1 ),
+                  AssociatorLeftToRight( cat, object_2, CoDualOnObjects( cat, object_2 ), object_1 ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( object_2 ),
-                    Braiding( CoDualOnObjects( object_2 ), object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, object_2 ),
+                    Braiding( cat, CoDualOnObjects( cat, object_2 ), object_1 ) ),
                   
-                  TensorProductOnMorphisms( 
-                    IdentityMorphism( object_2 ),
-                    IsomorphismFromTensorProductToInternalCoHom( object_1, object_2 ) ) 
+                  TensorProductOnMorphisms( cat, 
+                    IdentityMorphism( cat, object_2 ),
+                    IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) ) 
                 ] );
                     
     return morphism;
@@ -90,18 +90,18 @@ AddDerivationToCAP( CoclosedEvaluationMorphismWithGivenRange,
   function( cat, object_1, object_2, object_2_tensored_internal_cohom )
     local morphism;
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    CoclosedEvaluationForCoDual( object_2 ),
-                    IdentityMorphism( object_1 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    CoclosedEvaluationForCoDual( cat, object_2 ),
+                    IdentityMorphism( cat, object_1 ) ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( object_2 ),
-                    Braiding( CoDualOnObjects( object_2 ), object_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, object_2 ),
+                    Braiding( cat, CoDualOnObjects( cat, object_2 ), object_1 ) ),
                   
-                  TensorProductOnMorphisms( 
-                    IdentityMorphism( object_2 ),
-                    IsomorphismFromTensorProductToInternalCoHom( object_1, object_2 ) ) 
+                  TensorProductOnMorphisms( cat, 
+                    IdentityMorphism( cat, object_2 ),
+                    IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) ) 
                 ] );
                     
     return morphism;
@@ -115,30 +115,30 @@ AddDerivationToCAP( CoclosedCoevaluationMorphismWithGivenSource,
   function( cat, object_1, object_2, internal_cohom )
     local morphism, codual_1, id_2;
     
-    codual_1 := CoDualOnObjects( object_1 );
+    codual_1 := CoDualOnObjects( cat, object_1 );
     
-    id_2 := IdentityMorphism( object_2 );
+    id_2 := IdentityMorphism( cat, object_2 );
     
-    morphism := PreCompose( [
-                  IsomorphismFromInternalCoHomToTensorProduct(
-                    TensorProductOnObjects( object_1, object_2 ),
+    morphism := PreComposeList( cat, [
+                  IsomorphismFromInternalCoHomToTensorProduct( cat,
+                    TensorProductOnObjects( cat, object_1, object_2 ),
                     object_1),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( object_1, object_2 ),
-                    IdentityMorphism( codual_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, object_1, object_2 ),
+                    IdentityMorphism( cat, codual_1 ) ),
                     
-                  AssociatorLeftToRight( object_2, object_1, codual_1 ),
+                  AssociatorLeftToRight( cat, object_2, object_1, codual_1 ),
                     
-                  TensorProductOnMorphisms(
+                  TensorProductOnMorphisms( cat,
                     id_2,
-                    Braiding( object_1, codual_1 ) ),
+                    Braiding( cat, object_1, codual_1 ) ),
                     
-                  TensorProductOnMorphisms(
+                  TensorProductOnMorphisms( cat,
                     id_2,
-                    CoclosedCoevaluationForCoDual( object_1 ) ),
+                    CoclosedCoevaluationForCoDual( cat, object_1 ) ),
                     
-                  RightUnitor( object_2 ) 
+                  RightUnitor( cat, object_2 ) 
                 ] );
                     
     return morphism;
@@ -152,26 +152,26 @@ AddDerivationToCAP( CoclosedCoevaluationMorphismWithGivenSource,
   function( cat, object_1, object_2, internal_cohom )
     local morphism, codual_1, id_2;
     
-    codual_1 := CoDualOnObjects( object_1 );
+    codual_1 := CoDualOnObjects( cat, object_1 );
     
-    id_2 := IdentityMorphism( object_2 );
+    id_2 := IdentityMorphism( cat, object_2 );
     
-    morphism := PreCompose( [
-                  IsomorphismFromInternalCoHomToTensorProduct(
-                    TensorProductOnObjects( object_1, object_2 ),
+    morphism := PreComposeList( cat, [
+                  IsomorphismFromInternalCoHomToTensorProduct( cat,
+                    TensorProductOnObjects( cat, object_1, object_2 ),
                     object_1),
                     
-                  TensorProductOnMorphisms(
-                    Braiding( object_1, object_2 ),
-                    IdentityMorphism( codual_1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, object_1, object_2 ),
+                    IdentityMorphism( cat, codual_1 ) ),
                     
-                  TensorProductOnMorphisms(
+                  TensorProductOnMorphisms( cat,
                     id_2,
-                    Braiding( object_1, codual_1 ) ),
+                    Braiding( cat, object_1, codual_1 ) ),
                     
-                  TensorProductOnMorphisms(
+                  TensorProductOnMorphisms( cat,
                     id_2,
-                    CoclosedCoevaluationForCoDual( object_1 ) ) 
+                    CoclosedCoevaluationForCoDual( cat, object_1 ) ) 
                 ] );
                     
     return morphism;
@@ -184,7 +184,7 @@ AddDerivationToCAP( MorphismFromInternalCoHomToTensorProductWithGivenObjects,
                   
   function( cat, internal_cohom, object_1, object_2, tensor_object )
     
-    return IsomorphismFromInternalCoHomToTensorProduct( object_1, object_2 );
+    return IsomorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromInternalCoHomToTensorProductWithGivenObjects using IsomorphismFromInternalCoHomToTensorProduct" );
@@ -195,7 +195,7 @@ AddDerivationToCAP( MorphismFromTensorProductToInternalCoHomWithGivenObjects,
                   
   function( cat, tensor_object, object_1, object_2, internal_hom )
     
-    return IsomorphismFromTensorProductToInternalCoHom( object_1, object_2 );
+    return IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromTensorProductToInternalCoHomWithGivenObjects using IsomorphismFromTensorProductToInternalCoHom" );
@@ -205,7 +205,7 @@ AddDerivationToCAP( IsomorphismFromInternalCoHomToTensorProduct,
                     
   function( cat, object_1, object_2 )
     
-    return MorphismFromInternalCoHomToTensorProduct( object_1, object_2 );
+    return MorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToTensorProduct using MorphismFromInternalCoHomToTensorProduct" );
@@ -215,7 +215,7 @@ AddDerivationToCAP( IsomorphismFromTensorProductToInternalCoHom,
                     
   function( cat, object_1, object_2 )
     
-    return MorphismFromTensorProductToInternalCoHom( object_1, object_2 );
+    return MorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalCoHom using MorphismFromTensorProductToInternalCoHom" );
@@ -225,12 +225,12 @@ AddDerivationToCAP( CoclosedCoevaluationForCoDualWithGivenTensorProduct,
   function( cat, tensor_object, object, unit )
     local morphism;
     
-    morphism := IdentityMorphism( object );
+    morphism := IdentityMorphism( cat, object );
     
-    morphism := PreCompose( [
-                  Braiding( CoDualOnObjects( object ), object ),
-                  IsomorphismFromTensorProductToInternalCoHom( object, object ),
-                  CoLambdaIntroduction( morphism ) 
+    morphism := PreComposeList( cat, [
+                  Braiding( cat, CoDualOnObjects( cat, object ), object ),
+                  IsomorphismFromTensorProductToInternalCoHom( cat, object, object ),
+                  CoLambdaIntroduction( cat, morphism ) 
                 ] );
                             
     return morphism;
@@ -246,10 +246,10 @@ AddDerivationToCAP( CoTraceMap,
     
     object := Source( morphism );
     
-    return PreCompose( [
-             CoclosedEvaluationForCoDual( object ) ,
-             IsomorphismFromTensorProductToInternalCoHom( object, object ),
-             CoLambdaIntroduction( morphism )
+    return PreComposeList( cat, [
+             CoclosedEvaluationForCoDual( cat, object ) ,
+             IsomorphismFromTensorProductToInternalCoHom( cat, object, object ),
+             CoLambdaIntroduction( cat, morphism )
            ] );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
@@ -260,7 +260,7 @@ AddDerivationToCAP( CoRankMorphism,
                     
   function( cat, object )
     
-    return CoTraceMap( IdentityMorphism( object ) );
+    return CoTraceMap( cat, IdentityMorphism( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "Corank of an object as the cotrace of its identity" );
@@ -270,7 +270,7 @@ AddDerivationToCAP( InternalCoHomTensorProductCompatibilityMorphismInverseWithGi
                     
   function( cat, source, list, range )
     
-    return Inverse( InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects( source, list, range ) );
+    return InverseForMorphisms( cat, InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects( cat, source, list, range ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects as the inverse of TensorProductInternalCoHomCompatibilityMorphismWithGivenObjects" );
@@ -303,7 +303,7 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalCoHom,
                     
   function( cat, object_1, object_2 )
     
-    return IdentityMorphism( TensorProductOnObjects( object_1, CoDualOnObjects( object_2 ) ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, CoDualOnObjects( cat, object_2 ) ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalCoHom as the identity of (a tensored CoDual(b))" );
@@ -330,7 +330,7 @@ AddFinalDerivation( IsomorphismFromInternalCoHomToTensorProduct,
                     
   function( cat, object_1, object_2 )
     
-    return IdentityMorphism( TensorProductOnObjects( object_1, CoDualOnObjects( object_2 ) ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, CoDualOnObjects( cat, object_2 ) ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToTensorProduct as the identity of (a tensored CoDual(b))" );
@@ -360,7 +360,7 @@ AddFinalDerivation( IsomorphismFromInternalCoHomToCoDual,
                     
   function( cat, object )
     
-    return IdentityMorphism( CoDualOnObjects( object ) );
+    return IdentityMorphism( cat, CoDualOnObjects( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToCoDual as the identity of the CoDual" );
@@ -387,7 +387,7 @@ AddFinalDerivation( IsomorphismFromCoDualToInternalCoHom,
                     
   function( cat, object )
     
-    return IdentityMorphism( CoDualOnObjects( object ) );
+    return IdentityMorphism( cat, CoDualOnObjects( cat, object ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromCoDualToInternalCoHom as the identity of the CoDual" );

--- a/MonoidalCategories/gap/SymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/SymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -3,9 +3,9 @@ AddDerivationToCAP( TensorProductToInternalHomAdjunctionMap,
                     
   function( cat, object_1, object_2, morphism )
     
-    return PreCompose( 
-             CoevaluationMorphism( object_1, object_2 ), 
-             InternalHomOnMorphisms( IdentityMorphism( object_2 ), morphism ) );
+    return PreCompose( cat,
+             CoevaluationMorphism( cat, object_1, object_2 ), 
+             InternalHomOnMorphisms( cat, IdentityMorphism( cat, object_2 ), morphism ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "TensorProductToInternalHomAdjunctionMap using CoevaluationMorphism and InternalHom" );
@@ -15,9 +15,9 @@ AddDerivationToCAP( InternalHomToTensorProductAdjunctionMap,
                     
   function( cat, object_1, object_2, morphism )
     
-    return PreCompose( 
-             TensorProductOnMorphisms( morphism, IdentityMorphism( object_1 ) ),
-             EvaluationMorphism( object_1, object_2 ) );
+    return PreCompose( cat,
+             TensorProductOnMorphisms( cat, morphism, IdentityMorphism( cat, object_1 ) ),
+             EvaluationMorphism( cat, object_1, object_2 ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "InternalHomToTensorProductAdjunctionMap using TensorProductOnMorphisms and EvaluationMorphism" );
@@ -27,9 +27,9 @@ AddDerivationToCAP( UniversalPropertyOfDual,
                     
   function( cat, object_1, object_2, test_morphism )
     
-    return PreCompose( 
-             TensorProductToInternalHomAdjunctionMap( object_1, object_2, test_morphism ),
-             IsomorphismFromInternalHomToDual( object_2 ) );
+    return PreCompose( cat,
+             TensorProductToInternalHomAdjunctionMap( cat, object_1, object_2, test_morphism ),
+             IsomorphismFromInternalHomToDual( cat, object_2 ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "UniversalPropertyOfDual using the tensor hom adjunction" );
@@ -40,10 +40,10 @@ AddDerivationToCAP( MorphismToBidualWithGivenBidual,
   function( cat, object, bidual )
     local morphism;
 
-    morphism := PreCompose( Braiding( object, DualOnObjects( object ) ),
-                            EvaluationForDual( object ) );
+    morphism := PreCompose( cat, Braiding( cat, object, DualOnObjects( cat, object ) ),
+                            EvaluationForDual( cat, object ) );
     
-    return UniversalPropertyOfDual( object, DualOnObjects( object ), morphism );
+    return UniversalPropertyOfDual( cat, object, DualOnObjects( cat, object ), morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "MorphismToBidualWithGivenBidual using the braiding and the universal property of the dual" );
@@ -54,20 +54,20 @@ AddDerivationToCAP( MorphismToBidualWithGivenBidual,
   function( cat, object, bidual )
     local morphism, dual_object, tensor_unit;
     
-    dual_object := DualOnObjects( object );
+    dual_object := DualOnObjects( cat, object );
     
-    tensor_unit := TensorUnit( CapCategory( object ) );
+    tensor_unit := TensorUnit( cat );
     
-    morphism := PreCompose( [
-                  CoevaluationMorphism( object, dual_object ),
+    morphism := PreComposeList( cat, [
+                  CoevaluationMorphism( cat, object, dual_object ),
                   
-                  InternalHomOnMorphisms(
-                    IdentityMorphism( dual_object ),
-                    Braiding( object, dual_object ) ),
+                  InternalHomOnMorphisms( cat,
+                    IdentityMorphism( cat, dual_object ),
+                    Braiding( cat, object, dual_object ) ),
                   
-                  InternalHomOnMorphisms(
-                    IdentityMorphism( dual_object ),
-                    EvaluationMorphism( object, tensor_unit ) )
+                  InternalHomOnMorphisms( cat,
+                    IdentityMorphism( cat, dual_object ),
+                    EvaluationMorphism( cat, object, tensor_unit ) )
                 ] );
     
     return morphism;
@@ -80,7 +80,7 @@ AddDerivationToCAP( DualOnObjects,
                   
   function( cat, object )
     
-    return Source( IsomorphismFromDualToInternalHom( object ) );
+    return Source( IsomorphismFromDualToInternalHom( cat, object ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "DualOnObjects as the source of IsomorphismFromDualToInternalHom" );
@@ -90,7 +90,7 @@ AddDerivationToCAP( DualOnObjects,
                   
   function( cat, object )
     
-    return Range( IsomorphismFromInternalHomToDual( object ) );
+    return Range( IsomorphismFromInternalHomToDual( cat, object ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "DualOnObjects as the range of IsomorphismFromInternalHomToDual" );
@@ -99,18 +99,15 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 AddDerivationToCAP( DualOnMorphismsWithGivenDuals,
                   
   function( cat, new_source, morphism, new_range )
-    local category;
     
-    category := CapCategory( morphism );
-    
-    return PreCompose( [ 
-             IsomorphismFromDualToInternalHom( Range( morphism ) ),
+    return PreComposeList( cat, [ 
+             IsomorphismFromDualToInternalHom( cat, Range( morphism ) ),
              
-             InternalHomOnMorphisms( 
+             InternalHomOnMorphisms( cat, 
                morphism,
-               IdentityMorphism( TensorUnit( category ) ) ),
+               IdentityMorphism( cat, TensorUnit( cat ) ) ),
                
-             IsomorphismFromInternalHomToDual( Source( morphism ) ) 
+             IsomorphismFromInternalHomToDual( cat, Source( morphism ) ) 
            ] );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
@@ -121,8 +118,8 @@ AddDerivationToCAP( EvaluationForDualWithGivenTensorProduct,
                   
   function( cat, tensor_object, object, unit )
     
-    return InternalHomToTensorProductAdjunctionMap( object, unit,
-                                                    IsomorphismFromDualToInternalHom( object ) );
+    return InternalHomToTensorProductAdjunctionMap( cat, object, unit,
+                                                    IsomorphismFromDualToInternalHom( cat, object ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "EvaluationForDualWithGivenTensorProduct using the tensor hom adjunction and IsomorphismFromDualToInternalHom" );
@@ -131,15 +128,13 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 AddDerivationToCAP( LambdaIntroduction,
                   
   function( cat, morphism )
-    local result_morphism, category, source;
-    
-    category := CapCategory( morphism );
+    local result_morphism, source;
     
     source := Source( morphism );
     
-    result_morphism := PreCompose( LeftUnitor( source ), morphism );
+    result_morphism := PreCompose( cat, LeftUnitor( cat, source ), morphism );
     
-    return TensorProductToInternalHomAdjunctionMap( TensorUnit( category ), source, result_morphism );
+    return TensorProductToInternalHomAdjunctionMap( cat, TensorUnit( cat ), source, result_morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "LambdaIntroduction using the tensor hom adjunction and left unitor" );
@@ -150,9 +145,9 @@ AddDerivationToCAP( LambdaElimination,
   function( cat, object_1, object_2, morphism )
     local result_morphism;
     
-    result_morphism := InternalHomToTensorProductAdjunctionMap( object_1, object_2, morphism );
+    result_morphism := InternalHomToTensorProductAdjunctionMap( cat, object_1, object_2, morphism );
     
-    return PreCompose( LeftUnitorInverse( object_1 ), result_morphism );
+    return PreCompose( cat, LeftUnitorInverse( cat, object_1 ), result_morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "LambdaElimination using the tensor hom adjunction and left unitor" );
@@ -168,50 +163,50 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObject
     a2 := list[3];
     b2 := list[4];
     
-    int_hom_a1_b1 := InternalHomOnObjects( a1, b1 );
+    int_hom_a1_b1 := InternalHomOnObjects( cat, a1, b1 );
     
-    int_hom_a2_b2 := InternalHomOnObjects( a2, b2 );
+    int_hom_a2_b2 := InternalHomOnObjects( cat, a2, b2 );
     
-    id_a2 := IdentityMorphism( a2 );
+    id_a2 := IdentityMorphism( cat, a2 );
     
     tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2 := 
-      TensorProductOnObjects( int_hom_a1_b1, int_hom_a2_b2 );
+      TensorProductOnObjects( cat, int_hom_a1_b1, int_hom_a2_b2 );
     
-    morphism := PreCompose( [
-                  AssociatorRightToLeft(
+    morphism := PreComposeList( cat, [
+                  AssociatorRightToLeft( cat,
                     tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2,
                     a1, a2 ),
                   
-                  TensorProductOnMorphisms(
-                    AssociatorLeftToRight( int_hom_a1_b1, int_hom_a2_b2, a1 ),
+                  TensorProductOnMorphisms( cat,
+                    AssociatorLeftToRight( cat, int_hom_a1_b1, int_hom_a2_b2, a1 ),
                     id_a2 ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      IdentityMorphism( int_hom_a1_b1 ),
-                      Braiding( int_hom_a2_b2, a1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      IdentityMorphism( cat, int_hom_a1_b1 ),
+                      Braiding( cat, int_hom_a2_b2, a1 ) ),
                     id_a2 ),
                   
-                  TensorProductOnMorphisms(
-                    AssociatorRightToLeft( int_hom_a1_b1, a1, int_hom_a2_b2 ),
+                  TensorProductOnMorphisms( cat,
+                    AssociatorRightToLeft( cat, int_hom_a1_b1, a1, int_hom_a2_b2 ),
                     id_a2 ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      EvaluationMorphism( a1, b1 ),
-                      IdentityMorphism( int_hom_a2_b2 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      EvaluationMorphism( cat, a1, b1 ),
+                      IdentityMorphism( cat, int_hom_a2_b2 ) ),
                     id_a2 ),
                   
-                  AssociatorLeftToRight( b1, int_hom_a2_b2, a2 ),
+                  AssociatorLeftToRight( cat, b1, int_hom_a2_b2, a2 ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( b1 ),
-                    EvaluationMorphism( a2, b2 ) )
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, b1 ),
+                    EvaluationMorphism( cat, a2, b2 ) )
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
+    return TensorProductToInternalHomAdjunctionMap( cat,
              tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2,
-             TensorProductOnObjects( a1, a2 ),
+             TensorProductOnObjects( cat, a1, a2 ),
              morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
@@ -223,22 +218,22 @@ AddDerivationToCAP( TensorProductDualityCompatibilityMorphismWithGivenObjects,
   function( cat, new_source, object_1, object_2, new_range )
     local morphism, unit, tensor_product_on_object_1_and_object_2;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( object_1, object_2 );
+    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    IsomorphismFromDualToInternalHom( object_1 ),
-                    IsomorphismFromDualToInternalHom( object_2 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromDualToInternalHom( cat, object_1 ),
+                    IsomorphismFromDualToInternalHom( cat, object_2 ) ),
                   
-                  TensorProductInternalHomCompatibilityMorphism( [ object_1, unit, object_2, unit ] ),
+                  TensorProductInternalHomCompatibilityMorphism( cat, [ object_1, unit, object_2, unit ] ),
                   
-                  InternalHomOnMorphisms(
-                    IdentityMorphism( tensor_product_on_object_1_and_object_2 ),
-                    LeftUnitor( unit ) ),
+                  InternalHomOnMorphisms( cat,
+                    IdentityMorphism( cat, tensor_product_on_object_1_and_object_2 ),
+                    LeftUnitor( cat, unit ) ),
                   
-                  IsomorphismFromInternalHomToDual( tensor_product_on_object_1_and_object_2 )
+                  IsomorphismFromInternalHomToDual( cat, tensor_product_on_object_1_and_object_2 )
                 ] );
     
     return morphism;
@@ -252,13 +247,13 @@ AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
   function( cat, object, internal_hom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose(
-             CoevaluationMorphism( object, unit ),
-             InternalHomOnMorphisms(
-               IdentityMorphism( unit ),
-               RightUnitor( object ) ) );
+    return PreCompose( cat,
+             CoevaluationMorphism( cat, object, unit ),
+             InternalHomOnMorphisms( cat,
+               IdentityMorphism( cat, unit ),
+               RightUnitor( cat, object ) ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalHomWithGivenInternalHom using the coevaluation morphism" );
@@ -269,12 +264,12 @@ AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
   function( cat, object, internal_hom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return TensorProductToInternalHomAdjunctionMap(
+    return TensorProductToInternalHomAdjunctionMap( cat,
              object,
              unit,
-             RightUnitor( object ) );
+             RightUnitor( cat, object ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalHomWithGivenInternalHom as the adjoint of the right unitor" );
@@ -285,7 +280,7 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #                     
 #   function( cat, object, internal_hom )
 #     
-#     return Inverse( IsomorphismFromObjectToInternalHom( object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalHom( cat, object ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom as the inverse of IsomorphismFromObjectToInternalHom" );
@@ -296,10 +291,10 @@ AddDerivationToCAP( IsomorphismFromInternalHomToObjectWithGivenInternalHom,
   function( cat, object, internal_hom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose( RightUnitorInverse( internal_hom ),
-                       EvaluationMorphism( unit, object ) );
+    return PreCompose( cat, RightUnitorInverse( cat, internal_hom ),
+                       EvaluationMorphism( cat, unit, object ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom using the evaluation morphism" );
@@ -310,7 +305,7 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #                     
 #   function( cat, object, internal_hom )
 #     
-#     return Inverse( IsomorphismFromInternalHomToObject( object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromInternalHomToObject( cat, object ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #       Description := "IsomorphismFromObjectToInternalHom as the inverse of IsomorphismFromInternalHomToObject" );
@@ -321,19 +316,19 @@ AddDerivationToCAP( MorphismFromTensorProductToInternalHomWithGivenObjects,
   function( cat, tensor_object, object_1, object_2, internal_hom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose( [ 
-             TensorProductOnMorphisms(
-               IsomorphismFromDualToInternalHom( object_1 ),
-               IsomorphismFromObjectToInternalHom( object_2 ) ),
+    return PreComposeList( cat, [ 
+             TensorProductOnMorphisms( cat,
+               IsomorphismFromDualToInternalHom( cat, object_1 ),
+               IsomorphismFromObjectToInternalHom( cat, object_2 ) ),
                 
-             TensorProductInternalHomCompatibilityMorphism(
+             TensorProductInternalHomCompatibilityMorphism( cat,
                [ object_1, unit, unit, object_2 ] ),
                 
-             InternalHomOnMorphisms(
-               RightUnitor( object_1 ),
-               LeftUnitor( object_2 ) ),
+             InternalHomOnMorphisms( cat,
+               RightUnitor( cat, object_1 ),
+               LeftUnitor( cat, object_2 ) ),
            ] );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
@@ -351,10 +346,10 @@ AddDerivationToCAP( EvaluationMorphismWithGivenSource,
                   
   function( cat, object_1, object_2, tensor_object )
     
-    return InternalHomToTensorProductAdjunctionMap(
+    return InternalHomToTensorProductAdjunctionMap( cat,
              object_1,
              object_2,
-             IdentityMorphism( InternalHomOnObjects( object_1, object_2 ) ) );
+             IdentityMorphism( cat, InternalHomOnObjects( cat, object_1, object_2 ) ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "EvaluationMorphismWithGivenSource using the tensor hom adjunction on the identity" );
@@ -364,10 +359,10 @@ AddDerivationToCAP( CoevaluationMorphismWithGivenRange,
                   
   function( cat, object_1, object_2, internal_hom )
     
-    return TensorProductToInternalHomAdjunctionMap(
+    return TensorProductToInternalHomAdjunctionMap( cat,
              object_1,
              object_2,
-             IdentityMorphism( TensorProductOnObjects( object_1, object_2 ) ) );
+             IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, object_2 ) ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "CoevaluationMorphismWithGivenRange using the tensor hom adjunction on the identity" );
@@ -378,30 +373,30 @@ AddDerivationToCAP( MonoidalPreComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local hom_x_y, hom_y_z, morphism;
     
-    hom_x_y := InternalHomOnObjects( x, y );
+    hom_x_y := InternalHomOnObjects( cat, x, y );
     
-    hom_y_z := InternalHomOnObjects( y, z );
+    hom_y_z := InternalHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  AssociatorLeftToRight( hom_x_y, hom_y_z, x ),
+    morphism := PreComposeList( cat, [ 
+                  AssociatorLeftToRight( cat, hom_x_y, hom_y_z, x ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( hom_x_y ),
-                    Braiding( hom_y_z, x ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, hom_x_y ),
+                    Braiding( cat, hom_y_z, x ) ),
                   
-                  AssociatorRightToLeft( hom_x_y, x, hom_y_z ),
+                  AssociatorRightToLeft( cat, hom_x_y, x, hom_y_z ),
                   
-                  TensorProductOnMorphisms(
-                    EvaluationMorphism( x, y ),
-                    IdentityMorphism( hom_y_z ) ),
+                  TensorProductOnMorphisms( cat,
+                    EvaluationMorphism( cat, x, y ),
+                    IdentityMorphism( cat, hom_y_z ) ),
                   
-                  Braiding( y, hom_y_z ),
+                  Braiding( cat, y, hom_y_z ),
                   
-                  EvaluationMorphism( y, z ) 
+                  EvaluationMorphism( cat, y, z ) 
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
-             TensorProductOnObjects( hom_x_y, hom_y_z ),
+    return TensorProductToInternalHomAdjunctionMap( cat,
+             TensorProductOnObjects( cat, hom_x_y, hom_y_z ),
              x,
              morphism );
     
@@ -414,22 +409,22 @@ AddDerivationToCAP( MonoidalPostComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local hom_x_y, hom_y_z, morphism;
     
-    hom_x_y := InternalHomOnObjects( x, y );
+    hom_x_y := InternalHomOnObjects( cat, x, y );
     
-    hom_y_z := InternalHomOnObjects( y, z );
+    hom_y_z := InternalHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  AssociatorLeftToRight( hom_y_z, hom_x_y, x ),
+    morphism := PreComposeList( cat, [ 
+                  AssociatorLeftToRight( cat, hom_y_z, hom_x_y, x ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( hom_y_z ),
-                    EvaluationMorphism( x, y ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, hom_y_z ),
+                    EvaluationMorphism( cat, x, y ) ),
                   
-                  EvaluationMorphism( y, z )
+                  EvaluationMorphism( cat, y, z )
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
-             TensorProductOnObjects( hom_y_z, hom_x_y ),
+    return TensorProductToInternalHomAdjunctionMap( cat,
+             TensorProductOnObjects( cat, hom_y_z, hom_x_y ),
              x,
              morphism );
     
@@ -442,9 +437,9 @@ AddDerivationToCAP( MonoidalPostComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local braiding;
     
-    braiding := Braiding( InternalHomOnObjects( y, z ), InternalHomOnObjects( x, y ) );
+    braiding := Braiding( cat, InternalHomOnObjects( cat, y, z ), InternalHomOnObjects( cat, x, y ) );
     
-    return PreCompose( braiding, MonoidalPreComposeMorphism( x, y, z ) );
+    return PreCompose( cat, braiding, MonoidalPreComposeMorphism( cat, x, y, z ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "MonoidalPostComposeMorphismWithGivenObjects using MonoidalPreComposeMorphism and braiding" );
@@ -455,9 +450,9 @@ AddDerivationToCAP( MonoidalPreComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local braiding;
     
-    braiding := Braiding( InternalHomOnObjects( x, y ), InternalHomOnObjects( y, z ) );
+    braiding := Braiding( cat, InternalHomOnObjects( cat, x, y ), InternalHomOnObjects( cat, y, z ) );
     
-    return PreCompose( braiding, MonoidalPostComposeMorphism( x, y, z ) );
+    return PreCompose( cat, braiding, MonoidalPostComposeMorphism( cat, x, y, z ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "MonoidalPreComposeMorphismWithGivenObjects using MonoidalPostComposeMorphism and braiding" );
@@ -473,36 +468,36 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObject
     a2 := list[3];
     b2 := list[4];
     
-    int_hom_a1_b1 := InternalHomOnObjects( a1, b1 );
+    int_hom_a1_b1 := InternalHomOnObjects( cat, a1, b1 );
     
-    int_hom_a2_b2 := InternalHomOnObjects( a2, b2 );
+    int_hom_a2_b2 := InternalHomOnObjects( cat, a2, b2 );
     
-    id_a2 := IdentityMorphism( a2 );
+    id_a2 := IdentityMorphism( cat, a2 );
     
     tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2 := 
-      TensorProductOnObjects( int_hom_a1_b1, int_hom_a2_b2 );
+      TensorProductOnObjects( cat, int_hom_a1_b1, int_hom_a2_b2 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      IdentityMorphism( int_hom_a1_b1 ),
-                      Braiding( int_hom_a2_b2, a1 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      IdentityMorphism( cat, int_hom_a1_b1 ),
+                      Braiding( cat, int_hom_a2_b2, a1 ) ),
                     id_a2 ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      EvaluationMorphism( a1, b1 ),
-                      IdentityMorphism( int_hom_a2_b2 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      EvaluationMorphism( cat, a1, b1 ),
+                      IdentityMorphism( cat, int_hom_a2_b2 ) ),
                     id_a2 ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( b1 ),
-                    EvaluationMorphism( a2, b2 ) )
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, b1 ),
+                    EvaluationMorphism( cat, a2, b2 ) )
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
+    return TensorProductToInternalHomAdjunctionMap( cat,
              tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2,
-             TensorProductOnObjects( a1, a2 ),
+             TensorProductOnObjects( cat, a1, a2 ),
              morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory and IsStrictMonoidalCategory,
@@ -514,18 +509,18 @@ AddDerivationToCAP( TensorProductDualityCompatibilityMorphismWithGivenObjects,
   function( cat, new_source, object_1, object_2, new_range )
     local morphism, unit, tensor_product_on_object_1_and_object_2;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( object_1, object_2 );
+    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    IsomorphismFromDualToInternalHom( object_1 ),
-                    IsomorphismFromDualToInternalHom( object_2 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromDualToInternalHom( cat, object_1 ),
+                    IsomorphismFromDualToInternalHom( cat, object_2 ) ),
                   
-                  TensorProductInternalHomCompatibilityMorphism( [ object_1, unit, object_2, unit ] ),
+                  TensorProductInternalHomCompatibilityMorphism( cat, [ object_1, unit, object_2, unit ] ),
                   
-                  IsomorphismFromInternalHomToDual( tensor_product_on_object_1_and_object_2 ) 
+                  IsomorphismFromInternalHomToDual( cat, tensor_product_on_object_1_and_object_2 ) 
                 ] );
     
     return morphism;
@@ -539,26 +534,26 @@ AddDerivationToCAP( MonoidalPreComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local hom_x_y, hom_y_z, morphism;
     
-    hom_x_y := InternalHomOnObjects( x, y );
+    hom_x_y := InternalHomOnObjects( cat, x, y );
     
-    hom_y_z := InternalHomOnObjects( y, z );
+    hom_y_z := InternalHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( hom_x_y ),
-                    Braiding( hom_y_z, x ) ),
+    morphism := PreComposeList( cat, [ 
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, hom_x_y ),
+                    Braiding( cat, hom_y_z, x ) ),
                   
-                  TensorProductOnMorphisms(
-                    EvaluationMorphism( x, y ),
-                    IdentityMorphism( hom_y_z ) ),
+                  TensorProductOnMorphisms( cat,
+                    EvaluationMorphism( cat, x, y ),
+                    IdentityMorphism( cat, hom_y_z ) ),
                   
-                  Braiding( y, hom_y_z ),
+                  Braiding( cat, y, hom_y_z ),
                   
-                  EvaluationMorphism( y, z )
+                  EvaluationMorphism( cat, y, z )
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
-             TensorProductOnObjects( hom_x_y, hom_y_z ),
+    return TensorProductToInternalHomAdjunctionMap( cat,
+             TensorProductOnObjects( cat, hom_x_y, hom_y_z ),
              x,
              morphism );
     
@@ -571,20 +566,20 @@ AddDerivationToCAP( MonoidalPostComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local hom_x_y, hom_y_z, morphism;
     
-    hom_x_y := InternalHomOnObjects( x, y );
+    hom_x_y := InternalHomOnObjects( cat, x, y );
     
-    hom_y_z := InternalHomOnObjects( y, z );
+    hom_y_z := InternalHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( hom_y_z ),
-                    EvaluationMorphism( x, y ) ),
+    morphism := PreComposeList( cat, [ 
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, hom_y_z ),
+                    EvaluationMorphism( cat, x, y ) ),
                   
-                  EvaluationMorphism( y, z )
+                  EvaluationMorphism( cat, y, z )
                 ] );
     
-    return TensorProductToInternalHomAdjunctionMap(
-             TensorProductOnObjects( hom_y_z, hom_x_y ),
+    return TensorProductToInternalHomAdjunctionMap( cat,
+             TensorProductOnObjects( cat, hom_y_z, hom_x_y ),
              x,
              morphism );
     

--- a/MonoidalCategories/gap/SymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/SymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -3,9 +3,9 @@ AddDerivationToCAP( TensorProductToInternalCoHomAdjunctionMap,
 
   function( cat, object_1, object_2, morphism )
     
-    return PreCompose( 
-             InternalCoHomOnMorphisms( morphism, IdentityMorphism( object_1 ) ),
-             CoclosedCoevaluationMorphism( object_1, object_2 ) );
+    return PreCompose( cat,
+             InternalCoHomOnMorphisms( cat, morphism, IdentityMorphism( cat, object_1 ) ),
+             CoclosedCoevaluationMorphism( cat, object_1, object_2 ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "TensorProductToInternalCoHomAdjunctionMap using CoclosedCoevaluationMorphism and InternalCoHom" );
@@ -15,9 +15,9 @@ AddDerivationToCAP( InternalCoHomToTensorProductAdjunctionMap,
 
   function( cat, object_1, object_2, morphism )
     
-    return PreCompose(
-             CoclosedEvaluationMorphism( object_1, object_2 ),
-             TensorProductOnMorphisms( IdentityMorphism( object_2 ), morphism ) );
+    return PreCompose( cat,
+             CoclosedEvaluationMorphism( cat, object_1, object_2 ),
+             TensorProductOnMorphisms( cat, IdentityMorphism( cat, object_2 ), morphism ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "InternalCoHomToTensorProductAdjunctionMap using TensorProductOnMorphisms and CoclosedEvaluationMorphism" );
@@ -27,9 +27,9 @@ AddDerivationToCAP( UniversalPropertyOfCoDual,
 
   function( cat, object_1, object_2, test_morphism )
     
-    return PreCompose( 
-             IsomorphismFromCoDualToInternalCoHom( object_2 ),
-             TensorProductToInternalCoHomAdjunctionMap( object_1, object_2, test_morphism ) );
+    return PreCompose( cat,
+             IsomorphismFromCoDualToInternalCoHom( cat, object_2 ),
+             TensorProductToInternalCoHomAdjunctionMap( cat, object_1, object_2, test_morphism ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "UniversalPropertyOfCoDual using the cohom tensor adjunction" );
@@ -40,11 +40,11 @@ AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
   function( cat, cobidual, object )
     local morphism;
 
-    morphism := PreCompose( 
-                  CoclosedEvaluationForCoDual( object ),
-                  Braiding( object, CoDualOnObjects( object ) ) );
+    morphism := PreCompose( cat,
+                  CoclosedEvaluationForCoDual( cat, object ),
+                  Braiding( cat, object, CoDualOnObjects( cat, object ) ) );
                   
-    return UniversalPropertyOfCoDual( CoDualOnObjects( object ), object, morphism );
+    return UniversalPropertyOfCoDual( cat, CoDualOnObjects( cat, object ), object, morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "MorphismFromCoBidualWithGivenCoBidual using the braiding and the universal property of the codual" );
@@ -55,20 +55,20 @@ AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
   function( cat, cobidual, object )
     local morphism, codual_object, tensor_unit;
     
-    codual_object := CoDualOnObjects( object );
+    codual_object := CoDualOnObjects( cat, object );
     
-    tensor_unit := TensorUnit( CapCategory( object ) );
+    tensor_unit := TensorUnit( cat );
     
-    morphism := PreCompose( [
-                  InternalCoHomOnMorphisms(
-                    CoclosedEvaluationMorphism( tensor_unit, object ),
-                    IdentityMorphism( codual_object ) ),
+    morphism := PreComposeList( cat, [
+                  InternalCoHomOnMorphisms( cat,
+                    CoclosedEvaluationMorphism( cat, tensor_unit, object ),
+                    IdentityMorphism( cat, codual_object ) ),
                   
-                  InternalCoHomOnMorphisms(
-                    Braiding( object, codual_object ),
-                    IdentityMorphism( codual_object ) ),
+                  InternalCoHomOnMorphisms( cat,
+                    Braiding( cat, object, codual_object ),
+                    IdentityMorphism( cat, codual_object ) ),
                   
-                  CoclosedCoevaluationMorphism( codual_object, object )
+                  CoclosedCoevaluationMorphism( cat, codual_object, object )
                 ] );
     
     return morphism;
@@ -81,7 +81,7 @@ AddDerivationToCAP( CoDualOnObjects,
 
   function( cat, object )
     
-    return Source( IsomorphismFromCoDualToInternalCoHom( object ) );
+    return Source( IsomorphismFromCoDualToInternalCoHom( cat, object ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoDualOnObjects as the source of IsomorphismFromCoDualToInternalCoHom" );
@@ -91,7 +91,7 @@ AddDerivationToCAP( CoDualOnObjects,
 
   function( cat, object )
     
-    return Range( IsomorphismFromInternalCoHomToCoDual( object ) );
+    return Range( IsomorphismFromInternalCoHomToCoDual( cat, object ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoDualOnObjects as the range of IsomorphismFromInternalCoHomToCoDual" );
@@ -100,18 +100,16 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 AddDerivationToCAP( CoDualOnMorphismsWithGivenCoDuals,
 
   function( cat, new_source, morphism, new_range )
-    local category, result_morphism;
+    local result_morphism;
     
-    category := CapCategory( morphism );
-    
-    result_morphism := PreCompose( [
-                         IsomorphismFromCoDualToInternalCoHom( Range( morphism ) ),
+    result_morphism := PreComposeList( cat, [
+                         IsomorphismFromCoDualToInternalCoHom( cat, Range( morphism ) ),
                          
-                         InternalCoHomOnMorphisms( 
-                           IdentityMorphism( TensorUnit( category ) ),
+                         InternalCoHomOnMorphisms( cat, 
+                           IdentityMorphism( cat, TensorUnit( cat ) ),
                            morphism ),
                            
-                         IsomorphismFromInternalCoHomToCoDual( Source( morphism ) ) 
+                         IsomorphismFromInternalCoHomToCoDual( cat, Source( morphism ) ) 
                        ] );
                        
     return result_morphism;
@@ -124,10 +122,10 @@ AddDerivationToCAP( CoclosedEvaluationForCoDualWithGivenTensorProduct,
 
   function( cat, unit, object, tensor_object )
 
-    return InternalCoHomToTensorProductAdjunctionMap( 
+    return InternalCoHomToTensorProductAdjunctionMap( cat, 
             unit, 
             object,
-            IsomorphismFromInternalCoHomToCoDual( object ) );
+            IsomorphismFromInternalCoHomToCoDual( cat, object ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoclosedEvaluationForCoDualWithGivenTensorProduct using the cohom tensor adjunction and IsomorphismFromInternalCoHomToCoDual" );
@@ -136,17 +134,15 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 AddDerivationToCAP( CoLambdaIntroduction,
 
   function( cat, morphism )
-    local result_morphism, category, range;
-
-    category := CapCategory( morphism );
+    local result_morphism, range;
 
     range := Range( morphism );
 
-    result_morphism := PreCompose( morphism, RightUnitorInverse( range ) );
+    result_morphism := PreCompose( cat, morphism, RightUnitorInverse( cat, range ) );
 
-    return TensorProductToInternalCoHomAdjunctionMap( 
+    return TensorProductToInternalCoHomAdjunctionMap( cat, 
              range, 
-             TensorUnit( category ), 
+             TensorUnit( cat ), 
              result_morphism );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -158,9 +154,9 @@ AddDerivationToCAP( CoLambdaElimination,
   function( cat, object_1, object_2, morphism )
     local result_morphism;
     
-    result_morphism := InternalCoHomToTensorProductAdjunctionMap( object_1, object_2, morphism );
+    result_morphism := InternalCoHomToTensorProductAdjunctionMap( cat, object_1, object_2, morphism );
     
-    return PreCompose( result_morphism, RightUnitor( object_2 ) );
+    return PreCompose( cat, result_morphism, RightUnitor( cat, object_2 ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoLambdaElimination using the cohom tensor adjunction and right unitor" );
@@ -176,52 +172,52 @@ AddDerivationToCAP( InternalCoHomTensorProductCompatibilityMorphismWithGivenObje
     b1 := list[3];
     b2 := list[4];
     
-    tensor_product_b1_b2 := TensorProductOnObjects( b1, b2 );
+    tensor_product_b1_b2 := TensorProductOnObjects( cat, b1, b2 );
     
-    int_cohom_a1_b1 := InternalCoHomOnObjects( a1, b1 );
+    int_cohom_a1_b1 := InternalCoHomOnObjects( cat, a1, b1 );
     
-    int_cohom_a2_b2 := InternalCoHomOnObjects( a2, b2 );
+    int_cohom_a2_b2 := InternalCoHomOnObjects( cat, a2, b2 );
     
-    id_int_cohom_a1_b1 := IdentityMorphism( int_cohom_a1_b1 );
+    id_int_cohom_a1_b1 := IdentityMorphism( cat, int_cohom_a1_b1 );
     
-    id_int_cohom_a2_b2 := IdentityMorphism( int_cohom_a2_b2 );
+    id_int_cohom_a2_b2 := IdentityMorphism( cat, int_cohom_a2_b2 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms( 
-                    IdentityMorphism( a1 ),
-                    CoclosedEvaluationMorphism( a2, b2 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat, 
+                    IdentityMorphism( cat, a1 ),
+                    CoclosedEvaluationMorphism( cat, a2, b2 ) ),
                   
-                  AssociatorRightToLeft( a1, b2,  int_cohom_a2_b2),
+                  AssociatorRightToLeft( cat, a1, b2,  int_cohom_a2_b2),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      CoclosedEvaluationMorphism( a1, b1 ),
-                      IdentityMorphism( b2 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      CoclosedEvaluationMorphism( cat, a1, b1 ),
+                      IdentityMorphism( cat, b2 ) ),
                      id_int_cohom_a2_b2),
                   
-                  TensorProductOnMorphisms(
-                    AssociatorLeftToRight( b1, int_cohom_a1_b1, b2 ),
+                  TensorProductOnMorphisms( cat,
+                    AssociatorLeftToRight( cat, b1, int_cohom_a1_b1, b2 ),
                     id_int_cohom_a2_b2 ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      IdentityMorphism( b1 ),
-                      Braiding( b2, int_cohom_a1_b1 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      IdentityMorphism( cat, b1 ),
+                      Braiding( cat, b2, int_cohom_a1_b1 ) ),
                     id_int_cohom_a2_b2 ),
                   
-                  TensorProductOnMorphisms(
-                    AssociatorRightToLeft( b1, b2, int_cohom_a1_b1 ),
+                  TensorProductOnMorphisms( cat,
+                    AssociatorRightToLeft( cat, b1, b2, int_cohom_a1_b1 ),
                     id_int_cohom_a2_b2 ),
                   
-                  AssociatorLeftToRight(
+                  AssociatorLeftToRight( cat,
                     tensor_product_b1_b2,
                     int_cohom_a1_b1,
                     int_cohom_a2_b2 )
                 ] );
 
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              tensor_product_b1_b2,
-             TensorProductOnObjects( int_cohom_a1_b1, int_cohom_a2_b2 ),
+             TensorProductOnObjects( cat, int_cohom_a1_b1, int_cohom_a2_b2 ),
              morphism );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -233,22 +229,22 @@ AddDerivationToCAP( CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
   function( cat, new_source, object_1, object_2, new_range )
     local morphism, unit, tensor_product_on_object_1_and_object_2;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( object_1, object_2 );
+    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
     
-    morphism := PreCompose( [
-                  IsomorphismFromCoDualToInternalCoHom( tensor_product_on_object_1_and_object_2 ),
+    morphism := PreComposeList( cat, [
+                  IsomorphismFromCoDualToInternalCoHom( cat, tensor_product_on_object_1_and_object_2 ),
                   
-                  InternalCoHomOnMorphisms(
-                    LeftUnitorInverse( unit ),
-                    IdentityMorphism( tensor_product_on_object_1_and_object_2 ) ),
+                  InternalCoHomOnMorphisms( cat,
+                    LeftUnitorInverse( cat, unit ),
+                    IdentityMorphism( cat, tensor_product_on_object_1_and_object_2 ) ),
                   
-                  InternalCoHomTensorProductCompatibilityMorphism( [ unit, unit, object_1, object_2 ] ),
+                  InternalCoHomTensorProductCompatibilityMorphism( cat, [ unit, unit, object_1, object_2 ] ),
                   
-                  TensorProductOnMorphisms(
-                    IsomorphismFromInternalCoHomToCoDual( object_1 ),
-                    IsomorphismFromInternalCoHomToCoDual( object_2 ) )
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromInternalCoHomToCoDual( cat, object_1 ),
+                    IsomorphismFromInternalCoHomToCoDual( cat, object_2 ) )
                 ] );
 
     return morphism;
@@ -262,14 +258,14 @@ AddDerivationToCAP( IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom,
   function( cat, object, internal_cohom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose(
-             InternalCoHomOnMorphisms(
-               LeftUnitorInverse( object ),
-               IdentityMorphism( unit ) ),
+    return PreCompose( cat,
+             InternalCoHomOnMorphisms( cat,
+               LeftUnitorInverse( cat, object ),
+               IdentityMorphism( cat, unit ) ),
                
-             CoclosedCoevaluationMorphism( unit, object ));
+             CoclosedCoevaluationMorphism( cat, unit, object ));
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom using the coclosed coevaluation morphism" );
@@ -280,12 +276,12 @@ AddDerivationToCAP( IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom,
   function( cat, object, internal_cohom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              unit,
              object,
-             LeftUnitorInverse( object ) );
+             LeftUnitorInverse( cat, object ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom as the adjoint of the left inverse unitor" );
@@ -296,7 +292,7 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 #                     
 #   function( cat, object, internal_hom )
 #     
-#     return Inverse( IsomorphismFromObjectToInternalHom( object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalHom( cat, object ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom as the inverse of IsomorphismFromObjectToInternalHom" );
@@ -307,10 +303,10 @@ AddDerivationToCAP( IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom,
   function( cat, object, internal_cohom )
     local unit;
     
-    unit := TensorUnit( CapCategory( object ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose( CoclosedEvaluationMorphism( object, unit ),
-                       LeftUnitor( internal_cohom ) );
+    return PreCompose( cat, CoclosedEvaluationMorphism( cat, object, unit ),
+                       LeftUnitor( cat, internal_cohom ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom using the coclosed evaluation morphism" );
@@ -321,7 +317,7 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 #                     
 #   function( cat, object, internal_hom )
 #     
-#     return Inverse( IsomorphismFromInternalHomToObject( object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromInternalHomToObject( cat, object ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #       Description := "IsomorphismFromObjectToInternalHom as the inverse of IsomorphismFromInternalHomToObject" );
@@ -332,19 +328,19 @@ AddDerivationToCAP( MorphismFromInternalCoHomToTensorProductWithGivenObjects,
   function( cat, internal_cohom, object_1, object_2, tensor_object )
     local unit;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    return PreCompose( [ 
-             InternalCoHomOnMorphisms( 
-               RightUnitorInverse( object_1 ),
-               LeftUnitorInverse( object_2 ) ),
+    return PreComposeList( cat, [ 
+             InternalCoHomOnMorphisms( cat, 
+               RightUnitorInverse( cat, object_1 ),
+               LeftUnitorInverse( cat, object_2 ) ),
               
-             InternalCoHomTensorProductCompatibilityMorphism(
+             InternalCoHomTensorProductCompatibilityMorphism( cat,
                [ object_1, unit, unit, object_2 ] ),
               
-             TensorProductOnMorphisms(
-               IsomorphismFromInternalCoHomToObject( object_1 ),
-               IsomorphismFromInternalCoHomToCoDual( object_2 ) )
+             TensorProductOnMorphisms( cat,
+               IsomorphismFromInternalCoHomToObject( cat, object_1 ),
+               IsomorphismFromInternalCoHomToCoDual( cat, object_2 ) )
            ] );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -355,10 +351,10 @@ AddDerivationToCAP( CoclosedEvaluationMorphismWithGivenRange,
                   
   function( cat, object_1, object_2, tensor_object )
     
-    return InternalCoHomToTensorProductAdjunctionMap(
+    return InternalCoHomToTensorProductAdjunctionMap( cat,
              object_1,
              object_2,
-             IdentityMorphism( InternalCoHomOnObjects( object_1, object_2 ) )
+             IdentityMorphism( cat, InternalCoHomOnObjects( cat, object_1, object_2 ) )
            );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -368,10 +364,10 @@ AddDerivationToCAP( CoclosedCoevaluationMorphismWithGivenSource,
                   
   function( cat, object_1, object_2, internal_cohom )
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              object_1,
              object_2,
-             IdentityMorphism( TensorProductOnObjects( object_1, object_2 ) )
+             IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, object_2 ) )
            );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -383,31 +379,31 @@ AddDerivationToCAP( MonoidalPreCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local cohom_x_y, cohom_y_z, morphism;
     
-    cohom_x_y := InternalCoHomOnObjects( x, y );
+    cohom_x_y := InternalCoHomOnObjects( cat, x, y );
     
-    cohom_y_z := InternalCoHomOnObjects( y, z );
+    cohom_y_z := InternalCoHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [
-                  CoclosedEvaluationMorphism( x, y ),
+    morphism := PreComposeList( cat, [
+                  CoclosedEvaluationMorphism( cat, x, y ),
                   
-                  Braiding( y, cohom_x_y ),
+                  Braiding( cat, y, cohom_x_y ),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( cohom_x_y ),
-                    CoclosedEvaluationMorphism( y, z ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, cohom_x_y ),
+                    CoclosedEvaluationMorphism( cat, y, z ) ),
                   
-                  AssociatorRightToLeft( cohom_x_y, z, cohom_y_z ),
+                  AssociatorRightToLeft( cat, cohom_x_y, z, cohom_y_z ),
                   
-                  TensorProductOnMorphisms(
-                    Braiding( cohom_x_y, z ),
-                    IdentityMorphism( cohom_y_z ) ),
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, cohom_x_y, z ),
+                    IdentityMorphism( cat, cohom_y_z ) ),
                   
-                  AssociatorLeftToRight( z, cohom_x_y, x, cohom_y_z ),
+                  AssociatorLeftToRight( cat, z, cohom_x_y, x, cohom_y_z ),
                 ] );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              z,
-             TensorProductOnObjects( cohom_x_y, cohom_y_z ),
+             TensorProductOnObjects( cat, cohom_x_y, cohom_y_z ),
              morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -419,24 +415,24 @@ AddDerivationToCAP( MonoidalPostCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local cohom_x_y, cohom_y_z, morphism;
     
-    cohom_x_y := InternalCoHomOnObjects( x, y );
+    cohom_x_y := InternalCoHomOnObjects( cat, x, y );
     
-    cohom_y_z := InternalCoHomOnObjects( y, z );
+    cohom_y_z := InternalCoHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  CoclosedEvaluationMorphism( x, y ),
+    morphism := PreComposeList( cat, [ 
+                  CoclosedEvaluationMorphism( cat, x, y ),
                   
-                  TensorProductOnMorphisms(
-                    CoclosedEvaluationMorphism( y, z ),
-                    IdentityMorphism( cohom_x_y )
+                  TensorProductOnMorphisms( cat,
+                    CoclosedEvaluationMorphism( cat, y, z ),
+                    IdentityMorphism( cat, cohom_x_y )
                   ),
                   
-                  AssociatorLeftToRight( z, cohom_y_z, cohom_x_y )
+                  AssociatorLeftToRight( cat, z, cohom_y_z, cohom_x_y )
                 ] );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              z,
-             TensorProductOnObjects( cohom_y_z, cohom_x_y ),
+             TensorProductOnObjects( cat, cohom_y_z, cohom_x_y ),
              morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -448,9 +444,9 @@ AddDerivationToCAP( MonoidalPostCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local braiding;
     
-    braiding := Braiding( InternalCoHomOnObjects( x, y ), InternalCoHomOnObjects( y, z ) );
+    braiding := Braiding( cat, InternalCoHomOnObjects( cat, x, y ), InternalCoHomOnObjects( cat, y, z ) );
     
-    return PreCompose( MonoidalPreCoComposeMorphism( x, y, z ), braiding );
+    return PreCompose( cat, MonoidalPreCoComposeMorphism( cat, x, y, z ), braiding );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "MonoidalPostCoComposeMorphismWithGivenObjects using MonoidalPreCoComposeMorphism and braiding" );
@@ -461,9 +457,9 @@ AddDerivationToCAP( MonoidalPreCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local braiding;
     
-    braiding := Braiding( InternalCoHomOnObjects( y, z ), InternalCoHomOnObjects( x, y ) );
+    braiding := Braiding( cat, InternalCoHomOnObjects( cat, y, z ), InternalCoHomOnObjects( cat, x, y ) );
     
-    return PreCompose( MonoidalPostCoComposeMorphism( x, y, z ), braiding );
+    return PreCompose( cat, MonoidalPostCoComposeMorphism( cat, x, y, z ), braiding );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "MonoidalPreCoComposeMorphismWithGivenObjects using MonoidalPostCoComposeMorphism and braiding" );
@@ -479,35 +475,35 @@ AddDerivationToCAP( InternalCoHomTensorProductCompatibilityMorphismWithGivenObje
     b1 := list[3];
     b2 := list[4];
     
-    int_cohom_a1_b1 := InternalCoHomOnObjects( a1, b1 );
+    int_cohom_a1_b1 := InternalCoHomOnObjects( cat, a1, b1 );
     
-    int_cohom_a2_b2 := InternalCoHomOnObjects( a2, b2 );
+    int_cohom_a2_b2 := InternalCoHomOnObjects( cat, a2, b2 );
     
-    id_int_cohom_a2_b2 := IdentityMorphism( int_cohom_a2_b2 );
+    id_int_cohom_a2_b2 := IdentityMorphism( cat, int_cohom_a2_b2 );
     
-    tensor_product_b1_b2 := TensorProductOnObjects( b1, b2 );
+    tensor_product_b1_b2 := TensorProductOnObjects( cat, b1, b2 );
     
-    morphism := PreCompose( [
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( a1 ),
-                    CoclosedEvaluationMorphism( a2, b2 ) ),
+    morphism := PreComposeList( cat, [
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, a1 ),
+                    CoclosedEvaluationMorphism( cat, a2, b2 ) ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      CoclosedEvaluationMorphism( a1, b1 ),
-                      IdentityMorphism( b2 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      CoclosedEvaluationMorphism( cat, a1, b1 ),
+                      IdentityMorphism( cat, b2 ) ),
                     id_int_cohom_a2_b2 ),
                   
-                  TensorProductOnMorphisms(
-                    TensorProductOnMorphisms(
-                      IdentityMorphism( b1 ),
-                      Braiding( int_cohom_a1_b1, b2 ) ),
+                  TensorProductOnMorphisms( cat,
+                    TensorProductOnMorphisms( cat,
+                      IdentityMorphism( cat, b1 ),
+                      Braiding( cat, int_cohom_a1_b1, b2 ) ),
                     id_int_cohom_a2_b2 )
                 ] );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              tensor_product_b1_b2,
-             TensorProductOnObjects( int_cohom_a1_b1, int_cohom_a2_b2 ),
+             TensorProductOnObjects( cat, int_cohom_a1_b1, int_cohom_a2_b2 ),
              morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory and IsStrictMonoidalCategory,
@@ -519,18 +515,18 @@ AddDerivationToCAP( CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
   function( cat, new_source, object_1, object_2, new_range )
     local morphism, unit, tensor_product_on_object_1_and_object_2;
     
-    unit := TensorUnit( CapCategory( object_1 ) );
+    unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( object_1, object_2 );
+    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
     
-    morphism := PreCompose( [
-                  IsomorphismFromCoDualToInternalCoHom( tensor_product_on_object_1_and_object_2 ),
+    morphism := PreComposeList( cat, [
+                  IsomorphismFromCoDualToInternalCoHom( cat, tensor_product_on_object_1_and_object_2 ),
                   
-                  InternalCoHomTensorProductCompatibilityMorphism( [ unit, unit, object_1, object_2 ] ),
+                  InternalCoHomTensorProductCompatibilityMorphism( cat, [ unit, unit, object_1, object_2 ] ),
                   
-                  TensorProductOnMorphisms(
-                    IsomorphismFromInternalCoHomToCoDual( object_1 ),
-                    IsomorphismFromInternalCoHomToCoDual( object_2 ) )
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromInternalCoHomToCoDual( cat, object_1 ),
+                    IsomorphismFromInternalCoHomToCoDual( cat, object_2 ) )
                 ] );
               
     return morphism;
@@ -544,27 +540,27 @@ AddDerivationToCAP( MonoidalPreCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local cohom_x_y, cohom_y_z, morphism;
     
-    cohom_x_y := InternalCoHomOnObjects( x, y );
+    cohom_x_y := InternalCoHomOnObjects( cat, x, y );
     
-    cohom_y_z := InternalCoHomOnObjects( y, z );
+    cohom_y_z := InternalCoHomOnObjects( cat, y, z );
     
-    morphism := PreCompose( [ 
-                  CoclosedEvaluationMorphism( x, y ),
+    morphism := PreComposeList( [ 
+                  CoclosedEvaluationMorphism( cat, x, y ),
                   
-                  Braiding( y, cohom_x_y),
+                  Braiding( cat, y, cohom_x_y),
                   
-                  TensorProductOnMorphisms(
-                    IdentityMorphism( cohom_x_y ),
-                    CoclosedEvaluationMorphism( y, z ) ),
+                  TensorProductOnMorphisms( cat,
+                    IdentityMorphism( cat, cohom_x_y ),
+                    CoclosedEvaluationMorphism( cat, y, z ) ),
                   
-                  TensorProductOnMorphisms(
-                    Braiding( cohom_x_y, z ),
-                    IdentityMorphism( cohom_y_z ) )
+                  TensorProductOnMorphisms( cat,
+                    Braiding( cat, cohom_x_y, z ),
+                    IdentityMorphism( cat, cohom_y_z ) )
                 ] );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              z,
-             TensorProductOnObjects( cohom_x_y, cohom_y_z ),
+             TensorProductOnObjects( cat, cohom_x_y, cohom_y_z ),
              morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory and IsStrictMonoidalCategory,
@@ -576,21 +572,21 @@ AddDerivationToCAP( MonoidalPostCoComposeMorphismWithGivenObjects,
   function( cat, new_source, x, y, z, new_range )
     local cohom_x_y, cohom_y_z, morphism;
     
-    cohom_x_y := InternalCoHomOnObjects( x, y );
+    cohom_x_y := InternalCoHomOnObjects( cat, x, y );
     
-    cohom_y_z := InternalCoHomOnObjects( y, z );
+    cohom_y_z := InternalCoHomOnObjects( cat, y, z );
     
-    morphism := PreCompose(   [ 
-                  CoclosedEvaluationMorphism( x, y ),
+    morphism := PreComposeList( cat, [ 
+                  CoclosedEvaluationMorphism( cat, x, y ),
                   
-                  TensorProductOnMorphisms(
-                    CoclosedEvaluationMorphism( y, z ),
-                    IdentityMorphism( cohom_x_y ) )
+                  TensorProductOnMorphisms( cat,
+                    CoclosedEvaluationMorphism( cat, y, z ),
+                    IdentityMorphism( cat, cohom_x_y ) )
                 ] );
     
-    return TensorProductToInternalCoHomAdjunctionMap(
+    return TensorProductToInternalCoHomAdjunctionMap( cat,
              z,
-             TensorProductOnObjects( cohom_y_z, cohom_x_y ),
+             TensorProductOnObjects( cat, cohom_y_z, cohom_x_y ),
              morphism );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory and IsStrictMonoidalCategory,

--- a/MonoidalCategories/gap/SymmetricMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/SymmetricMonoidalCategoriesDerivedMethods.gi
@@ -3,7 +3,7 @@ AddDerivationToCAP( BraidingWithGivenTensorProducts,
                   
   function( cat, object_1_tensored_object_2, object_1, object_2, object_2_tensored_object_1 )
     
-    return BraidingInverseWithGivenTensorProducts(
+    return BraidingInverseWithGivenTensorProducts( cat,
                             object_1_tensored_object_2,
                             object_2, object_1,
                             object_2_tensored_object_1 );
@@ -16,7 +16,7 @@ AddDerivationToCAP( BraidingInverseWithGivenTensorProducts,
                   
   function( cat, object_2_tensored_object_1, object_1, object_2, object_1_tensored_object_2 )
     
-    return BraidingWithGivenTensorProducts(
+    return BraidingWithGivenTensorProducts( cat,
                      object_2_tensored_object_1,
                      object_2, object_1,
                      object_1_tensored_object_2 );


### PR DESCRIPTION
As a preparation, add `PreComposeList` and `PostComposeList` as dedicated versions of the convenience functions of `PreCompose` and `PostCompose` for lists, so that the compiler can distinguish the cases.

Since the changes in this PR are straight-foward, I will merge it without additional review if and when the CI succeeds.