### PR TITLE
Introduce Left/RightPresentationsAsFreydCategoryOfCategoryOfRows/Columns

### DIFF
--- a/CompilerForCAP/examples/PrecompileModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.g
+++ b/CompilerForCAP/examples/PrecompileModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.g
@@ -1,0 +1,151 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "ModulePresentationsForCAP", false );
+#! true
+
+QQ := HomalgFieldOfRationalsInSingular( );;
+QQxy := QQ * "x,y";;
+EEE := KoszulDualRing( QQxy * "a,b" );;
+
+# CAUTION: when adding new operations make sure that they are compatible
+# with the ones added manually in `ADD_FUNCTIONS_FOR_LEFT/RIGHT_PRESENTATION`.
+operations_for_arbitrary_ring := [
+    "AdditionForMorphisms",
+    "AdditiveInverseForMorphisms",
+    #"AssociatorLeftToRightWithGivenTensorProducts",
+    #"AssociatorRightToLeftWithGivenTensorProducts",
+    #"BraidingWithGivenTensorProducts",
+    #"CoevaluationMorphismWithGivenRange",
+    "CokernelColiftWithGivenCokernelObject",
+    "CokernelProjection",
+    #"Colift",
+    #"ColiftOrFail",
+    "DirectSum",
+    "EpimorphismFromSomeProjectiveObject",
+    #"EvaluationMorphismWithGivenSource",
+    "IdentityMorphism",
+    "InjectionOfCofactorOfDirectSumWithGivenDirectSum",
+    #"InternalHomOnMorphismsWithGivenInternalHoms",
+    #"InternalHomOnObjects",
+    #"IsColiftable",
+    "IsCongruentForMorphisms",
+    "IsEqualForMorphisms",
+    #"IsEqualForObjects",
+    #"IsLiftable",
+    #"IsWellDefinedForMorphisms",
+    #"IsWellDefinedForObjects",
+    "IsZeroForMorphisms",
+    #"KernelEmbedding",
+    #"LeftUnitorWithGivenTensorProduct",
+    #"Lift",
+    #"LiftAlongMonomorphism",
+    #"LiftOrFail",
+    #"MultiplyWithElementOfCommutativeRingForMorphisms",
+    #"PreCompose",
+    "ProjectionInFactorOfDirectSumWithGivenDirectSum",
+    #"RightUnitorWithGivenTensorProduct",
+    #"TensorProductOnMorphismsWithGivenTensorProducts",
+    #"TensorProductOnObjects",
+    #"TensorUnit",
+    "UniversalMorphismFromDirectSumWithGivenDirectSum",
+    "UniversalMorphismFromZeroObjectWithGivenZeroObject",
+    "UniversalMorphismIntoDirectSumWithGivenDirectSum",
+    "UniversalMorphismIntoZeroObjectWithGivenZeroObject",
+    "ZeroMorphism",
+    "ZeroObject" 
+];;
+
+operations_for_commutative_ring := Concatenation(
+    operations_for_arbitrary_ring,
+    [ "MultiplyWithElementOfCommutativeRingForMorphisms" ]
+);;
+
+precompile_LeftPresentations := function( ring, name, operations )
+    
+    CapJitPrecompileCategoryAndCompareResult(
+        ring -> LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring ),
+        [ ring ],
+        "ModulePresentationsForCAP",
+        Concatenation(
+            "LeftPresentationsAsFreydCategoryOfCategoryOfRowsOf",
+            name,
+            "Precompiled"
+        ) :
+        operations := operations
+    ); end;;
+
+precompile_LeftPresentations(
+    QQ, "Field", operations_for_commutative_ring
+);;
+precompile_LeftPresentations(
+    QQxy, "CommutativeRing", operations_for_commutative_ring
+);;
+precompile_LeftPresentations(
+    EEE, "ArbitraryRing", operations_for_arbitrary_ring
+);;
+
+precompile_RightPresentations := function( ring, name, operations )
+    
+    CapJitPrecompileCategoryAndCompareResult(
+        ring -> RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring ),
+        [ ring ],
+        "ModulePresentationsForCAP",
+        Concatenation(
+            "RightPresentationsAsFreydCategoryOfCategoryOfColumnsOf",
+            name,
+            "Precompiled"
+        ) :
+        operations := operations
+    ); end;;
+
+precompile_RightPresentations(
+    QQ, "Field", operations_for_commutative_ring
+);;
+precompile_RightPresentations(
+    QQxy, "CommutativeRing", operations_for_commutative_ring
+);;
+precompile_RightPresentations(
+    EEE, "ArbitraryRing", operations_for_arbitrary_ring
+);;
+
+
+# check that the compiled code is loaded automatically
+# for this, we use the name of the argument of `ZeroObject`:
+# for non-compiled code it is "cat", while for compiled code it is "cat_1"
+
+cat := LeftPresentations( QQ );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+cat := LeftPresentations( QQxy );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+cat := LeftPresentations( EEE );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+cat := RightPresentations( QQ );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+cat := RightPresentations( QQxy );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+cat := RightPresentations( EEE );;
+NamesLocalVariablesFunction( Last( cat!.added_functions.ZeroObject )[1] )[1]
+    = "cat_1";
+#! true
+
+
+#! @EndExample

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.12-03",
+Version := "2021.12-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/FreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gd
@@ -69,7 +69,7 @@ DeclareAttribute( "UnderlyingCategory",
 DeclareAttribute( "RelationMorphism",
                   IsFreydCategoryObject );
 
-DeclareAttribute( "MorphismDatum",
+DeclareAttribute( "UnderlyingMorphism",
                   IsFreydCategoryMorphism );
 
 DeclareAttribute( "MorphismWitness",

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -129,7 +129,7 @@ InstallGlobalFunction( FREYD_CATEGORY,
     
     AddObjectRepresentation( freyd_category, IsFreydCategoryObject and HasRelationMorphism );
     
-    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism and HasMorphismDatum );
+    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism and HasUnderlyingMorphism );
     
     INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY( freyd_category );
     
@@ -453,7 +453,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
                                  rec( ), cat,
                                  source,
                                  range,
-                                 MorphismDatum, morphism_datum
+                                 UnderlyingMorphism, morphism_datum
         );
         
     end );
@@ -462,7 +462,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
     AddMorphismDatum( category,
       function( cat, mor )
         
-        return MorphismDatum( mor );
+        return UnderlyingMorphism( mor );
         
     end );
     

--- a/FreydCategoriesForCAP/gap/GradedModulePresentationsByFreyd/GradedModulePresentationsByFreyd.gi
+++ b/FreydCategoriesForCAP/gap/GradedModulePresentationsByFreyd/GradedModulePresentationsByFreyd.gi
@@ -39,7 +39,7 @@ InstallMethod( FreydCategory,
       
       AddObjectRepresentation( category, IsFreydCategoryObject and HasRelationMorphism and IsFpGradedLeftModulesObject );
       
-      AddMorphismRepresentation( category, IsFreydCategoryMorphism and HasMorphismDatum and IsFpGradedLeftModulesMorphism );
+      AddMorphismRepresentation( category, IsFreydCategoryMorphism and HasUnderlyingMorphism and IsFpGradedLeftModulesMorphism );
       
       return category;
       
@@ -69,7 +69,7 @@ InstallMethod( FreydCategory,
       
       AddObjectRepresentation( category, IsFreydCategoryObject and HasRelationMorphism and IsFpGradedRightModulesObject );
       
-      AddMorphismRepresentation( category, IsFreydCategoryMorphism and HasMorphismDatum and IsFpGradedRightModulesMorphism );
+      AddMorphismRepresentation( category, IsFreydCategoryMorphism and HasUnderlyingMorphism and IsFpGradedRightModulesMorphism );
       
       return category;
       

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -15,7 +15,7 @@ S := GradedRing( Q["x,y"] );
 Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
-#! 40 primitive operations were used to derive 196 operations for this category which
+#! 40 primitive operations were used to derive 232 operations for this category which
 #! * IsAbCategory
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
@@ -71,7 +71,7 @@ CohP1 := Sgrmod / C;
 #! The Serre quotient category of The category of graded left f.p. modules
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian
 InfoOfInstalledOperationsOfCategory( CohP1 );
-#! 21 primitive operations were used to derive 155 operations for this category which
+#! 21 primitive operations were used to derive 187 operations for this category which
 #! * IsAbCategory
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );

--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ModulePresentationsForCAP",
 Subtitle := "Category R-pres for CAP",
-Version := "2021.11-02",
+Version := "2021.12-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -92,7 +92,9 @@ Dependencies := rec(
                            [ "MonoidalCategories", ">= 2019.01.16" ],
                            [ "GeneralizedMorphismsForCAP", ">=0" ],
   ],
-  SuggestedOtherPackages := [ ],
+  SuggestedOtherPackages := [
+    [ "FreydCategoriesForCAP", ">= 2021.12-04" ],
+  ],
   ExternalConditions := [ ],
 ),
 

--- a/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
@@ -22,9 +22,9 @@ InstallMethod( PresentationMorphism,
     left := IsLeftPresentation( source );
     
     if not IsCapCategory( source ) = IsCapCategory( range ) then
-      
-      Error( "source and range must lie in the same category" );
-      
+        
+        Error( "source and range must lie in the same category" );
+        
     fi;
     
     if not IsIdenticalObj( UnderlyingHomalgRing( source ), HomalgRing( matrix ) ) then
@@ -34,33 +34,57 @@ InstallMethod( PresentationMorphism,
     fi;
     
     if left then
-      
-      if NrRows( matrix ) <> source!.nr_generators then
-          
-          Error( "the number of rows of the given matrix is incorrect" );
-          
-      fi;
-      
-      if NrColumns( matrix ) <> range!.nr_generators then
         
-        Error( "the number of columns of the given matrix is incorrect" );
+        if IsBound( source!.nr_generators ) and NrRows( matrix ) <> source!.nr_generators then
+            
+            Error( "the number of rows of the given matrix is incorrect" );
+            
+        fi;
         
-      fi;
-      
+        if HasUnderlyingMatrix( source ) and NrRows( matrix ) <> NrColumns( UnderlyingMatrix( source ) ) then
+            
+            Error( "the number of rows of the given matrix is incorrect" );
+            
+        fi;
+        
+        if IsBound( range!.nr_generators ) and NrColumns( matrix ) <> range!.nr_generators then
+            
+            Error( "the number of columns of the given matrix is incorrect" );
+            
+        fi;
+        
+        if HasUnderlyingMatrix( range ) and NrColumns( matrix ) <> NrColumns( UnderlyingMatrix( range ) ) then
+            
+            Error( "the number of columns of the given matrix is incorrect" );
+            
+        fi;
+        
     else
-      
-      if NrColumns( matrix ) <> source!.nr_generators then
         
-        Error( "the number of columns of the given matrix is incorrect" );
+        if IsBound( source!.nr_generators ) and NrColumns( matrix ) <> source!.nr_generators then
+            
+            Error( "the number of columns of the given matrix is incorrect" );
+            
+        fi;
         
-      fi;
-      
-      if NrRows( matrix ) <> range!.nr_generators then
+        if HasUnderlyingMatrix( source ) and NrColumns( matrix ) <> NrRows( UnderlyingMatrix( source ) ) then
+            
+            Error( "the number of columns of the given matrix is incorrect" );
+            
+        fi;
         
-        Error( "the number of rows of the given matrix is incorrect" );
+        if IsBound( range!.nr_generators ) and NrRows( matrix ) <> range!.nr_generators then
+            
+            Error( "the number of rows of the given matrix is incorrect" );
+            
+        fi;
         
-      fi;
-      
+        if HasUnderlyingMatrix( range ) and NrRows( matrix ) <> NrRows( UnderlyingMatrix( range ) ) then
+            
+            Error( "the number of rows of the given matrix is incorrect" );
+            
+        fi;
+        
     fi;
     
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), category,

--- a/ModulePresentationsForCAP/gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gd
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gd
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Declarations
+#
+#! @Chapter Module Presentations
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+#! @Description
+#! The argument is a homalg ring $R$.
+#! The output is the category of left presentations
+#! over $R$, constructed internally as the `FreydCategory`
+#! of the `CategoryOfRows` of <A>R</A>.
+#! Only available if the package `FreydCategoriesForCAP` is available.
+#! @Returns a category
+#! @Arguments R
+DeclareOperation( "LeftPresentationsAsFreydCategoryOfCategoryOfRows",
+                  [ IsHomalgRing ] );
+
+#! @Description
+#! The argument is a homalg ring $R$.
+#! The output is the category of right presentations
+#! over $R$, constructed internally as the `FreydCategory`
+#! of the `CategoryOfColumns` of <A>R</A>.
+#! Only available if the package `FreydCategoriesForCAP` is available.
+#! @Returns a category
+#! @Arguments R
+DeclareOperation( "RightPresentationsAsFreydCategoryOfCategoryOfColumns",
+                  [ IsHomalgRing ] );

--- a/ModulePresentationsForCAP/gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gi
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallMethod( LeftPresentationsAsFreydCategoryOfCategoryOfRows,
+               [ IsHomalgRing ],
+               
+  function( ring )
+    local category_of_rows, freyd, object_constructor, object_datum, morphism_constructor, morphism_datum, wrapper;
+    
+    category_of_rows := CategoryOfRows( ring : FinalizeCategory := true );
+    
+    freyd := FREYD_CATEGORY( category_of_rows : FinalizeCategory := true );
+    
+    object_constructor := function( cat, object_in_freyd )
+        
+        return ObjectifyObjectForCAPWithAttributes( rec( ), cat,
+                                                    UnderlyingMatrix, UnderlyingMatrix( RelationMorphism( object_in_freyd ) )
+        );
+        
+    end;
+    
+    object_datum := function( cat, obj )
+      local freyd, category_of_rows, relation_morphism;
+        
+        freyd := UnderlyingCategory( cat );
+        
+        category_of_rows := UnderlyingCategory( freyd );
+        
+        relation_morphism := CategoryOfRowsMorphism( category_of_rows,
+            CategoryOfRowsObject( category_of_rows, NrRows( UnderlyingMatrix( obj ) ) ),
+            UnderlyingMatrix( obj ),
+            CategoryOfRowsObject( category_of_rows, NrCols( UnderlyingMatrix( obj ) ) )
+        );
+        
+        return FreydCategoryObject( freyd, relation_morphism );
+        
+    end;
+    
+    morphism_constructor := function( cat, source, morphism_in_freyd, range )
+        
+        return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat,
+                source,
+                range,
+                UnderlyingMatrix, UnderlyingMatrix( UnderlyingMorphism( morphism_in_freyd ) ) );
+        
+    end;
+    
+    morphism_datum := function( cat, mor )
+      local freyd, category_of_rows, morphism_datum;
+        
+        freyd := UnderlyingCategory( cat );
+        
+        category_of_rows := UnderlyingCategory( freyd );
+        
+        morphism_datum := CategoryOfRowsMorphism( category_of_rows,
+            CategoryOfRowsObject( category_of_rows, NrRows( UnderlyingMatrix( mor ) ) ),
+            UnderlyingMatrix( mor ),
+            CategoryOfRowsObject( category_of_rows, NrCols( UnderlyingMatrix( mor ) ) )
+        );
+        
+        return FreydCategoryMorphism( freyd, ObjectDatum( cat, Source( mor ) ), morphism_datum, ObjectDatum( cat, Range( mor ) ) );
+        
+    end;
+    
+    wrapper := WrapperCategory( freyd, rec(
+        name := Concatenation( "Category of left presentations of ", RingName( ring ) ),
+        category_filter := IsCategoryOfLeftPresentations,
+        category_object_filter := IsLeftPresentation,
+        category_morphism_filter := IsLeftPresentationMorphism and HasUnderlyingMatrix,
+        object_constructor := object_constructor,
+        object_datum := object_datum,
+        morphism_constructor := morphism_constructor,
+        morphism_datum := morphism_datum,
+        only_primitive_operations := true,
+    ) : FinalizeCategory := false );
+    
+    wrapper!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingRing",
+        ],
+    );
+    
+    SetUnderlyingRing( wrapper, ring );
+    
+    wrapper!.ring_for_representation_category := ring;
+    
+    AddCategoryToFamily( wrapper, "ModuleCategory" );
+    
+    ## TODO: avoid code duplication (see RightPresentations)
+    AddTheoremFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "PropositionsForGeneralModuleCategories.tex" )
+    );
+    
+    AddPredicateImplicationFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "PredicateImplicationsForGeneralModuleCategories.tex" )
+     );
+    
+    AddEvalRuleFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "RelationsForGeneralModuleCategories.tex" )
+    );
+    
+    Finalize( wrapper );
+    
+    return wrapper;
+    
+end );
+
+##
+InstallMethod( RightPresentationsAsFreydCategoryOfCategoryOfColumns,
+               [ IsHomalgRing ],
+               
+  function( ring )
+    local category_of_columns, freyd, object_constructor, object_datum, morphism_constructor, morphism_datum, wrapper;
+    
+    category_of_columns := CategoryOfColumns( ring : FinalizeCategory := true );
+    
+    freyd := FREYD_CATEGORY( category_of_columns : FinalizeCategory := true );
+    
+    object_constructor := function( cat, object_in_freyd )
+        
+        return ObjectifyObjectForCAPWithAttributes( rec( ), cat,
+                                                    UnderlyingMatrix, UnderlyingMatrix( RelationMorphism( object_in_freyd ) )
+        );
+        
+    end;
+    
+    object_datum := function( cat, obj )
+      local freyd, category_of_columns, relation_morphism;
+        
+        freyd := UnderlyingCategory( cat );
+        
+        category_of_columns := UnderlyingCategory( freyd );
+        
+        relation_morphism := CategoryOfColumnsMorphism( category_of_columns,
+            CategoryOfColumnsObject( category_of_columns, NrCols( UnderlyingMatrix( obj ) ) ),
+            UnderlyingMatrix( obj ),
+            CategoryOfColumnsObject( category_of_columns, NrRows( UnderlyingMatrix( obj ) ) )
+        );
+        
+        return FreydCategoryObject( freyd, relation_morphism );
+        
+    end;
+    
+    morphism_constructor := function( cat, source, morphism_in_freyd, range )
+        
+        return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat,
+                source,
+                range,
+                UnderlyingMatrix, UnderlyingMatrix( UnderlyingMorphism( morphism_in_freyd ) ) );
+        
+    end;
+    
+    morphism_datum := function( cat, mor )
+      local freyd, category_of_columns, morphism_datum;
+        
+        freyd := UnderlyingCategory( cat );
+        
+        category_of_columns := UnderlyingCategory( freyd );
+        
+        morphism_datum := CategoryOfColumnsMorphism( category_of_columns,
+            CategoryOfColumnsObject( category_of_columns, NrCols( UnderlyingMatrix( mor ) ) ),
+            UnderlyingMatrix( mor ),
+            CategoryOfColumnsObject( category_of_columns, NrRows( UnderlyingMatrix( mor ) ) )
+        );
+        
+        return FreydCategoryMorphism( freyd, ObjectDatum( cat, Source( mor ) ), morphism_datum, ObjectDatum( cat, Range( mor ) ) );
+        
+    end;
+    
+    wrapper := WrapperCategory( freyd, rec(
+        name := Concatenation( "Category of right presentations of ", RingName( ring ) ),
+        category_filter := IsCategoryOfRightPresentations,
+        category_object_filter := IsRightPresentation,
+        category_morphism_filter := IsRightPresentationMorphism and HasUnderlyingMatrix,
+        object_constructor := object_constructor,
+        object_datum := object_datum,
+        morphism_constructor := morphism_constructor,
+        morphism_datum := morphism_datum,
+        only_primitive_operations := true,
+    ) : FinalizeCategory := false );
+    
+    wrapper!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingRing",
+        ],
+    );
+    
+    SetUnderlyingRing( wrapper, ring );
+    
+    wrapper!.ring_for_representation_category := ring;
+    
+    AddCategoryToFamily( wrapper, "ModuleCategory" );
+    
+    ## TODO: avoid code duplication (see LeftPresentations)
+    AddTheoremFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "PropositionsForGeneralModuleCategories.tex" )
+    );
+    
+    AddPredicateImplicationFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "PredicateImplicationsForGeneralModuleCategories.tex" )
+     );
+    
+    AddEvalRuleFileToCategory( wrapper,
+      Filename(
+        DirectoriesPackageLibrary( "ModulePresentationsForCAP", "LogicForModulePresentations" ),
+        "RelationsForGeneralModuleCategories.tex" )
+    );
+    
+    Finalize( wrapper );
+    
+    return wrapper;
+    
+end );

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gd
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gd
@@ -65,18 +65,6 @@ DeclareGlobalFunction( "ADD_KERNEL_LEFT" );
 
 DeclareGlobalFunction( "ADD_PRECOMPOSE_LEFT" );
 
-DeclareGlobalFunction( "ADD_ZERO_MORPHISM_LEFT" );
-
-DeclareGlobalFunction( "ADD_EQUAL_FOR_MORPHISMS_LEFT" );
-
-DeclareGlobalFunction( "ADD_COKERNEL_LEFT" );
-
-DeclareGlobalFunction( "ADD_DIRECT_SUM_LEFT" );
-
-DeclareGlobalFunction( "ADD_ZERO_OBJECT_LEFT" );
-
-DeclareGlobalFunction( "ADD_IDENTITY_LEFT" );
-
 DeclareGlobalFunction( "ADD_IS_WELL_DEFINED_FOR_MORPHISM_LEFT" );
 
 DeclareGlobalFunction( "ADD_TENSOR_PRODUCT_ON_OBJECTS_LEFT" );
@@ -101,18 +89,6 @@ DeclareGlobalFunction( "ADD_FUNCTIONS_FOR_RIGHT_PRESENTATION" );
 DeclareGlobalFunction( "ADD_KERNEL_RIGHT" );
 
 DeclareGlobalFunction( "ADD_PRECOMPOSE_RIGHT" );
-
-DeclareGlobalFunction( "ADD_ZERO_MORPHISM_RIGHT" );
-
-DeclareGlobalFunction( "ADD_EQUAL_FOR_MORPHISMS_RIGHT" );
-
-DeclareGlobalFunction( "ADD_COKERNEL_RIGHT" );
-
-DeclareGlobalFunction( "ADD_DIRECT_SUM_RIGHT" );
-
-DeclareGlobalFunction( "ADD_ZERO_OBJECT_RIGHT" );
-
-DeclareGlobalFunction( "ADD_IDENTITY_RIGHT" );
 
 DeclareGlobalFunction( "ADD_IS_WELL_DEFINED_FOR_MORPHISM_RIGHT" );
 
@@ -139,20 +115,8 @@ DeclareGlobalFunction( "ADD_IS_WELL_DEFINED_FOR_OBJECTS" );
 
 DeclareGlobalFunction( "ADD_EQUAL_FOR_OBJECTS" );
 
-DeclareGlobalFunction( "ADD_IS_ZERO_FOR_MORPHISMS" );
-
-DeclareGlobalFunction( "ADD_ADDITION_FOR_MORPHISMS" );
-
-DeclareGlobalFunction( "ADD_ADDITIVE_INVERSE_FOR_MORPHISMS" );
-
-DeclareGlobalFunction( "ADD_IS_IDENTICAL_FOR_MORPHISMS" );
-
 DeclareGlobalFunction( "ADD_TENSOR_PRODUCT_ON_MORPHISMS" );
-
-DeclareGlobalFunction( "ADD_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT" );
 
 DeclareGlobalFunction( "ADD_LIFT_AND_COLIFT_LEFT" );
 
 DeclareGlobalFunction( "ADD_LIFT_AND_COLIFT_RIGHT" );
-
-DeclareGlobalFunction( "ADD_MULTIPLY_WITH_ELEMENT_OF_COMMUTATIVE_RING_FOR_MORPHISMS_LEFT_AND_RIGHT" );

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -11,6 +11,9 @@ InstallMethod( LeftPresentations,
   function( ring )
     local category;
     
+    # Since `FreydCategoriesForCAP` is not deposited, we cannot simply return `LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring )`
+    # but have to construct the category manually.
+    
     category := CreateCapCategory( Concatenation( "Category of left presentations of ", RingName( ring ) ) );
     
     category!.category_as_first_argument := true;
@@ -37,6 +40,36 @@ InstallMethod( LeftPresentations,
       
       SetCommutativeRingOfLinearCategory( category, ring );
       
+    fi;
+    
+    if ValueOption( "no_precompiled_code" ) = true then
+        
+        if IsPackageMarkedForLoading( "FreydCategoriesForCAP", ">= 2021.11-01" ) then
+            
+            return LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring );
+            
+        else
+            
+            Error( "To get a version of `LeftPresentations` without precompiled code, the package `FreydCategoriesForCAP` is required." );
+            
+        fi;
+        
+    else
+        
+        if HasIsFieldForHomalg( ring ) and IsFieldForHomalg( ring ) then
+            
+            ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled( category );
+            
+        elif HasIsCommutative( ring ) and IsCommutative( ring ) then
+            
+            ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled( category );
+            
+        else
+            
+            ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled( category );
+            
+        fi;
+        
     fi;
     
     ADD_FUNCTIONS_FOR_LEFT_PRESENTATION( category );
@@ -75,6 +108,9 @@ InstallMethod( RightPresentations,
   function( ring )
     local category;
     
+    # Since `FreydCategoriesForCAP` is not deposited, we cannot simply return `RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring )`
+    # but have to construct the category manually.
+    
     category := CreateCapCategory( Concatenation( "Category of right presentations of ", RingName( ring ) ) );
     
     category!.category_as_first_argument := true;
@@ -101,6 +137,36 @@ InstallMethod( RightPresentations,
       
       SetCommutativeRingOfLinearCategory( category, ring );
       
+    fi;
+    
+    if ValueOption( "no_precompiled_code" ) = true then
+        
+        if IsPackageMarkedForLoading( "FreydCategoriesForCAP", ">= 2021.11-01" ) then
+            
+            return RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring );
+            
+        else
+            
+            Error( "To get a version of `RightPresentations` without precompiled code, the package `FreydCategoriesForCAP` is required." );
+            
+        fi;
+        
+    else
+        
+        if HasIsFieldForHomalg( ring ) and IsFieldForHomalg( ring ) then
+            
+            ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled( category );
+            
+        elif HasIsCommutative( ring ) and IsCommutative( ring ) then
+            
+            ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled( category );
+            
+        else
+            
+            ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled( category );
+            
+        fi;
+        
     fi;
     
     ADD_FUNCTIONS_FOR_RIGHT_PRESENTATION( category );
@@ -149,42 +215,26 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_PRESENTATION,
                        
   function( category )
     
+    # special, lazy installation
     ADD_KERNEL_LEFT( category );
     
+    # has special cases
     ADD_PRECOMPOSE_LEFT( category );
     
-    ADD_ADDITION_FOR_MORPHISMS( category );
-    
-    ADD_ADDITIVE_INVERSE_FOR_MORPHISMS( category );
-    
-    ADD_IS_ZERO_FOR_MORPHISMS( category );
-    
-    ADD_ZERO_MORPHISM_LEFT( category );
-    
-    ADD_EQUAL_FOR_MORPHISMS_LEFT( category );
-    
-    ADD_COKERNEL_LEFT( category );
-    
-    ADD_DIRECT_SUM_LEFT( category );
-    
-    ADD_ZERO_OBJECT_LEFT( category );
-    
-    ADD_IDENTITY_LEFT( category );
-    
+    # simpler than the compiled version
     ADD_EQUAL_FOR_OBJECTS( category );
     
+    # IsWellDefined* should not be compiled
     ADD_IS_WELL_DEFINED_FOR_OBJECTS( category );
     
     ADD_IS_WELL_DEFINED_FOR_MORPHISM_LEFT( category );
     
-    ADD_IS_IDENTICAL_FOR_MORPHISMS( category );
-    
-    ADD_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT( category );
-    
     if HasIsCommutative( category!.ring_for_representation_category ) and IsCommutative( category!.ring_for_representation_category ) then
       
+      # differs from the compiled version
       ADD_LIFT_AND_COLIFT_LEFT( category );
       
+      # this tensor structure slightly differs from the tensor structure of FreydCategory
       ADD_ASSOCIATOR_LEFT( category );
       
       ADD_UNITOR( category );
@@ -205,8 +255,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_LEFT_PRESENTATION,
       
       ADD_COEVALUATION_MORPHISM_LEFT( category );
       
-      ADD_MULTIPLY_WITH_ELEMENT_OF_COMMUTATIVE_RING_FOR_MORPHISMS_LEFT_AND_RIGHT( category );
-      
     fi;
     
 end );
@@ -220,33 +268,11 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_RIGHT_PRESENTATION,
     
     ADD_PRECOMPOSE_RIGHT( category );
     
-    ADD_ADDITION_FOR_MORPHISMS( category );
-    
-    ADD_ADDITIVE_INVERSE_FOR_MORPHISMS( category );
-    
-    ADD_IS_ZERO_FOR_MORPHISMS( category );
-    
-    ADD_ZERO_MORPHISM_RIGHT( category );
-    
-    ADD_EQUAL_FOR_MORPHISMS_RIGHT( category );
-    
-    ADD_COKERNEL_RIGHT( category );
-    
-    ADD_DIRECT_SUM_RIGHT( category );
-    
-    ADD_ZERO_OBJECT_RIGHT( category );
-    
-    ADD_IDENTITY_RIGHT( category );
-    
     ADD_EQUAL_FOR_OBJECTS( category );
     
     ADD_IS_WELL_DEFINED_FOR_OBJECTS( category );
     
     ADD_IS_WELL_DEFINED_FOR_MORPHISM_RIGHT( category );
-    
-    ADD_IS_IDENTICAL_FOR_MORPHISMS( category );
-    
-    ADD_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT( category );
     
     if HasIsCommutative( category!.ring_for_representation_category ) and IsCommutative( category!.ring_for_representation_category ) then
       
@@ -271,8 +297,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_RIGHT_PRESENTATION,
       ADD_EVALUATION_MORPHISM_RIGHT( category );
       
       ADD_COEVALUATION_MORPHISM_RIGHT( category );
-      
-      ADD_MULTIPLY_WITH_ELEMENT_OF_COMMUTATIVE_RING_FOR_MORPHISMS_LEFT_AND_RIGHT( category );
       
     fi;
     
@@ -359,21 +383,6 @@ InstallGlobalFunction( ADD_IS_WELL_DEFINED_FOR_MORPHISM_RIGHT,
         fi;
         
         return true;
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_IS_IDENTICAL_FOR_MORPHISMS,
-                              
-  function( category )
-    
-    AddIsEqualForMorphisms( category,
-    
-      function( cat, morphism_1, morphism_2 )
-        
-        return UnderlyingMatrix( morphism_1 ) = UnderlyingMatrix( morphism_2 );
         
     end );
     
@@ -597,526 +606,6 @@ InstallGlobalFunction( ADD_PRECOMPOSE_RIGHT,
       ]
       
     );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ADDITION_FOR_MORPHISMS,
-                       
-  function( category )
-    
-    AddAdditionForMorphisms( category,
-                             
-      function( cat, morphism_1, morphism_2 )
-        
-        return PresentationMorphism( Source( morphism_1 ), UnderlyingMatrix( morphism_1 ) + UnderlyingMatrix( morphism_2 ), Range( morphism_1 ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ADDITIVE_INVERSE_FOR_MORPHISMS,
-                       
-  function( category )
-    
-    AddAdditiveInverseForMorphisms( category,
-                                    
-      function( cat, morphism_1 )
-        
-        return PresentationMorphism( Source( morphism_1 ), - UnderlyingMatrix( morphism_1 ), Range( morphism_1 ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_IS_ZERO_FOR_MORPHISMS,
-                       
-  function( category )
-    ## FIXME: Use DecideZeroRows here (and DecideZeroColumns for the case of right modules)
-#     AddIsZeroForMorphisms( category,
-#                            
-#       function( cat, morphism )
-#         
-#         return IsZero( UnderlyingMatrix( morphism ) );
-#         
-#     end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ZERO_MORPHISM_LEFT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddZeroMorphism( category,
-                     
-      function( cat, source, range )
-        local matrix;
-        
-        matrix := HomalgZeroMatrix( NrColumns( UnderlyingMatrix( source ) ), NrColumns( UnderlyingMatrix( range ) ), homalg_ring );
-        
-        return PresentationMorphism( source, matrix, range );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ZERO_MORPHISM_RIGHT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddZeroMorphism( category,
-                     
-      function( cat, source, range )
-        local matrix;
-        
-        matrix := HomalgZeroMatrix( NrRows( UnderlyingMatrix( range ) ), NrRows( UnderlyingMatrix( source ) ), homalg_ring );
-        
-        return PresentationMorphism( source, matrix, range );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_EQUAL_FOR_MORPHISMS_LEFT,
-                       
-  function( category )
-    
-    AddIsCongruentForMorphisms( category,
-                            
-      function( cat, morphism_1, morphism_2 )
-        local result_of_divide;
-        
-        result_of_divide := DecideZeroRows( UnderlyingMatrix( morphism_1 ) - UnderlyingMatrix( morphism_2 ), UnderlyingMatrix( Range( morphism_1 ) ) );
-        
-        return IsZero( result_of_divide );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_EQUAL_FOR_MORPHISMS_RIGHT,
-                       
-  function( category )
-    
-    AddIsCongruentForMorphisms( category,
-                            
-      function( cat, morphism_1, morphism_2 )
-        local result_of_divide;
-        
-        result_of_divide := DecideZeroColumns( UnderlyingMatrix( morphism_1 ) - UnderlyingMatrix( morphism_2 ), UnderlyingMatrix( Range( morphism_1 ) ) );
-        
-        return IsZero( result_of_divide );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_COKERNEL_LEFT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddCokernelProjection( category,
-                     
-      function( cat, morphism )
-        local cokernel_object, projection;
-        
-        cokernel_object := UnionOfRows( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
-        
-        cokernel_object := AsLeftPresentation( cokernel_object );
-        
-        projection := HomalgIdentityMatrix( NrColumns( UnderlyingMatrix( Range( morphism ) ) ), homalg_ring );
-        
-        return PresentationMorphism( Range( morphism ), projection, cokernel_object );
-        
-    end );
-    
-    AddCokernelColiftWithGivenCokernelObject( category,
-      
-      function( cat, morphism, test_object, test_morphism, cokernel_object )
-        
-        return PresentationMorphism( cokernel_object, UnderlyingMatrix( test_morphism ), Range( test_morphism ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_COKERNEL_RIGHT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddCokernelProjection( category,
-                     
-      function( cat, morphism )
-        local cokernel_object, projection;
-        
-        cokernel_object := UnionOfColumns( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
-        
-        cokernel_object := AsRightPresentation( cokernel_object );
-        
-        projection := HomalgIdentityMatrix( NrRows( UnderlyingMatrix( Range( morphism ) ) ), homalg_ring );
-        
-        return PresentationMorphism( Range( morphism ), projection, cokernel_object );
-        
-    end );
-    
-    AddCokernelColiftWithGivenCokernelObject( category,
-      
-      function( cat, morphism, test_object, test_morphism, cokernel_object )
-        
-        return PresentationMorphism( cokernel_object, UnderlyingMatrix( test_morphism ), Range( test_morphism ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_DIRECT_SUM_LEFT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddDirectSum( category,
-                  
-      function( cat, product_object )
-        local objects, direct_sum;
-        
-        objects := product_object;
-        
-        objects := List( objects, UnderlyingMatrix );
-        
-        direct_sum := DiagMat( objects );
-        
-        return AsLeftPresentation( direct_sum );
-        
-    end );
-    
-    AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
-                                                 
-      function( cat, product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix;
-        
-        objects := product_object;
-        
-        object_column_dimension := List( objects, i -> NrColumns( UnderlyingMatrix( i ) ) );
-        
-        dimension_of_factor := object_column_dimension[ component_number ];
-        
-        projection := List( object_column_dimension, i -> 
-                            HomalgZeroMatrix( i, dimension_of_factor, homalg_ring ) );
-        
-        projection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
-        
-        projection_matrix := UnionOfRows( projection );
-        
-        return PresentationMorphism( direct_sum_object, projection_matrix, objects[ component_number ] );
-        
-    end );
-    
-    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
-                                                                 
-      function( cat, diagram, test_object, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product;
-        
-        components := product_morphism;
-        
-        number_of_components := Length( components );
-        
-        map_into_product := UnionOfColumns( List( components, c -> UnderlyingMatrix( c ) ) );
-        
-        return PresentationMorphism( Source( components[ 1 ] ), map_into_product, direct_sum );
-        
-    end );
-    
-    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
-                                              
-      function( cat, product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix;
-        
-        objects := product_object;
-        
-        object_column_dimension := List( objects, i -> NrColumns( UnderlyingMatrix( i ) ) );
-        
-        dimension_of_cofactor := object_column_dimension[ component_number ];
-        
-        injection := List( object_column_dimension, i -> HomalgZeroMatrix( dimension_of_cofactor, i, homalg_ring ) );
-        
-        injection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
-        
-        injection_matrix := UnionOfColumns( injection );
-        
-        return PresentationMorphism( objects[ component_number ], injection_matrix, direct_sum_object );
-        
-    end );
-    
-    AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
-                                                         
-      function( cat, diagram, test_object, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product;
-        
-        components := product_morphism;
-        
-        number_of_components := Length( components );
-        
-        map_into_product := UnionOfRows( List( components, c -> UnderlyingMatrix( c ) ) );
-        
-        return PresentationMorphism( direct_sum, map_into_product, Range( components[ 1 ] ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_DIRECT_SUM_RIGHT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddDirectSum( category,
-                  
-      function( cat, product_object )
-        local objects, direct_sum;
-        
-        objects := product_object;
-        
-        objects := List( objects, UnderlyingMatrix );
-        
-        direct_sum := DiagMat( objects );
-        
-        return AsRightPresentation( direct_sum );
-        
-    end );
-    
-    AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
-                                                 
-      function( cat, product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_factor, projection, projection_matrix;
-        
-        objects := product_object;
-        
-        object_column_dimension := List( objects, i -> NrRows( UnderlyingMatrix( i ) ) );
-        
-        dimension_of_factor := object_column_dimension[ component_number ];
-        
-        projection := List( object_column_dimension, i -> HomalgZeroMatrix( dimension_of_factor, i, homalg_ring ) );
-        
-        projection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
-        
-        projection_matrix := UnionOfColumns( projection );
-        
-        return PresentationMorphism( direct_sum_object, projection_matrix, objects[ component_number ] );
-        
-    end );
-    
-    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
-                                                                 
-      function( cat, diagram, test_object, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product;
-        
-        components := product_morphism;
-        
-        number_of_components := Length( components );
-        
-        map_into_product := UnionOfRows( List( components, c -> UnderlyingMatrix( c ) ) );
-        
-        return PresentationMorphism( Source( components[ 1 ] ), map_into_product, direct_sum );
-        
-    end );
-    
-    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
-                                              
-      function( cat, product_object, component_number, direct_sum_object )
-        local objects, object_column_dimension, dimension_of_cofactor, injection, injection_matrix;
-        
-        objects := product_object;
-        
-        object_column_dimension := List( objects, i -> NrRows( UnderlyingMatrix( i ) ) );
-        
-        dimension_of_cofactor := object_column_dimension[ component_number ];
-        
-        injection := List( object_column_dimension, i -> HomalgZeroMatrix( i, dimension_of_cofactor, homalg_ring ) );
-        
-        injection[ component_number ] := HomalgIdentityMatrix( object_column_dimension[ component_number ], homalg_ring );
-        
-        injection_matrix := UnionOfRows( injection );
-        
-        return PresentationMorphism( objects[ component_number ], injection_matrix, direct_sum_object );
-        
-    end );
-    
-    AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
-                                                         
-      function( cat, diagram, test_object, product_morphism, direct_sum )
-        local components, number_of_components, map_into_product;
-        
-        components := product_morphism;
-        
-        number_of_components := Length( components );
-        
-        map_into_product := UnionOfColumns( List( components, c -> UnderlyingMatrix( c ) ) );
-        
-        return PresentationMorphism( direct_sum, map_into_product, Range( components[ 1 ] ) );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ZERO_OBJECT_LEFT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddZeroObject( category,
-                   
-      function( cat )
-        local matrix;
-        
-        matrix := HomalgZeroMatrix( 0, 0, homalg_ring );
-        
-        return AsLeftPresentation( matrix );
-        
-    end );
-    
-    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( category,
-                                                                   
-      function( cat, object, terminal_object )
-        local nr_columns, morphism;
-        
-        nr_columns := NrColumns( UnderlyingMatrix( object ) );
-        
-        morphism := HomalgZeroMatrix( nr_columns, 0, homalg_ring );
-        
-        return PresentationMorphism( object, morphism, terminal_object );
-        
-    end );
-    
-    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( category,
-                                                                 
-      function( cat, object, initial_object )
-        local nr_columns, morphism;
-        
-        nr_columns := NrColumns( UnderlyingMatrix( object ) );
-        
-        morphism := HomalgZeroMatrix( 0, nr_columns, homalg_ring );
-        
-        return PresentationMorphism( initial_object, morphism, object );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_ZERO_OBJECT_RIGHT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddZeroObject( category,
-                   
-      function( cat )
-        local matrix;
-        
-        matrix := HomalgZeroMatrix( 0, 0, homalg_ring );
-        
-        return AsRightPresentation( matrix );
-        
-    end );
-    
-    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( category,
-                                                                   
-      function( cat, object, terminal_object )
-        local nr_rows, morphism;
-        
-        nr_rows := NrRows( UnderlyingMatrix( object ) );
-        
-        morphism := HomalgZeroMatrix( 0, nr_rows, homalg_ring );
-        
-        return PresentationMorphism( object, morphism, terminal_object );
-        
-    end );
-    
-    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( category,
-                                                                 
-      function( cat, object, initial_object )
-        local nr_rows, morphism;
-        
-        nr_rows := NrRows( UnderlyingMatrix( object ) );
-        
-        morphism := HomalgZeroMatrix( nr_rows, 0, homalg_ring );
-        
-        return PresentationMorphism( initial_object, morphism, object );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_IDENTITY_LEFT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddIdentityMorphism( category,
-                         
-      function( cat, object )
-        local matrix;
-        
-        matrix := HomalgIdentityMatrix( NrColumns( UnderlyingMatrix( object ) ), homalg_ring );
-        
-        return PresentationMorphism( object, matrix, object );
-        
-    end );
-    
-end );
-
-##
-InstallGlobalFunction( ADD_IDENTITY_RIGHT,
-                       
-  function( category )
-    local homalg_ring;
-    
-    homalg_ring := category!.ring_for_representation_category;
-    
-    AddIdentityMorphism( category,
-                         
-      function( cat, object )
-        local matrix;
-        
-        matrix := HomalgIdentityMatrix( NrRows( UnderlyingMatrix( object ) ), homalg_ring );
-        
-        return PresentationMorphism( object, matrix, object );
-        
-    end );
     
 end );
 
@@ -1699,14 +1188,6 @@ InstallGlobalFunction( ADD_COEVALUATION_MORPHISM_RIGHT,
     
 end );
 
-##
-InstallGlobalFunction( ADD_EPIMORPHISM_FROM_SOME_PROJECTIVE_OBJECT, 
-    function( category )
-    
-    AddEpimorphismFromSomeProjectiveObject( category, { cat, obj } -> CoverByFreeModule( obj ) );
-    
-end );
-
 InstallGlobalFunction( ADD_LIFT_AND_COLIFT_LEFT, 
 
   function( category )
@@ -2251,18 +1732,4 @@ InstallGlobalFunction( ADD_LIFT_AND_COLIFT_RIGHT,
     
   end, 1000 );
   
-end );
-
-##
-InstallGlobalFunction( ADD_MULTIPLY_WITH_ELEMENT_OF_COMMUTATIVE_RING_FOR_MORPHISMS_LEFT_AND_RIGHT,
-  
-  function( category )
-    
-    AddMultiplyWithElementOfCommutativeRingForMorphisms( category,
-      { cat, r, phi } -> PresentationMorphism(
-                        Source( phi ),
-                        r * UnderlyingMatrix( phi ),
-                        Range( phi )
-                    ) );
-                    
 end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberColumns( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfRows( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberColumns( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, deduped_1_1, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberColumns( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), NumberColumns( UnderlyingMatrix( b_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberColumns( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfRows( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberColumns( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, deduped_1_1, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberColumns( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), NumberColumns( UnderlyingMatrix( b_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
+        
+########
+function ( cat_1, r_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberColumns( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfRows( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberColumns( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, deduped_1_1, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroRows( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberColumns( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberColumns( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberColumns( UnderlyingMatrix( a_1 ) ), NumberColumns( UnderlyingMatrix( b_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
+        
+########
+function ( cat_1, r_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled.gi
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberRows( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfColumns( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberRows( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( deduped_1_1, 0, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberRows( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( b_1 ) ), NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled.gi
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberRows( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfColumns( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberRows( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( deduped_1_1, 0, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberRows( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( b_1 ) ), NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
+        
+########
+function ( cat_1, r_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled.gi
+++ b/ModulePresentationsForCAP/gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled.gi
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ModulePresentationsForCAP: Category R-pres for CAP
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, UnderlyingMatrix( a_1 ) + UnderlyingMatrix( b_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, - UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelColiftWithGivenCokernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnderlyingMatrix( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCokernelProjection( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := Range( alpha_1 );
+    deduped_2_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_1_1 := NumberRows( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, UnionOfColumns( deduped_4_1, deduped_1_1, [ deduped_2_1, UnderlyingMatrix( alpha_1 ) ] ) ), UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_4_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, DiagMat( UnderlyingRing( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddEpimorphismFromSomeProjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := NumberRows( UnderlyingMatrix( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( deduped_1_1, 0, deduped_2_1 ) ), A_1, UnderlyingMatrix, HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_2_1[logic_new_func_x_2], hoisted_3_1, hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ) + (- UnderlyingMatrix( arg3_1 )), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return UnderlyingMatrix( arg2_1 ) = UnderlyingMatrix( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsZero( DecideZeroColumns( UnderlyingMatrix( arg2_1 ), UnderlyingMatrix( Range( arg2_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := List( objects_1, function ( logic_new_func_x_2 )
+            return NumberRows( UnderlyingMatrix( logic_new_func_x_2 ) );
+        end );
+    deduped_5_1 := deduped_6_1[k_1];
+    hoisted_4_1 := deduped_7_1;
+    hoisted_3_1 := deduped_5_1;
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := HomalgIdentityMatrix( deduped_5_1, deduped_7_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMatrix, UnionOfColumns( deduped_7_1, deduped_5_1, List( [ 1 .. Length( objects_1 ) ], function ( logic_new_func_x_2 )
+                if logic_new_func_x_2 = k_1 then
+                    return hoisted_1_1;
+                else
+                    return HomalgZeroMatrix( hoisted_3_1, hoisted_2_1[logic_new_func_x_2], hoisted_4_1 );
+                fi;
+                return;
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, UnionOfColumns( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( T_1 ) ), 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, UnionOfRows( UnderlyingRing( cat_1 ), NumberRows( UnderlyingMatrix( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMatrix( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMatrix, HomalgZeroMatrix( 0, NumberRows( UnderlyingMatrix( T_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMatrix, HomalgZeroMatrix( NumberRows( UnderlyingMatrix( b_1 ) ), NumberRows( UnderlyingMatrix( a_1 ) ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, UnderlyingMatrix, HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
+        
+########
+function ( cat_1, r_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled", function ( ring )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( ring )
+    return RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring );
+end;
+        
+        
+    
+    cat := category_constructor( ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/ModulePresentationsForCAP/init.g
+++ b/ModulePresentationsForCAP/init.g
@@ -4,16 +4,18 @@
 # Reading the declaration part of the package.
 #
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsForCAP.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsForCAP.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationObject.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationObject.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationMorphism.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationMorphism.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationFunctors.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationFunctors.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationNaturalTransformations.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationNaturalTransformations.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/LiftPresentationTransformation.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/LiftPresentationTransformation.gd" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/Tools.gd");
+ReadPackage( "ModulePresentationsForCAP", "gap/Tools.gd" );
+
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gd" );

--- a/ModulePresentationsForCAP/read.g
+++ b/ModulePresentationsForCAP/read.g
@@ -4,16 +4,30 @@
 # Reading the implementation part of the package.
 #
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsForCAP.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfFieldPrecompiled.gi" );
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfCommutativeRingPrecompiled.gi" );
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/LeftPresentationsAsFreydCategoryOfCategoryOfRowsOfArbitraryRingPrecompiled.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationObject.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfFieldPrecompiled.gi" );
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfCommutativeRingPrecompiled.gi" );
+ReadPackage( "ModulePresentationsForCAP", "gap/precompiled_categories/RightPresentationsAsFreydCategoryOfCategoryOfColumnsOfArbitraryRingPrecompiled.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationMorphism.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsForCAP.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationFunctors.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationObject.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationNaturalTransformations.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationMorphism.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/LiftPresentationTransformation.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationFunctors.gi" );
 
-ReadPackage( "ModulePresentationsForCAP", "gap/Tools.gi");
+ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationNaturalTransformations.gi" );
+
+ReadPackage( "ModulePresentationsForCAP", "gap/LiftPresentationTransformation.gi" );
+
+ReadPackage( "ModulePresentationsForCAP", "gap/Tools.gi" );
+
+if IsPackageMarkedForLoading( "FreydCategoriesForCAP", ">= 2021.12-04" ) then
+    
+    ReadPackage( "ModulePresentationsForCAP", "gap/ModulePresentationsAsFreydCategoryOfCategoryOfRowsOrColumns.gi" );
+    
+fi;


### PR DESCRIPTION
Use those to generate (i.e. precompile) some operations for `Left/RightPresentations`, so we can drop the code in `ModulePresentationsForCAP`, see `ADD_FUNCTIONS_FOR_LEFT_PRESENTATION`. The optional dependency on `FreydCategoriesForCAP` is only needed for precompilation.

Note: I know that `ModulePresentationsForCAP` should be replaced by `FreydCategory` anyway. With this PR we can see and check what is actually missing for achieving this.

@sebastianpos Again, this does not need a review, but your general approval of the overall idea :-)