### PR TITLE
Add experimental code to AdditiveClosure which allows to load precompiled code automatically

### DIFF
--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -265,7 +265,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     fi;
     
     # check that category_constructor supports `FinalizeCategory` and `enable_compilation`
-    cat := CallFuncList( category_constructor, given_arguments : FinalizeCategory := false, enable_compilation := true );
+    cat := CallFuncList( category_constructor, given_arguments : FinalizeCategory := false, enable_compilation := true, no_precompiled_code := true );
     
     if HasIsFinalized( cat ) then
         
@@ -351,7 +351,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         "        \n",
         "        \n",
         "    \n",
-        "    cat := category_constructor( ", parameters_string, " : FinalizeCategory := false );\n"
+        "    cat := category_constructor( ", parameters_string, " : FinalizeCategory := false, no_precompiled_code := true );\n"
     );
     output_string := Concatenation( output_string, current_string );
     

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsOfFieldPrecompiled.gi
@@ -15,7 +15,7 @@ end;
         
         
     
-    cat := category_constructor( field : FinalizeCategory := false );
+    cat := category_constructor( field : FinalizeCategory := false, no_precompiled_code := true );
     
     ##
     AddAdditionForMorphisms( cat,

--- a/FreydCategoriesForCAP/gap/precompiled_categories/OppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/OppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -15,7 +15,7 @@ end;
         
         
     
-    cat := category_constructor( field : FinalizeCategory := false );
+    cat := category_constructor( field : FinalizeCategory := false, no_precompiled_code := true );
     
     ##
     AddAdditionForMorphisms( cat,

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -15,7 +15,7 @@ end;
         
         
     
-    cat := category_constructor( field : FinalizeCategory := false );
+    cat := category_constructor( field : FinalizeCategory := false, no_precompiled_code := true );
     
     ##
     AddAdditionForMorphisms( cat,

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -16,7 +16,7 @@ end;
         
         
     
-    cat := category_constructor( field : FinalizeCategory := false );
+    cat := category_constructor( field : FinalizeCategory := false, no_precompiled_code := true );
     
     ##
     AddAdditionForMorphisms( cat,


### PR DESCRIPTION
In the current form this is a no-op, but it will be used for
AdditiveClosure( Algebroid ) soon.

I expect that we will have to refine this, but only after considering concrete examples, that's why I will merge this in this experimental state. It does not affect any existing code by default, so this should not cause any issues.