### PR TITLE
Fix regression of 18bbbf1b in FreydCategory

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.11-03",
+Version := "2021.11-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -841,7 +841,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
             
             return FreydCategoryMorphism( cat, Source( test_morphism ), tau_A, Source( alpha ) );
         
-        end );
+        end, 200 ); # should be as expensive as ColiftAlongEpimorphism, see below
         
         ##
         AddColiftAlongEpimorphism( category,
@@ -859,7 +859,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY,
             
             return FreydCategoryMorphism( cat, Range( alpha ), PreCompose( underlying_category, sigma_A, MorphismDatum( cat, test_morphism ) ), Range( test_morphism ) );
         
-        end );
+        end, 200 ); # must be more expensive than CokernelColiftWithGivenCokernelObject but cheaper than Colift
         
     fi;
     


### PR DESCRIPTION
by better reflecting the weight of LiftAlongMonomorphism and
ColiftAlongEpimorphism in FreydCategory. Without this, after 18bbbf1b,
CokernelColift is derived via ColiftAlongEpimorphism instead of
CokernelColiftWithGivenCokernelObject because this derivation seems
cheaper.