### PR TITLE
Make sure that dual_pre/postprocessor_funcs do not use `Opposite`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.09-01",
+Version := "2021.09-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2942,7 +2942,7 @@ HomomorphismStructureOnMorphisms := rec(
   return_type := "other_morphism",
   dual_operation := "HomomorphismStructureOnMorphisms",
   dual_preprocessor_func := function( cat, alpha, beta )
-    return [ Opposite( cat ), MorphismDatum( cat, beta ), MorphismDatum( cat, alpha ) ];
+    return [ OppositeCategory( cat ), MorphismDatum( cat, beta ), MorphismDatum( cat, alpha ) ];
   end,
   dual_postprocessor_func := IdFunc,
 ),
@@ -2955,7 +2955,7 @@ HomomorphismStructureOnMorphismsWithGivenObjects := rec(
   return_type := "other_morphism",
   dual_operation := "HomomorphismStructureOnMorphismsWithGivenObjects",
   dual_preprocessor_func := function( cat, source, alpha, beta, range )
-    return [ Opposite( cat ), source, MorphismDatum( cat, beta ), MorphismDatum( cat, alpha ), range ];
+    return [ OppositeCategory( cat ), source, MorphismDatum( cat, beta ), MorphismDatum( cat, alpha ), range ];
   end,
   dual_postprocessor_func := IdFunc,
 ),
@@ -2985,7 +2985,7 @@ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGiv
   return_type := "other_morphism",
   dual_operation := "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
   dual_preprocessor_func := function( cat, distinguished_object, alpha, hom_source_range )
-    return [ Opposite( cat ), distinguished_object, MorphismDatum( cat, alpha ), hom_source_range ];
+    return [ OppositeCategory( cat ), distinguished_object, MorphismDatum( cat, alpha ), hom_source_range ];
   end,
   dual_postprocessor_func := IdFunc
 ),
@@ -2995,7 +2995,7 @@ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism := rec
   return_type := "morphism",
   dual_operation := "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
   dual_preprocessor_func := function( cat, A, B, morphism )
-    return [ Opposite( cat ), ObjectDatum( cat, B ), ObjectDatum( cat, A ), morphism ];
+    return [ OppositeCategory( cat ), ObjectDatum( cat, B ), ObjectDatum( cat, A ), morphism ];
   end
 ),
 
@@ -4159,7 +4159,7 @@ end );
 
 InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
   function( record )
-    local recnames, current_recname, current_rec, io_type, number_of_arguments, flattened_filter_list, functorial,
+    local recnames, current_recname, current_rec, io_type, number_of_arguments, flattened_filter_list, functorial, func_string,
           installation_name, output_list, input_list, argument_names, return_list, current_output, input_position, list_position,
           without_given_name, with_given_names, with_given_name, without_given_rec, with_given_object_position, object_name,
           object_filter_list, with_given_object_filter, given_source_argument_name, given_range_argument_name, with_given_rec, i;
@@ -4321,6 +4321,36 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
         if not IsBound( current_rec.dual_arguments_reversed ) then
             
             current_rec.dual_arguments_reversed := false;
+            
+        fi;
+        
+        # check if current_rec.dual_preprocessor_func uses Opposite
+        if IsBound( current_rec.dual_preprocessor_func ) then
+            
+            func_string := PrintString( current_rec.dual_preprocessor_func );
+            
+            func_string := ReplacedString( func_string, "OppositeCategory", "" );
+            
+            if PositionSublist( func_string, "Opposite" ) <> fail then
+                
+                Error( "<current_rec.dual_preprocessor_func> seems to use the attribute `Opposite`. Please use `OppositeCategory` (for categories),  `ObjectDatum` (for objects), or `MorphismDatum` (for morphisms) instead." );
+                
+            fi;
+            
+        fi;
+        
+        # check if current_rec.dual_postprocessor_func uses Opposite
+        if IsBound( current_rec.dual_postprocessor_func ) then
+            
+            func_string := PrintString( current_rec.dual_postprocessor_func );
+            
+            func_string := ReplacedString( func_string, "OppositeCategory", "" );
+            
+            if PositionSublist( func_string, "Opposite" ) <> fail then
+                
+                Error( "<current_rec.dual_postprocessor_func> seems to use the attribute `Opposite`. Please use `OppositeCategory` (for categories),  `ObjectDatum` (for objects), or `MorphismDatum` (for morphisms) instead." );
+                
+            fi;
             
         fi;
         

--- a/CAP/gap/OppositeCategory.gd
+++ b/CAP/gap/OppositeCategory.gd
@@ -37,6 +37,9 @@ DeclareGlobalFunction( "CAP_INTERNAL_OPPOSITE_RECURSIVE" );
 DeclareAttribute( "Opposite",
                   IsCapCategory );
 
+DeclareAttribute( "OppositeCategory",
+                  IsCapCategory );
+
 DeclareOperation( "Opposite",
                   [ IsCapCategory, IsString ] );
 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -129,7 +129,7 @@ InstallGlobalFunction( CAP_INTERNAL_OPPOSITE_RECURSIVE,
   function( obj )
     
     if IsCapCategory( obj ) then
-        return Opposite( obj );
+        return OppositeCategory( obj );
     elif IsCapCategoryObject( obj ) then
         return ObjectDatum( CapCategory( obj ), obj );
     elif IsCapCategoryMorphism( obj ) then
@@ -269,7 +269,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                 
                 if filter = "category" then
                     
-                    return Concatenation( "Opposite( ", argument_name, " )" );
+                    return Concatenation( "OppositeCategory( ", argument_name, " )" );
                     
                 elif filter = "object" then
                     
@@ -448,7 +448,7 @@ InstallMethod( Opposite,
     
     opposite_category!.compiler_hints := rec(
         category_attribute_names := [
-            "Opposite",
+            "OppositeCategory",
         ],
     );
     
@@ -456,6 +456,7 @@ InstallMethod( Opposite,
     AddMorphismRepresentation( opposite_category, IsCapCategoryOppositeMorphismRep );
     
     SetWasCreatedAsOppositeCategory( opposite_category, true );
+    SetOppositeCategory( opposite_category, category );
     
     SetOpposite( opposite_category, category );
     SetOpposite( category, opposite_category );
@@ -464,7 +465,7 @@ InstallMethod( Opposite,
       local opposite_object;
         
         #% CAP_JIT_DROP_NEXT_STATEMENT
-        CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( object, Opposite( cat ), {} -> "the object datum given to the object constructor of <cat>" );
+        CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( object, OppositeCategory( cat ), {} -> "the object datum given to the object constructor of <cat>" );
         
         #% CAP_JIT_DROP_NEXT_STATEMENT
         if HasOpposite( object ) then
@@ -500,15 +501,15 @@ InstallMethod( Opposite,
       local opposite_morphism;
         
         #% CAP_JIT_DROP_NEXT_STATEMENT
-        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( morphism, Opposite( cat ), {} -> "the morphism datum given to the morphism constructor of <cat>" );
+        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( morphism, OppositeCategory( cat ), {} -> "the morphism datum given to the morphism constructor of <cat>" );
         
-        if IsEqualForObjects( Opposite( cat ), Source( morphism ), Opposite( range ) ) = false then
+        if IsEqualForObjects( OppositeCategory( cat ), Source( morphism ), Opposite( range ) ) = false then
             
             Error( "the source of the morphism datum must be equal to <Opposite( range )>" );
             
         fi;
         
-        if IsEqualForObjects( Opposite( cat ), Range( morphism ), Opposite( source ) ) = false then
+        if IsEqualForObjects( OppositeCategory( cat ), Range( morphism ), Opposite( source ) ) = false then
             
             Error( "the range of the morphism datum must be equal to <Opposite( source )>" );
             

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -12,7 +12,7 @@ BindGlobal( "ADD_FUNCTIONS_FOR_OppositeOfMatrixCategoryPrecompiled", function ( 
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( a_1 ), Range( a_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( b_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( a_1 ) ) + UnderlyingMatrix( Opposite( b_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( b_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( a_1 ) ) + UnderlyingMatrix( Opposite( b_1 ) ) ) );
 end
 ########
         
@@ -25,7 +25,7 @@ end
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( a_1 ), Range( a_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( a_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, -1 * UnderlyingMatrix( Opposite( a_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( a_1 ) ), Range( Opposite( a_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, -1 * UnderlyingMatrix( Opposite( a_1 ) ) ) );
 end
 ########
         
@@ -40,10 +40,10 @@ function ( cat_1, arg2_1, arg3_1 )
     cap_jit_hoisted_expression_1_1 := HomalgIdentityMatrix( Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingFieldForHomalg( Opposite( arg3_1 ) ) );
     cap_jit_hoisted_expression_2_1 := Dimension( Opposite( arg3_1 ) );
     cap_jit_hoisted_expression_3_1 := Dimension( Opposite( arg2_1 ) );
-    cap_jit_hoisted_expression_4_1 := Opposite( cat_1 );
+    cap_jit_hoisted_expression_4_1 := OppositeCategory( cat_1 );
     cap_jit_hoisted_expression_5_1 := Opposite( arg3_1 );
     cap_jit_hoisted_expression_6_1 := Opposite( arg2_1 );
-    cap_jit_hoisted_expression_7_1 := UnderlyingRing( Opposite( cat_1 ) );
+    cap_jit_hoisted_expression_7_1 := UnderlyingRing( OppositeCategory( cat_1 ) );
     cap_jit_hoisted_expression_8_1 := ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, Opposite( arg2_1 ) );
     cap_jit_hoisted_expression_9_1 := ObjectifyObjectForCAPWithAttributes( rec(
@@ -65,7 +65,7 @@ end
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         
@@ -79,9 +79,9 @@ function ( cat_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberRows( SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, SyzygiesOfRows( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -94,7 +94,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Range( alpha_1 ), Range( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Source( Opposite( beta_1 ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Source( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, RightDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -107,9 +107,9 @@ end
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, Sum( List( arg2_1, function ( logic_new_func_x_2 )
+             ), OppositeCategory( cat_1 ), Dimension, Sum( List( arg2_1, function ( logic_new_func_x_2 )
                   return Dimension( Opposite( logic_new_func_x_2 ) );
-              end ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+              end ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         
@@ -121,7 +121,7 @@ end
 ########
 function ( cat_1 )
     return ID_FUNC( ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         
@@ -135,7 +135,7 @@ function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, Opposite( A_1 ) ), A_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -146,7 +146,7 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
-    return ID_FUNC( HomomorphismStructureOnMorphismsWithGivenObjects( [ Opposite( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][1], [ Opposite( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][2], [ Opposite( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][3], [ Opposite( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][4], [ Opposite( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][5] ) );
+    return ID_FUNC( HomomorphismStructureOnMorphismsWithGivenObjects( [ OppositeCategory( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][1], [ OppositeCategory( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][2], [ OppositeCategory( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][3], [ OppositeCategory( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][4], [ OppositeCategory( cat_1 ), source_1, MorphismDatum( cat_1, beta_1 ), MorphismDatum( cat_1, alpha_1 ), range_1 ][5] ) );
 end
 ########
         
@@ -158,7 +158,7 @@ end
 ########
 function ( cat_1, arg2_1, arg3_1 )
     return ID_FUNC( ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, Dimension( Opposite( arg3_1 ) ) * Dimension( Opposite( arg2_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         
@@ -171,7 +171,7 @@ end
 function ( cat_1, a_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, a_1, a_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( a_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( a_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( a_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -184,15 +184,15 @@ end
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, objects_1[k_1], P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( P_1 ), Opposite( objects_1[k_1] ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( objects_1[k_1] ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ 1 .. k_1 - 1 ]}, function ( c_2 )
                     return Dimension( c_2 );
-                end ), Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( Opposite( cat_1 ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( Opposite( cat_1 ) ) ), HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
+                end ), Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ), HomalgZeroMatrix( Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                     return Dimension( c_2 );
-                end ), Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) ) );
+                end ), Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) ) );
 end
 ########
         
@@ -204,9 +204,9 @@ end
 ########
 function ( cat_1, alpha_1 )
     return ID_FUNC( ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, NumberColumns( ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), ObjectifyObjectForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, 1, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), ObjectifyObjectForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, ConvertMatrixToRow( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -340,9 +340,9 @@ end
 function ( cat_1, arg2_1 )
     local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1, cap_jit_hoisted_expression_4_1, cap_jit_hoisted_expression_5_1, cap_jit_hoisted_expression_6_1;
     cap_jit_hoisted_expression_1_1 := not true;
-    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Source( Opposite( arg2_1 ) ) ), UnderlyingRing( Opposite( cat_1 ) ) );
-    cap_jit_hoisted_expression_3_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) );
-    cap_jit_hoisted_expression_4_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Range( Opposite( arg2_1 ) ) ), UnderlyingRing( Opposite( cat_1 ) ) );
+    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Source( Opposite( arg2_1 ) ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
+    cap_jit_hoisted_expression_3_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
+    cap_jit_hoisted_expression_4_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Range( Opposite( arg2_1 ) ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
     cap_jit_hoisted_expression_5_1 := NumberRows( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Source( Opposite( arg2_1 ) ) );
     cap_jit_hoisted_expression_6_1 := NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) <> Dimension( Range( Opposite( arg2_1 ) ) );
     return function (  )
@@ -375,7 +375,7 @@ end
 function ( cat_1, arg2_1 )
     local cap_jit_hoisted_expression_1_1, cap_jit_hoisted_expression_2_1, cap_jit_hoisted_expression_3_1;
     cap_jit_hoisted_expression_1_1 := not true;
-    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) );
+    cap_jit_hoisted_expression_2_1 := not IS_IDENTICAL_OBJ( UnderlyingFieldForHomalg( Opposite( arg2_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) );
     cap_jit_hoisted_expression_3_1 := Dimension( Opposite( arg2_1 ) ) < 0;
     return function (  )
             if cap_jit_hoisted_expression_1_1 then
@@ -424,9 +424,9 @@ function ( cat_1, alpha_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) ), Source( alpha_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Range( Opposite( alpha_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-               ), Opposite( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ), Source( alpha_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), Range( Opposite( alpha_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+               ), OppositeCategory( cat_1 ), Dimension, NumberColumns( SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, SyzygiesOfColumns( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -439,7 +439,7 @@ end
 function ( cat_1, arg2_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, NumberColumns( UnderlyingMatrix( Opposite( arg2_1 ) ) ) - RowRankOfMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         
@@ -452,7 +452,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), Source( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Range( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Range( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, LeftDivide( UnderlyingMatrix( Opposite( beta_1 ) ), UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
 end
 ########
         
@@ -466,7 +466,7 @@ function ( cat_1, A_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, A_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Opposite, Opposite( A_1 ) ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( A_1 ), Opposite( A_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( Opposite( A_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -479,7 +479,7 @@ end
 function ( cat_1, alpha_1, beta_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, Source( alpha_1 ), Range( beta_1 ), Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Source( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( beta_1 ) ) * UnderlyingMatrix( Opposite( alpha_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Source( Opposite( beta_1 ) ), Range( Opposite( alpha_1 ) ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnderlyingMatrix( Opposite( beta_1 ) ) * UnderlyingMatrix( Opposite( alpha_1 ) ) ) );
 end
 ########
         
@@ -492,15 +492,15 @@ end
 function ( cat_1, objects_1, k_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, objects_1[k_1], Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( objects_1[k_1] ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( objects_1[k_1] ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ 1 .. k_1 - 1 ]}, function ( c_2 )
                     return Dimension( c_2 );
-                end ), UnderlyingRing( Opposite( cat_1 ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( Opposite( cat_1 ) ) ), HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
+                end ), UnderlyingRing( OppositeCategory( cat_1 ) ) ), HomalgIdentityMatrix( Dimension( Opposite( objects_1[k_1] ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ), HomalgZeroMatrix( Dimension( Opposite( objects_1[k_1] ) ), Sum( List( objects_1, function ( x_2 )
                         return Opposite( x_2 );
                     end ){[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                     return Dimension( c_2 );
-                end ), UnderlyingRing( Opposite( cat_1 ) ) ) ) ) );
+                end ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) ) );
 end
 ########
         
@@ -537,7 +537,7 @@ end
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, T_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( Opposite( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfColumns( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
                   return UnderlyingMatrix( Opposite( logic_new_func_x_2 ) );
               end ) ) ) );
 end
@@ -552,7 +552,7 @@ end
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, P_1, T_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( T_1 ) ), 0, UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( T_1 ), Opposite( P_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( T_1 ) ), 0, UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -565,7 +565,7 @@ end
 function ( cat_1, objects_1, T_1, tau_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( Opposite( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, UnionOfRows( UnderlyingRing( OppositeCategory( cat_1 ) ), Dimension( Opposite( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
                   return UnderlyingMatrix( Opposite( logic_new_func_x_2 ) );
               end ) ) ) );
 end
@@ -580,7 +580,7 @@ end
 function ( cat_1, T_1, P_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, T_1, P_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( Opposite( T_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( P_1 ), Opposite( T_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( 0, Dimension( Opposite( T_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -593,7 +593,7 @@ end
 function ( cat_1, a_1, b_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, a_1, b_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Opposite( b_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( b_1 ) ), Dimension( Opposite( a_1 ) ), UnderlyingRing( Opposite( cat_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( b_1 ), Opposite( a_1 ), UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ), UnderlyingMatrix, HomalgZeroMatrix( Dimension( Opposite( b_1 ) ), Dimension( Opposite( a_1 ) ), UnderlyingRing( OppositeCategory( cat_1 ) ) ) ) );
 end
 ########
         
@@ -606,7 +606,7 @@ end
 function ( cat_1 )
     return ObjectifyObjectForCAPWithAttributes( rec(
            ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
-             ), Opposite( cat_1 ), Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( Opposite( cat_1 ) ) ) );
+             ), OppositeCategory( cat_1 ), Dimension, 0, UnderlyingFieldForHomalg, UnderlyingRing( OppositeCategory( cat_1 ) ) ) );
 end
 ########
         


### PR DESCRIPTION
If ObjectDatum and MorphismDatum are overwritten, `Opposite` does not
return the expected result. This commit adds a suitable warning for code
in dual_pre/postprocessor_func. To distinguish the case of categories,
this commit introduces the new attribute `OppositeCategory`.