### PR TITLE
Add process_coverage_ignored_lines.py

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -40,6 +40,7 @@ jobs:
           export SOURCE_DATE_EPOCH=0
           TERM=dumb make -C CAP_project -j $(nproc) --output-sync ci-test
           cp ./CAP_project/.codecov.yml ./
+          (cd CAP_project && LANG=C.UTF-8 python3 process_coverage_ignored_lines.py)
           curl -s https://codecov.io/bash | bash
           git config --global user.name "Bot"
           git config --global user.email "empty"

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -41,6 +41,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     
     if IsOperation( func ) or IsKernelFunction( func ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "<func> is a operation or kernel function, this is not supported yet." );
         
     fi;
@@ -48,8 +49,10 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     debug := false;
     
     if debug then
+        # COVERAGE_IGNORE_BLOCK_START
         Display( func );
         Error( "start compilation" );
+        # COVERAGE_IGNORE_BLOCK_END
     fi;
     
     if Length( jit_args ) > 0 and IsCapCategory( jit_args[1] ) then
@@ -72,47 +75,59 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         Info( InfoCapJit, 1, "Start resolving." );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "start resolving" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitResolvedOperations" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitResolvedOperations( tree, jit_args );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedArguments" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedArguments( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitDroppedUnusedBindings" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitDroppedUnusedBindings( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedBindings (for global variables only)" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedBindings( tree : inline_gvars_only := true );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitResolvedGlobalVariables" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitResolvedGlobalVariables( tree );
@@ -129,63 +144,79 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         Info( InfoCapJit, 1, "Apply rules." );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply rules" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitAppliedLogic" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitAppliedLogic( tree, jit_args );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitDroppedHandledEdgeCases" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitDroppedHandledEdgeCases( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedArguments" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedArguments( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedSimpleFunctionCalls" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedSimpleFunctionCalls( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedFunctionCalls" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedFunctionCalls( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitDroppedUnusedBindings" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitDroppedUnusedBindings( tree );
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitInlinedBindings" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitInlinedBindings( tree );
@@ -197,9 +228,11 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     if Length( jit_args ) > 0 and IsCapCategory( jit_args[1] ) then
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
             Display( compiled_func );
             Error( "apply CapJitAppliedCompilerHints" );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         tree := CapJitAppliedCompilerHints( tree, jit_args[1] );
@@ -207,15 +240,18 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     fi;
     
     if debug then
+        # COVERAGE_IGNORE_BLOCK_START
         compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
         Display( compiled_func );
         Error( "apply CapJitHoistedExpressions" );
+        # COVERAGE_IGNORE_BLOCK_END
     fi;
     
     tree := CapJitHoistedExpressions( tree );
     
     if debug then
         
+        # COVERAGE_IGNORE_BLOCK_START
         compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
         
         Display( compiled_func );
@@ -223,6 +259,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         Assert( 0, CallFuncList( compiled_func, jit_args ) = CallFuncList( func, jit_args ) );
         
         Error( "compilation finished" );
+        # COVERAGE_IGNORE_BLOCK_END
         
     fi;
     

--- a/CompilerForCAP/gap/CompilerHints.gi
+++ b/CompilerForCAP/gap/CompilerHints.gi
@@ -50,6 +50,7 @@ InstallGlobalFunction( CapJitReplacedSourceAndRangeAttributes, function ( tree, 
                         
                         if morphism_attribute_position = fail then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             Error( "cannot find morphism attribute" );
                             
                         fi;
@@ -88,6 +89,7 @@ InstallGlobalFunction( CapJitReplacedSourceAndRangeAttributes, function ( tree, 
                             
                             if source_attribute_position = fail then
                                 
+                                # COVERAGE_IGNORE_NEXT_LINE
                                 Error( "cannot find source attribute" );
                                 
                             fi;
@@ -124,6 +126,7 @@ InstallGlobalFunction( CapJitReplacedSourceAndRangeAttributes, function ( tree, 
                             
                             if range_attribute_position = fail then
                                 
+                                # COVERAGE_IGNORE_NEXT_LINE
                                 Error( "cannot find range attribute" );
                                 
                             fi;

--- a/CompilerForCAP/gap/DropHandledEdgeCases.gi
+++ b/CompilerForCAP/gap/DropHandledEdgeCases.gi
@@ -79,6 +79,7 @@ InstallGlobalFunction( CapJitDroppedHandledEdgeCases, function ( tree )
                         
                         if tree.branches.length = 0 then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             Error( "No branches remain, this should never happen." );
                             
                         fi;

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -9,6 +9,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
     ErrorWithFuncLocation := function ( args... )
         
         # using LocationFunc causes a segfault (https://github.com/gap-system/gap/issues/4507)
+        # COVERAGE_IGNORE_NEXT_LINE
         CallFuncList( Error, Concatenation( [ "for function at ", FilenameFunc( func ), ":", StartlineFunc( func ), ":\n" ], args ) );
         
     end;
@@ -29,6 +30,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
     
     if not IsList( given_arguments ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the option \"given_arguments\" must be a list" );
         
     fi;
@@ -37,6 +39,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
     
     if tree.variadic and Length( given_arguments ) >= tree.narg then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "cannot insert given arguments into variadic arguments" );
         
     fi;
@@ -193,6 +196,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                 
                 if "RETURN_VALUE" in tree.nams then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     ErrorWithFuncLocation( "Function has argument or local variable with name RETURN_VALUE. This is not supported." );
                     
                 fi;
@@ -253,6 +257,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                         
                     else
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         ErrorWithFuncLocation( "tree contains hvar ref outside of stack" );
                         
                     fi;
@@ -289,6 +294,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                         
                         if i = Length( tree.statements ) then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "The pragma CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL must not occur as the last statement in a sequence of statements" );
                             
                         fi;
@@ -305,6 +311,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                             
                         else
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "The line following the pragma CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL must either assign a variable to the result of a function call or return the result of a function call" );
                             
                         fi;
@@ -317,6 +324,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                             
                         else
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "The pragma CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL can only be used for calls to global functions or operations" );
                             
                         fi;
@@ -342,6 +350,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                         
                         if i = Length( tree.statements ) then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "The pragma CAP_JIT_DROP_NEXT_STATEMENT must not occur as the last statement in a sequence of statements" );
                             
                         fi;
@@ -447,6 +456,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
             
         else
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "this should never happen" );
             
         fi;
@@ -482,6 +492,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                 
                 if IsBound( bindings.(rec_name) ) then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     ErrorWithFuncLocation( "Variable with name ", name, " is assigned more than once (not as part of a rapid reassignment). This is not supported." );
                     
                 fi;
@@ -490,6 +501,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                 
                 if Position( tree.nams, name ) <= tree.narg then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     ErrorWithFuncLocation( "A function argument with name ", name, " is assigned. This is not supported." );
                     
                 fi;
@@ -506,6 +518,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                     
                     if statement.func_id <> tree.id then
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         ErrorWithFuncLocation( "A higher variable with name ", statement.name, " is assigned. This is not supported." );
                         
                     fi;
@@ -524,6 +537,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                     
                     if statement.branches.1.body.statements.length = 0 then
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         ErrorWithFuncLocation( "Found empty if branch. This is not supported." );
                         
                     fi;
@@ -532,12 +546,14 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                         
                         if Last( statement.branches.1.body.statements ).func_id <> tree.id then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "Assignment to a non-local variable. This is not supported." );
                             
                         fi;
                         
                         if not Last( statement.branches ).condition.type = "EXPR_TRUE" then
                             
+                            # COVERAGE_IGNORE_NEXT_LINE
                             ErrorWithFuncLocation( "Found if without else clause. This is not supported." );
                             
                         fi;
@@ -553,6 +569,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                             
                             if branch.body.statements.length = 0 then
                                 
+                                # COVERAGE_IGNORE_NEXT_LINE
                                 ErrorWithFuncLocation( "Found empty if branch. This is not supported." );
                                 
                             fi;
@@ -561,6 +578,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                                 
                                 if branch.body.statements.(j).type <> "STAT_ASS_FVAR" then
                                     
+                                    # COVERAGE_IGNORE_NEXT_LINE
                                     ErrorWithFuncLocation( "The type ", branch.body.statements.(j).type, " is not supported at this point in the code." );
                                     
                                 fi;
@@ -571,6 +589,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                             
                             if Last( branch.body.statements ).type <> "STAT_ASS_FVAR" or Last( branch.body.statements ).func_id <> tree.id or Last( branch.body.statements ).name <> name then
                                 
+                                # COVERAGE_IGNORE_NEXT_LINE
                                 ErrorWithFuncLocation( "Not all if branches end with the assignment to the same local variable. This is not supported." );
                                 
                             fi;
@@ -589,12 +608,14 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
                         
                     else
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         ErrorWithFuncLocation( "statement type ", Last( statement.branches.1.body.statements ).type, " is not supported by CompilerForCAP" );
                         
                     fi;
                     
                 else
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     ErrorWithFuncLocation( "statement type ", statement.type, " is not supported by CompilerForCAP" );
                     
                 fi;
@@ -649,12 +670,14 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
     
     if not IsRecord( tree ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the syntax tree must be a record" );
         
     fi;
     
     if tree.type <> "EXPR_DECLARATIVE_FUNC" then
         
+        # COVERAGE_IGNORE_BLOCK_START
         Error( "The syntax tree is not of type EXPR_FUNC. However, if you type 'return;', it will be wrapped in a dummy function." );
         
         if StartsWith( tree.type, "EXPR" ) then
@@ -684,6 +707,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 ] ),
             ),
         );
+        # COVERAGE_IGNORE_BLOCK_END
         
     fi;
     
@@ -704,6 +728,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
         # check that the input is a proper tree, i.e. acyclic
         if IsBound( tree.touched ) then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "this subtree can be reached via at least two different paths, i.e. the input contains a cycle and thus is not a proper tree" );
             
         else
@@ -723,6 +748,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if tree.id in seen_function_ids then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "tree contains multiple functions with the same ID" );
                     
                 else
@@ -795,6 +821,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                     
                     if name = fail then
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         Error( "The relation \"is used by\" between bindings does not give rise to a partial order, i.e. a DAG. This is not supported." );
                         
                     fi;
@@ -964,6 +991,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if tree.type <> "STAT_SEQ_STAT" then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "enhanced syntax trees can only be used with short types" );
                     
                 fi;
@@ -974,6 +1002,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if tree.type <> "EXPR_FUNCCALL" then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "enhanced syntax trees can only be used with short types" );
                     
                 fi;
@@ -992,6 +1021,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if tree.type <> "STAT_PROCCALL" then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "enhanced syntax trees can only be used with short types" );
                     
                 fi;
@@ -1010,6 +1040,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if tree.type <> "STAT_FOR" then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "enhanced syntax trees can only be used with short types" );
                     
                 fi;
@@ -1081,12 +1112,14 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if func_pos = fail then
                     
+                    # COVERAGE_IGNORE_BLOCK_START
                     Error( "An FVAR references a variable outside of the function stack. However, if you type 'return;', it will be replaced by a dummy variable." );
                     
                     tree.type := ReplacedString( tree.type, "FVAR", "GVAR" );
                     tree.gvar := Concatenation( "FVAR_outside_of_function_stack_", tree.name );
                     
                     return tree;
+                    # COVERAGE_IGNORE_BLOCK_END
                     
                 fi;
                 
@@ -1097,10 +1130,12 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                 
                 if not tree.name in func_stack[func_pos].nams then
                     
+                    # COVERAGE_IGNORE_BLOCK_START
                     Error( "The FVAR name ", tree.name, " does not occur in the names of local variables of its function. ",
                         "However, if you type 'return;', the name will be added for debugging purposes (this might lead to unexpected results for variadic functions)." );
                     
                     Add( func_stack[func_pos].nams, tree.name );
+                    # COVERAGE_IGNORE_BLOCK_END
                     
                 fi;
                 

--- a/CompilerForCAP/gap/InlineFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gi
@@ -88,6 +88,7 @@ InstallGlobalFunction( CapJitInlinedFunctionCalls, function ( tree )
             
             if not (tree.args.length = 0 and inline_func.narg = 0) then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "found function call with arguments, please inline arguments first" );
                 
             fi;

--- a/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineSimpleFunctionCalls.gi
@@ -15,6 +15,7 @@ InstallGlobalFunction( CapJitInlinedSimpleFunctionCalls, function ( tree )
             
             if not (tree.args.length = 0 and tree.funcref.narg = 0) then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "found function call with arguments, please inline arguments first" );
                 
             fi;

--- a/CompilerForCAP/gap/IterateOverTree.gi
+++ b/CompilerForCAP/gap/IterateOverTree.gi
@@ -136,9 +136,11 @@ InstallGlobalFunction( CapJitIterateOverTree, function ( tree, pre_func, result_
         
     else
         
+        # COVERAGE_IGNORE_BLOCK_START
         Display( tree );
         
         Error( "cannot determine type of tree" );
+        # COVERAGE_IGNORE_BLOCK_END
         
     fi;
     
@@ -156,9 +158,11 @@ InstallGlobalFunction( CapJitIterateOverTree, function ( tree, pre_func, result_
         
     else
         
+        # COVERAGE_IGNORE_BLOCK_START
         Display( tree );
         
         Error( "cannot find iteration key" );
+        # COVERAGE_IGNORE_BLOCK_END
         
     fi;
     
@@ -168,9 +172,11 @@ InstallGlobalFunction( CapJitIterateOverTree, function ( tree, pre_func, result_
         
         if not IsBound( tree.(key) ) then
             
+            # COVERAGE_IGNORE_BLOCK_START
             Display( tree );
             
             Error( "invalid iteration key" );
+            # COVERAGE_IGNORE_BLOCK_END
             
         fi;
         

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -9,12 +9,14 @@ InstallGlobalFunction( CapJitAddLogicFunction, function ( func )
     
     if not IsFunction( func ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "a logic function must be a function" );
         
     fi;
     
     if not NumberArgumentsFunction( func ) in [ -2, -1, 2 ] then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "a logic function must be callable with two arguments" );
         
     fi;
@@ -527,6 +529,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TELESCOPED_ITERATION, function ( tree, r
                     
                 else
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "This should never happen" );
                     
                 fi;

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -21,24 +21,28 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_ENHANCE_LOGIC_TEMPLATE, function ( templ
     # some basic sanity checks
     if not IsRecord( template ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "a logic template must be a record" );
         
     fi;
     
     if not IsSubset( RecNames( template ), [ "variable_names", "src_template", "dst_template", "returns_value" ] ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "a logic template must have the following required record entries: variable_names, src_template, dst_template, returns_value" );
         
     fi;
     
     if IsBound( template.variable_filters ) and Length( template.variable_names ) <> Length( template.variable_filters ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the length of the record entries variable_names and variable_filters of a logic template must be equal" );
         
     fi;
 
     if IsBound( template.needed_packages ) and (not IsList( template.needed_packages ) or ForAny( template.needed_packages, p -> not IsList( p ) or Length( p ) <> 2 )) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the record entry needed_packages of a logic template must be a list of pairs" );
         
     fi;
@@ -165,6 +169,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_ENHANCE_LOGIC_TEMPLATE, function ( templ
                 
                 if src_template_path = fail then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "could not find matching func in src_template" );
                     
                 fi;
@@ -175,6 +180,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_ENHANCE_LOGIC_TEMPLATE, function ( templ
                 
                 if src_func.id in func_id_stack then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "A function in src_template is used multiple times in dst_template in a nested way. This is not supported." );
                     
                 fi;
@@ -350,10 +356,12 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
         tree_path := additional_arguments[2];
         
         if debug then
+            # COVERAGE_IGNORE_BLOCK_START
             Display( "now matching against" );
             Display( template_tree );
             Display( "result" );
             Display( result );
+            # COVERAGE_IGNORE_BLOCK_END
         fi;
         
         # check if we already bailed out in pre_func
@@ -378,8 +386,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 );
                 
                 if debug then
+                    # COVERAGE_IGNORE_BLOCK_START
                     Display( "matched via variable1" );
                     Display( true );
+                    # COVERAGE_IGNORE_BLOCK_END
                 fi;
                 
                 return true;
@@ -387,8 +397,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
             else
                 
                 if debug then
+                    # COVERAGE_IGNORE_BLOCK_START
                     Display( "matched via variable2" );
                     Display( CapJitIsEqualForEnhancedSyntaxTrees( variables[var_number].tree, tree ) );
+                    # COVERAGE_IGNORE_BLOCK_END
                 fi;
                 
                 return CapJitIsEqualForEnhancedSyntaxTrees( variables[var_number].tree, tree );
@@ -400,6 +412,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
         if template_tree.type <> tree.type then
             
             if debug then
+                # COVERAGE_IGNORE_NEXT_LINE
                 Display( "type mismatch" );
             fi;
             
@@ -410,6 +423,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
         if template_tree.type = "SYNTAX_TREE_LIST" and template_tree.length <> tree.length then
             
             if debug then
+                # COVERAGE_IGNORE_NEXT_LINE
                 Display( "list length mismatch" );
             fi;
             
@@ -421,8 +435,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
         for key in RecNames( template_tree ) do
             
             if debug then
+                # COVERAGE_IGNORE_BLOCK_START
                 Display( "checking" );
                 Display( key );
+                # COVERAGE_IGNORE_BLOCK_END
             fi;
             
             Assert( 0, IsBound( tree.(key) ) );
@@ -433,6 +449,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 if IsIdenticalObj( ValueGlobal( template_tree.gvar ), ValueGlobal( tree.gvar ) ) then
                     
                     if debug then
+                        # COVERAGE_IGNORE_NEXT_LINE
                         Display( "match: gvars point to identical values" );
                     fi;
                     
@@ -441,6 +458,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 else
                     
                     if debug then
+                        # COVERAGE_IGNORE_NEXT_LINE
                         Display( "mismatch: gvars point to non-identical values" );
                     fi;
                     
@@ -456,8 +474,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 if result.(key) = false then
                     
                     if debug then
+                        # COVERAGE_IGNORE_BLOCK_START
                         Display( "child mismatch" );
                         Display( key );
+                        # COVERAGE_IGNORE_BLOCK_END
                     fi;
                     
                     return false;
@@ -476,8 +496,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
             if template_tree.(key) <> tree.(key) then
                 
                 if debug then
+                    # COVERAGE_IGNORE_BLOCK_START
                     Display( "tree mismatch" );
                     Display( key );
+                    # COVERAGE_IGNORE_BLOCK_END
                 fi;
                 
                 return false;
@@ -488,11 +510,13 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 
             fi;
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "should never get here" );
             
         od;
         
         if debug then
+            # COVERAGE_IGNORE_NEXT_LINE
             Display( "everything matched" );
         fi;
         
@@ -591,8 +615,10 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
         
         if IsBound( template.debug ) and template.debug then
             
+            # COVERAGE_IGNORE_BLOCK_START
             Display( "try to match template:" );
             Display( template.src_template );
+            # COVERAGE_IGNORE_BLOCK_END
             
         fi;
         
@@ -635,6 +661,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
             
             if IsBound( template.debug ) and template.debug then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Display( "could not find a match" );
                 
             fi;
@@ -646,6 +673,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
         
         if IsBound( template.debug ) and template.debug then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "found match" );
             
         fi;
@@ -663,6 +691,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
         
         if not IsDenseList( variables ) or Length( variables ) <> Length( template.variable_names ) then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "matched wrong number of variables" );
             
         fi;
@@ -716,6 +745,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
             
             if IsBound( template.debug ) and template.debug then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "type check did not succeed" );
                 
             fi;
@@ -763,6 +793,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
             
             if IsBound( template.debug ) and template.debug then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "success, new_tree is well-defined" );
                 
             fi;
@@ -778,6 +809,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATE, function ( tree,
             
             if IsBound( template.debug ) and template.debug then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "new_tree is not well-defined" );
                 
             fi;

--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -250,6 +250,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if IsOperation( category_constructor ) or IsKernelFunction( category_constructor ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "category_constructor must be a regular function, i.e. not an operation or a kernel function" );
         
     fi;
@@ -260,6 +261,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if IsIdenticalObj( cat1, cat2 ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the category constructor must not return the same instance of the category if called twice" );
         
     fi;
@@ -269,6 +271,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if HasIsFinalized( cat ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the category constructor must support the option `FinalizeCategory`" );
         
     fi;
@@ -309,6 +312,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if Length( diff ) > 0 then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "The following strings are no CAP operations and can thus not be compiled: ", diff );
         
     fi;
@@ -317,6 +321,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if Length( diff ) > 0 then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "The following operations you want to have compiled are not computable in the given category: ", diff );
         
     fi;
@@ -327,6 +332,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     
     if package_info = fail then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "could not find package info" );
         
     fi;
@@ -351,6 +357,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         if not filter_list[1] = "category" then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( function_name, " does not get the category as the first argument. This is not supported when precompiling categories." );
             
         fi;
@@ -428,12 +435,14 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
                        
                     else
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         Error( "this should never happen" );
                         
                     fi;
                     
                 else
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "The category cannot compute the WithoutGiven operation of a WithGiven pair. This is not supported." );
                     
                 fi;
@@ -443,6 +452,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
             # check if we have been able to construct an example input
             if fail in example_input then
                 
+                # COVERAGE_IGNORE_NEXT_LINE
                 Error( "cannot generate example input for the operation ", function_name );
                 
             fi;
@@ -458,6 +468,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         if index = fail then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "All added functions for <function_name> in <cat> have additional filters. Cannot continue with compilation." );
             
         fi;
@@ -466,6 +477,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         if IsOperation( function_to_compile ) or IsKernelFunction( function_to_compile ) then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "Precompiling operations or kernel functions is not supported." );
             
         fi;
@@ -498,6 +510,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         if PositionSublist( function_string, "CAP_JIT_INTERNAL_GLOBAL_VARIABLE_" ) <> fail then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "Could not get rid of all global variables. You should use category_hints.category_attribute_names." );
             
         fi;
@@ -564,6 +577,8 @@ InstallGlobalFunction( "CapJitPrecompileCategoryAndCompareResult", function ( ca
         
     else
         
+        # this should never happen in tests
+        # COVERAGE_IGNORE_NEXT_LINE
         old_file_content := "";
         
     fi;
@@ -579,6 +594,8 @@ InstallGlobalFunction( "CapJitPrecompileCategoryAndCompareResult", function ( ca
     
     if old_file_content <> new_file_content then
         
+        # this should never happen in tests
+        # COVERAGE_IGNORE_NEXT_LINE
         Display( "WARNING: old and new file contents differ" );
         
     fi;

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -61,6 +61,7 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
                         
                     else
                         
+                        # COVERAGE_IGNORE_NEXT_LINE
                         Error( "this should never happen" );
                         
                     fi;

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -35,6 +35,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree, jit_args )
                 
                 if CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name).filter_list[1] <> "category" then
                     
+                    # COVERAGE_IGNORE_NEXT_LINE
                     Error( "cannot resolve CAP operations which do not get the category as the first argument" );
                     
                 fi;
@@ -123,6 +124,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree, jit_args )
         
         if not (IsBound( category!.category_as_first_argument ) and category!.category_as_first_argument = true) then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "only operations of categories with `category!.category_as_first_argument = true` can be resolved" );
             
         fi;
@@ -132,6 +134,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree, jit_args )
         
         if index = fail then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "All added functions for <operation> in <category> have additional filters. Cannot continue with compilation." );
             
         fi;
@@ -226,6 +229,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree, jit_args )
         
         if pos = fail then
             
+            # COVERAGE_IGNORE_NEXT_LINE
             Error( "Could not find known method for ", operation_name, " with correct length" );
             
         fi;

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -19,6 +19,7 @@ InstallGlobalFunction( CapJitIsCallToGlobalFunction, function ( tree, condition 
         
     else
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "<condition> must be a string or a function" );
         
     fi;
@@ -49,6 +50,7 @@ InstallGlobalFunction( CapJitResultFuncCombineChildren, function ( tree, result,
 
     else
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "this should never happen" );
         
     fi;
@@ -242,6 +244,7 @@ InstallGlobalFunction( CapJitRemovedReturnFail, function ( tree )
     
     if not found_return_fail then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "Could not detect a statement returning fail. Either the pragma CAP_JIT_NEXT_FUNCCALL_DOES_NOT_RETURN_FAIL is not set correctly or the given structure is not yet handled correctly by the compiler." );
         
     fi;
@@ -255,6 +258,7 @@ InstallGlobalFunction( CapJitPrettyPrintFunction, function ( func )
     
     if IsOperation( func ) or IsKernelFunction( func ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "<func> must neither be an operation nor a kernel function" );
         
     fi;
@@ -313,12 +317,14 @@ InstallGlobalFunction( CapJitAddBinding, function ( bindings, name, value )
     
     if not IsRecord( bindings ) or not IsBound( bindings.type ) or bindings.type <> "FVAR_BINDING_SEQ" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the first argument must be a syntax tree of type FVAR_BINDING_SEQ" );
         
     fi;
     
     if not IsString( name ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the second arguments must be a string" );
         
     fi;
@@ -327,6 +333,7 @@ InstallGlobalFunction( CapJitAddBinding, function ( bindings, name, value )
     
     if IsBound( bindings.(rec_name) ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "there already is a binding with name ", name );
         
     fi;
@@ -340,18 +347,21 @@ InstallGlobalFunction( CapJitValueOfBinding, function ( bindings, name )
     
     if not IsRecord( bindings ) or not IsBound( bindings.type ) or bindings.type <> "FVAR_BINDING_SEQ" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the first argument must be a syntax tree of type FVAR_BINDING_SEQ" );
         
     fi;
     
     if not IsString( name ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the second arguments must be a string" );
         
     fi;
     
     if not name in bindings.names then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( name, " is not the name of a binding" );
         
     fi;
@@ -364,18 +374,21 @@ InstallGlobalFunction( CapJitUnbindBinding, function ( bindings, name )
     
     if not IsRecord( bindings ) or not IsBound( bindings.type ) or bindings.type <> "FVAR_BINDING_SEQ" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the first argument must be a syntax tree of type FVAR_BINDING_SEQ" );
         
     fi;
     
     if not IsString( name ) then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( "the second arguments must be a string" );
         
     fi;
     
     if not name in bindings.names then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         Error( name, " is not the name of a binding" );
         
     fi;
@@ -434,6 +447,7 @@ InstallMethod( AsListMut,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -451,6 +465,7 @@ InstallMethod( Sublist,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -483,6 +498,7 @@ InstallMethod( Remove,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -518,6 +534,7 @@ InstallMethod( PositionProperty,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -567,6 +584,7 @@ InstallMethod( ListOp,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -594,6 +612,7 @@ InstallMethod( FilteredOp,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -611,6 +630,7 @@ InstallMethod( FirstOp,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -637,6 +657,7 @@ InstallMethod( LastOp,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -659,6 +680,7 @@ InstallMethod( ForAllOp,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;
@@ -676,6 +698,7 @@ InstallMethod( Iterator,
     
     if not IsBound( tree.type ) or tree.type <> "SYNTAX_TREE_LIST" then
         
+        # COVERAGE_IGNORE_NEXT_LINE
         TryNextMethod();
         
     fi;

--- a/process_coverage_ignored_lines.py
+++ b/process_coverage_ignored_lines.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+#######################################################
+# You should only use the coverage annotations for
+# a) lines around errors and warnings,
+# b) code solely existing for debugging purposes,
+# c) calls of `TryNextMethod` leading to external code.
+#######################################################
+
+import json
+import re
+import os
+from pathlib import Path
+
+regex_block_start = re.compile("^\s*# COVERAGE_IGNORE_BLOCK_START$")
+regex_block_end = re.compile("^\s*# COVERAGE_IGNORE_BLOCK_END$")
+regex_next_line = re.compile("^\s*# COVERAGE_IGNORE_NEXT_LINE$")
+
+for coverage_filename in Path(".").glob("**/coverage.json"):
+    print("processing coverage file " + str(coverage_filename))
+    with open(coverage_filename) as json_file:
+        data = json.load(json_file)
+        files = data["coverage"]
+        for filename, lines_covered in files.items():
+            if filename.startswith(os.getcwd()):
+                print(" processing code file " + filename)
+                line_number = 0
+                ignoring = False
+                ignored_lines = []
+                with open(filename) as file:
+                    while True:
+                        line_number += 1
+                        line = file.readline()
+                        
+                        if not line:
+                            break
+                        
+                        if regex_block_start.match(line) is not None:
+                            if ignoring:
+                                print("Error in line " + str(line_number) + ": start ignoring while already ignoring")
+                                exit(1)
+                            ignoring = True
+                        
+                        if regex_block_end.match(line) is not None:
+                            if not ignoring:
+                                print("Error in line " + str(line_number) + ": end ignoring while not ignoring")
+                                exit(1)
+                            ignoring = False
+                        
+                        if regex_next_line.match(line) is not None:
+                            if ignoring:
+                                print("Error in line " + str(line_number) + ": ignoring next line while already ignoring block")
+                                exit(1)
+                            ignored_lines.append(line_number + 1)
+                        
+                        if ignoring:
+                            ignored_lines.append(line_number)
+                
+                if ignoring:
+                    print("Error: ignoring until the end of the file")
+                    exit(1)
+                
+                for line_number in ignored_lines:
+                    if str(line_number) in lines_covered:
+                        if lines_covered[str(line_number)] != "0":
+                            print("Error in line " + str(line_number) + ": an ignored line is covered")
+                            exit(1)
+                        del lines_covered[str(line_number)]
+    
+    with open(coverage_filename, "w") as outfile:
+        json.dump(data, outfile, indent=0)


### PR DESCRIPTION
This PR adds a script which allows to ignore lines in code coverage via annotations. Those annotations should only be used for
* lines around errors and warnings,
* code solely existing for debugging purposes,
* calls of `TryNextMethod` leading to external code,

i.e. constructs which are hard to test in the usual way. With this, we can actually get the code coverage to 100%, which I will aim for in CompilerForCAP.