### PR TITLE
Make derivations deterministic

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.11-03",
+Version := "2021.11-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -600,8 +600,9 @@ end );
 InstallMethod( InstallDerivationsUsingOperation,
                [ IsOperationWeightListRep, IsString ],
 function( owl, op_name )
-  local Q, node, weight, d, new_weight, max_weight,
-        target, new_node;
+  local Q, node, weight, d, new_weight,
+        target, current_weight, current_derivation,
+        derivations_of_target, new_pos, current_pos;
   Q := StringMinHeap();
   Add( Q, op_name, 0 );
   while not IsEmptyHeap( Q ) do
@@ -613,8 +614,27 @@ function( owl, op_name )
         continue;
       fi;
       new_weight := OperationWeightUsingDerivation( owl, d );
+      if new_weight = infinity then
+        continue;
+      fi;
       target := TargetOperation( d );
-      if new_weight < CurrentOperationWeight( owl, target ) then
+      
+      current_weight := CurrentOperationWeight( owl, target );
+      current_derivation := DerivationOfOperation( owl, target );
+      
+      if current_derivation <> fail then
+          
+          derivations_of_target := DerivationsOfOperation( DerivationGraph( owl ), target );
+          
+          new_pos := PositionProperty( derivations_of_target, x -> IsIdenticalObj( x, d ) );
+          current_pos := PositionProperty( derivations_of_target, x -> IsIdenticalObj( x, current_derivation ) );
+          
+          Assert( 0, new_pos <> fail );
+          Assert( 0, current_pos <> fail );
+          
+      fi;
+      
+      if new_weight < current_weight or (new_weight = current_weight and current_derivation <> fail and new_pos < current_pos) then
         InstallDerivationForCategory( d, new_weight, CategoryOfOperationWeightList( owl ) );
         if Contains( Q, target ) then
           DecreaseKey( Q, target, new_weight );


### PR DESCRIPTION
i.e. independent of the order of installations of primitive operations:
Always prefer the first derivation of a given weight in the derivation
graph, even if another derivation of the same weight has already been
installed.

@ all: This might, of course, change the derivations currently used in a given category. In case that unwanted derivations are triggered after this PR, probably some weights of primitive operations should be adjusted.