### PR TITLE
Fix the finalize mess

### DIFF
--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -36,7 +36,7 @@ InstallMethod( LeftActionsCategory,
   function( acting_object, name, context_filter_list )
     local underlying_monoidal_category, preconditions, category_weight_list, i,
           structure_record, object_constructor, morphism_constructor, 
-          left_actions_category, identity_of_acting_object, tensor_preserves_epis, finalize;
+          left_actions_category, identity_of_acting_object, tensor_preserves_epis;
     
     underlying_monoidal_category := CapCategory( acting_object );
     
@@ -264,11 +264,7 @@ InstallMethod( LeftActionsCategory,
     
     ## TODO: Logic for left_actions_category
     
-    finalize := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FinalizeCategory", true );
-    
-    if finalize = true then
-        Finalize( left_actions_category );
-    fi;
+    Finalize( left_actions_category );
     
     return left_actions_category;
     
@@ -295,7 +291,7 @@ InstallMethod( RightActionsCategory,
   function( acting_object, name, context_filter_list )
     local underlying_monoidal_category, preconditions, category_weight_list, i,
           structure_record, object_constructor, morphism_constructor, 
-          right_actions_category, identity_of_acting_object, tensor_preserves_epis, finalize;
+          right_actions_category, identity_of_acting_object, tensor_preserves_epis;
     
     underlying_monoidal_category := CapCategory( acting_object );
     
@@ -523,11 +519,7 @@ InstallMethod( RightActionsCategory,
     
     ## TODO: Logic for right_actions_category
     
-    finalize := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FinalizeCategory", true );
-    
-    if finalize = true then
-        Finalize( right_actions_category );
-    fi;
+    Finalize( right_actions_category );
     
     return right_actions_category;
     

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -35,7 +35,7 @@ InstallMethod( LeftCoactionsCategory,
   function( coacting_object, name, context_filter_list )
     local underlying_monoidal_category, preconditions, category_weight_list, i,
           structure_record, object_constructor, morphism_constructor, 
-          left_coactions_category, identity_of_coacting_object, finalize;
+          left_coactions_category, identity_of_coacting_object;
     
     underlying_monoidal_category := CapCategory( coacting_object );
     
@@ -242,11 +242,7 @@ InstallMethod( LeftCoactionsCategory,
     
     ## TODO: Logic for left_coactions_category
     
-    finalize := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FinalizeCategory", true );
-    
-    if finalize = true then
-        Finalize( left_coactions_category );
-    fi;
+    Finalize( left_coactions_category );
     
     return left_coactions_category;
     
@@ -273,7 +269,7 @@ InstallMethod( RightCoactionsCategory,
   function( coacting_object, name, context_filter_list )
     local underlying_monoidal_category, preconditions, category_weight_list, i,
           structure_record, object_constructor, morphism_constructor, 
-          right_coactions_category, identity_of_coacting_object, finalize;
+          right_coactions_category, identity_of_coacting_object;
     
     underlying_monoidal_category := CapCategory( coacting_object );
     
@@ -480,11 +476,7 @@ InstallMethod( RightCoactionsCategory,
     
     ## TODO: Logic for right_coactions_category
     
-    finalize := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FinalizeCategory", true );
-    
-    if finalize = true then
-        Finalize( right_coactions_category );
-    fi;
+    Finalize( right_coactions_category );
     
     return right_coactions_category;
     

--- a/ActionsForCAP/gap/SemisimpleCategory.gi
+++ b/ActionsForCAP/gap/SemisimpleCategory.gi
@@ -47,7 +47,7 @@ InstallMethod( SemisimpleCategory,
   function( underlying_category, membership_function, membership_function_name )
     local name, semisimple_category;
     
-    if not HasIsFinalized( underlying_category ) or not IsFinalized( underlying_category ) then
+    if not IsFinalized( underlying_category ) then
         
         Error( "the underlying category must be finalized" );
         return;

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.10-03",
+Version := "2021.10-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -244,6 +244,8 @@ InstallGlobalFunction( "CREATE_CAP_CATEGORY_OBJECT",
     
     obj := CallFuncList( ObjectifyWithAttributes, flatted_attribute_list );
     
+    SetIsFinalized( obj, false );
+    
     obj!.derivations_weight_list := MakeOperationWeightList( obj, CAP_INTERNAL_DERIVATION_GRAPH );
     
     obj!.caches := rec( );

--- a/CAP/gap/Finalize.gd
+++ b/CAP/gap/Finalize.gd
@@ -11,8 +11,9 @@ DeclareGlobalVariable( "CAP_INTERNAL_FINAL_DERIVATION_LIST" );
 DeclareGlobalFunction( "AddFinalDerivation" );
 
 
-DeclareProperty( "IsFinalized",
-                  IsCapCategory );
+DeclareAttribute( "IsFinalized",
+                  IsCapCategory,
+                  "mutable" );
 
 DeclareOperation( "Finalize",
                   [ IsCapCategory ] );

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -162,13 +162,20 @@ end );
 InstallMethod( Finalize,
                [ IsCapCategory ],
   
-  IsFinalized );
-
-InstallMethod( IsFinalized,
-               [ IsCapCategory ],
-               
   function( category )
     local current_final_derivation, derivation_list, i, n, weight_list, weight, add_name, current_installs, current_tester_func, current_additional_func;
+    
+    if IsFinalized( category ) then
+        
+        return true;
+        
+    fi;
+    
+    if ValueOption( "FinalizeCategory" ) = false then
+        
+        return false;
+        
+    fi;
     
     derivation_list := ShallowCopy( CAP_INTERNAL_FINAL_DERIVATION_LIST.final_derivation_list );
     
@@ -251,6 +258,8 @@ InstallMethod( IsFinalized,
         derivation_list := derivation_list{ Difference( [ 1 .. Length( derivation_list ) ], current_installs ) };
         
     od;
+    
+    SetIsFinalized( category, true );
     
     return true;
     

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -168,7 +168,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
               current_function_argument_number, current_additional_filter_list_length, filter, input_human_readable_identifier_getter, input_sanity_check_functions,
               output_human_readable_identifier_getter, output_sanity_check_function, cap_jit_compiled_function;
         
-        if HasIsFinalized( category ) and IsFinalized( category ) then
+        if IsFinalized( category ) then
             Error( "cannot add methods anymore, category is finalized" );
         fi;
         
@@ -463,6 +463,15 @@ InstallGlobalFunction( CapInternalInstallAdd,
                                 
                   function( arg )
                     local redirect_return, pre_func_return, collect_timing_statistics, start_time, result, end_time, i;
+                    
+                    if not IsFinalized( category ) then
+                        
+                        Display( Concatenation(
+                            "WARNING: You are calling an operation in a unfinalized category with name \"", Name( category ),
+                            "\". This is fine for debugging purposes, but for production use you should finalize the category by calling `Finalize` (with the option `FinalizeCategory := true` if needed)."
+                        ) );
+                        
+                    fi;
                     
                     if (redirect_function <> false) and (not IsBound( category!.redirects.( function_name ) ) or category!.redirects.( function_name ) <> false) then
                         redirect_return := CallFuncList( redirect_function, arg );

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -430,9 +430,9 @@ InstallMethod( Opposite,
                [ IsCapCategory, IsString ],
                
   function( category, name )
-    local opposite_category, to_be_finalized;
+    local opposite_category;
     
-    if not HasIsFinalized( category ) or not IsFinalized( category ) then
+    if not IsFinalized( category ) then
         Error( "Input category must be finalized to create opposite category" );
     fi;
     
@@ -554,17 +554,7 @@ InstallMethod( Opposite,
         
     fi;
     
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-        
-        return opposite_category;
-        
-    else
-        
-        Finalize( opposite_category );
-        
-    fi;
+    Finalize( opposite_category );
     
     return opposite_category;
     

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -182,7 +182,7 @@ InstallMethodWithCrispCache( ProductOp,
   function( category_list, selector )
     local product_category, namestring;
     
-    if not ForAll( category_list, HasIsFinalized ) or not ForAll( category_list, IsFinalized ) then
+    if not ForAll( category_list, IsFinalized ) then
         Error( "all categories for the product must be finalized" );
     fi;
     

--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -269,7 +269,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
     # check that category_constructor supports `FinalizeCategory`
     cat := CallFuncList( category_constructor, given_arguments : FinalizeCategory := false, no_precompiled_code := true );
     
-    if HasIsFinalized( cat ) then
+    if IsFinalized( cat ) then
         
         # COVERAGE_IGNORE_NEXT_LINE
         Error( "the category constructor must support the option `FinalizeCategory`" );
@@ -547,12 +547,6 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         "    cat := category_constructor( ", parameters_string, " : FinalizeCategory := false, no_precompiled_code := true );\n",
         "    \n",
         "    ADD_FUNCTIONS_FOR_", compiled_category_name, "( cat );\n",
-        "    \n",
-        "    if ValueOption( \"FinalizeCategory\" ) = false then\n",
-        "        \n",
-        "        return cat;\n",
-        "        \n",
-        "    fi;\n",
         "    \n",
         "    Finalize( cat );\n",
         "    \n",

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -15,7 +15,7 @@ InstallMethod( AdditiveClosure,
                [ IsCapCategory ],
                
   function( underlying_category )
-    local category, matrix_element_as_morphism, list_list_as_matrix, homalg_ring, precompiled_towers, remaining_constructors_in_tower, precompiled_functions_adder, to_be_finalized, info;
+    local category, matrix_element_as_morphism, list_list_as_matrix, homalg_ring, precompiled_towers, remaining_constructors_in_tower, precompiled_functions_adder, info;
     
     if not ( HasIsAbCategory( underlying_category ) and IsAbCategory( underlying_category ) ) then
         
@@ -155,14 +155,6 @@ InstallMethod( AdditiveClosure,
     fi;
     
     category!.compiler_hints.precompiled_towers := precompiled_towers;
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-      
-      return category;
-    
-    fi;
     
     Finalize( category );
     

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -15,7 +15,7 @@ InstallMethod( AdelmanCategory,
                [ IsCapCategory ],
 
   function( underlying_category )
-    local adelman_category, func, to_be_finalized;
+    local adelman_category, func;
     
     if not HasIsAdditiveCategory( underlying_category ) then
         
@@ -67,14 +67,6 @@ InstallMethod( AdelmanCategory,
     AddMorphismRepresentation( adelman_category, IsAdelmanCategoryMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY( adelman_category );
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-      
-    if to_be_finalized = false then
-      
-      return adelman_category;
-    
-    fi;
     
     Finalize( adelman_category );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -20,7 +20,7 @@ InstallMethod( CategoryOfColumns,
                [ IsHomalgRing ],
                
   function( homalg_ring )
-    local cat, to_be_finalized;
+    local cat;
     
     cat := CategoryOfColumnsAsOppositeOfCategoryOfRows( homalg_ring : FinalizeCategory := false );
     
@@ -39,14 +39,6 @@ InstallMethod( CategoryOfColumns,
             ADD_FUNCTIONS_FOR_CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled( cat );
             
         fi;
-        
-    fi;
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-        
-        return cat;
         
     fi;
     

--- a/FreydCategoriesForCAP/gap/CategoryOfColumnsAsOppositeOfCategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumnsAsOppositeOfCategoryOfRows.gi
@@ -15,7 +15,7 @@ InstallMethod( CategoryOfColumnsAsOppositeOfCategoryOfRows,
                [ IsHomalgRing ],
                
   function( homalg_ring )
-    local category_of_rows, op, to_be_finalized;
+    local category_of_rows, op;
     
     category_of_rows := CategoryOfRows( homalg_ring : FinalizeCategory := true );
     
@@ -113,14 +113,6 @@ InstallMethod( CategoryOfColumnsAsOppositeOfCategoryOfRows,
     AddMorphismRepresentation( op, IsCategoryOfColumnsMorphism and HasUnderlyingMatrix );
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_COLUMNS_AS_OPPOSITE_OF_CATEGORY_OF_ROWS( op );
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-        
-        return op;
-        
-    fi;
     
     Finalize( op );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
@@ -18,7 +18,7 @@
 InstallMethod( CategoryOfGradedColumns,
                [ IsHomalgGradedRing ],
   function( homalg_graded_ring )
-    local category, to_be_finalized;
+    local category;
     
       # create category
       category := CreateCapCategory( Concatenation( "Category of graded columns over ", RingName( homalg_graded_ring ) ) );
@@ -46,14 +46,6 @@ InstallMethod( CategoryOfGradedColumns,
       INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_COLUMNS( category, category!.constructor_checks_wished );
       
       CapCategorySwitchLogicOff( category );
-      
-      to_be_finalized := ValueOption( "FinalizeCategory" );
-      
-      if to_be_finalized = false then
-        
-        return category;
-      
-      fi;
       
       # finalise it
       Finalize( category );

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
@@ -18,7 +18,7 @@
 InstallMethod( CategoryOfGradedRows,
                [ IsHomalgGradedRing ],
   function( homalg_graded_ring )
-    local category, to_be_finalized;
+    local category;
 
       # construct the category
       category := CreateCapCategory( Concatenation( "Category of graded rows over ", RingName( homalg_graded_ring ) ) );
@@ -46,14 +46,6 @@ InstallMethod( CategoryOfGradedRows,
       INSTALL_FUNCTIONS_FOR_CAP_CATEGORY_OF_GRADED_ROWS( category, category!.constructor_checks_wished );
       
       CapCategorySwitchLogicOff( category );
-      
-      to_be_finalized := ValueOption( "FinalizeCategory" );
-      
-      if to_be_finalized = false then
-        
-        return category;
-      
-      fi;
       
       # finalise the category
       Finalize( category );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -15,7 +15,7 @@ InstallMethod( CategoryOfRows,
                [ IsHomalgRing ],
                
   function( homalg_ring )
-    local overhead_option, category, to_be_finalized;
+    local overhead_option, category;
     
     overhead_option := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "overhead", true );
     
@@ -77,14 +77,6 @@ InstallMethod( CategoryOfRows,
     AddMorphismRepresentation( category, IsCategoryOfRowsMorphism and HasUnderlyingMatrix );
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS( category );
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-      
-    if to_be_finalized = false then
-      
-      return category;
-    
-    fi;
     
     Finalize( category );
     

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -23,7 +23,7 @@ BindGlobal( "InfoFreydCategoriesForCAP", NewInfoClass("InfoFreydCategoriesForCAP
 ##
 InstallGlobalFunction( FREYD_CATEGORY,
   function( underlying_category )
-    local freyd_category, to_be_finalized, conditions;
+    local freyd_category, conditions;
     
     if not IsValidInputForFreydCategory( underlying_category ) then
         return false;
@@ -112,14 +112,6 @@ InstallGlobalFunction( FREYD_CATEGORY,
     AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY( freyd_category );
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-      
-      return freyd_category;
-    
-    fi;
     
     Finalize( freyd_category );
     
@@ -1784,7 +1776,7 @@ InstallGlobalFunction( IsValidInputForFreydCategory,
     result := true;
 
     # first check if the category has been finalized (i.e. no methods are to be added...)
-    if not HasIsFinalized( category ) or not IsFinalized( category ) then
+    if not IsFinalized( category ) then
 
         Error( "Underlying category must be finalized" );
         result := false;

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -13,7 +13,7 @@
 ##
 InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
     function( ring, underlying_category, arg... )
-    local category, is_finite, to_be_finalized, sorting_function, with_nf, cocycle;
+    local category, is_finite, sorting_function, with_nf, cocycle;
     
     if not ( HasIsCommutative( ring ) and IsCommutative( ring ) ) then
         
@@ -86,14 +86,6 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
     AddMorphismRepresentation( category, IsLinearClosureMorphism and HasCoefficientsList and HasSupportMorphisms );
     
     INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE( category );
-    
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-    
-    if to_be_finalized = false then
-      
-      return category;
-      
-    fi;
     
     Finalize( category );
     

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -15,9 +15,7 @@ InstallMethod( RingAsCategory,
                [ IsRing ],
                
   function( ring )
-    local finalize_option, category;
-    
-    finalize_option := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FinalizeCategory", true );
+    local category;
     
     category := CreateCapCategory( Concatenation( "Ring as category( ", String( ring )," )" ) );
     
@@ -41,11 +39,7 @@ InstallMethod( RingAsCategory,
     
     INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY( category );
     
-    if finalize_option then
-        
-        Finalize( category );
-        
-    fi;
+    Finalize( category );
     
     return category;
     

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -653,12 +653,6 @@ end;
     
     ADD_FUNCTIONS_FOR_CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled( cat );
     
-    if ValueOption( "FinalizeCategory" ) = false then
-        
-        return cat;
-        
-    fi;
-    
     Finalize( cat );
     
     return cat;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -868,12 +868,6 @@ end;
     
     ADD_FUNCTIONS_FOR_CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled( cat );
     
-    if ValueOption( "FinalizeCategory" ) = false then
-        
-        return cat;
-        
-    fi;
-    
     Finalize( cat );
     
     return cat;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -962,12 +962,6 @@ end;
     
     ADD_FUNCTIONS_FOR_CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled( cat );
     
-    if ValueOption( "FinalizeCategory" ) = false then
-        
-        return cat;
-        
-    fi;
-    
     Finalize( cat );
     
     return cat;

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
@@ -320,7 +320,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospans,
   function( category, test_function, function_name )
     local serre_category, gen_category, name, preconditions, category_weight_list, i;
     
-    if not HasIsFinalized( category ) or not IsFinalized( category ) then
+    if not IsFinalized( category ) then
         
         Error( "category must be finalized" );
         return;

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
@@ -387,7 +387,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpans,
   function( category, test_function, function_name )
     local serre_category, gen_category, name, preconditions, category_weight_list, i;
     
-    if not HasIsFinalized( category ) or not IsFinalized( category ) then
+    if not IsFinalized( category ) then
         
         Error( "category must be finalized" );
         return;

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -341,7 +341,7 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrows,
   function( category, test_function, function_name )
     local serre_category, gen_category, name, preconditions, category_weight_list, i;
     
-    if not HasIsFinalized( category ) or not IsFinalized( category ) then
+    if not IsFinalized( category ) then
         
         Error( "category must be finalized" );
         return;

--- a/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
+++ b/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
@@ -12,7 +12,7 @@ InstallMethod( GradedLeftPresentations,
                [ IsHomalgGradedRing ],
                
   function( ring )
-    local category, to_be_finalized;
+    local category;
     
     category := CreateCapCategory( Concatenation( "The category of graded left f.p. modules over ", RingName( ring ) ) );
     
@@ -56,17 +56,7 @@ InstallMethod( GradedLeftPresentations,
 #         "RelationsForGeneralModuleCategories.tex" )
 #     );
     
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-   
-    if to_be_finalized = false then
-      
-       return category;
-    
-    else
-    
-       Finalize( category );
-      
-    fi;
+    Finalize( category );
     
     return category;
     
@@ -77,7 +67,7 @@ InstallMethod( GradedRightPresentations,
                [ IsHomalgRing ],
                
   function( ring )
-    local category, to_be_finalized;
+    local category;
     
     category := CreateCapCategory( Concatenation( "The category of graded right f.p. modules over ", RingName( ring ) ) );
     
@@ -120,17 +110,7 @@ InstallMethod( GradedRightPresentations,
 #         "RelationsForGeneralModuleCategories.tex" )
 #     );
     
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-   
-    if to_be_finalized = false then
-      
-       return category;
-    
-    else
-    
-       Finalize( category );
-      
-    fi;
+    Finalize( category );
     
     return category;
     

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -25,7 +25,7 @@ end );
 
 InstallGlobalFunction( MATRIX_CATEGORY,
   function( homalg_field )
-    local category, to_be_finalized;
+    local category;
     
     category := CreateCapCategory( Concatenation( "Category of matrices over ", RingName( homalg_field ) ) );
     
@@ -85,17 +85,7 @@ InstallGlobalFunction( MATRIX_CATEGORY,
         "PredicateImplicationsForMatrixCategory.tex" )
     );
      
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-   
-    if to_be_finalized = false then
-      
-       return category;
-    
-    else
-    
-       Finalize( category );
-      
-    fi;
+    Finalize( category );
     
     return category;
     

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1140,12 +1140,6 @@ end;
     
     ADD_FUNCTIONS_FOR_MatrixCategoryPrecompiled( cat );
     
-    if ValueOption( "FinalizeCategory" ) = false then
-        
-        return cat;
-        
-    fi;
-    
     Finalize( cat );
     
     return cat;

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -690,12 +690,6 @@ end;
     
     ADD_FUNCTIONS_FOR_OppositeOfMatrixCategoryPrecompiled( cat );
     
-    if ValueOption( "FinalizeCategory" ) = false then
-        
-        return cat;
-        
-    fi;
-    
     Finalize( cat );
     
     return cat;

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -12,7 +12,7 @@ InstallMethod( LeftPresentations,
                [ IsHomalgRing ],
                
   function( ring )
-    local category, to_be_finalized;
+    local category;
     
     category := CreateCapCategory( Concatenation( "Category of left presentations of ", RingName( ring ) ) );
     
@@ -62,17 +62,7 @@ InstallMethod( LeftPresentations,
         "RelationsForGeneralModuleCategories.tex" )
     );
     
-    to_be_finalized := ValueOption( "FinalizeCategory" );
-   
-    if to_be_finalized = false then
-      
-       return category;
-    
-    else
-    
-       Finalize( category );
-      
-    fi;
+    Finalize( category );
     
     return category;
     


### PR DESCRIPTION
1. Turn `IsFinalized` into a mutable attribute (properties cannot be
   mutable).
2. Do not finalize a category automatically when asking `IsFinalized`.
3. Set `IsFinalized` to `false` by default and to `true` when finalizing.
4. With 2. and 3. it's possible to get rid of `HasIsFinalized`.
5. Respect the option `FinalizeCategory` in `Finalize`.
6. With 5. we can get rid of the checks regarding `FinalizeCategory`
   everywhere else in the code.
7. Add a warning when calling an operation in an unfinalized category.

@sebastianpos Do you agree with the points above? I do not think a review of the code is necessary because any problem with this should show up very clearly in tests.