### PR TITLE
Add CategoryOfRowsAsAdditiveClosureOfRingAsCategory and use precompiled code by default in CategoryofRows (in a special case)

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2021.11-06",
+Version := "2021.11-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/PrecompileCategoryOfColumnsAsOppositeOfCategoryOfRows.g
+++ b/CompilerForCAP/examples/PrecompileCategoryOfColumnsAsOppositeOfCategoryOfRows.g
@@ -9,7 +9,7 @@ LoadPackage( "FreydCategoriesForCAP", false );
 
 QQ := HomalgFieldOfRationalsInSingular( );;
 QQxy := QQ * "x,y";;
-EEE := KoszulDualRing( QQxy );;
+EEE := KoszulDualRing( QQxy * "a,b" );;
 
 precompile_CategoryOfColumns := function( homalg_ring, name )
     

--- a/CompilerForCAP/examples/PrecompileCategoryOfRowsAsAdditiveClosureOfRingAsCategory.g
+++ b/CompilerForCAP/examples/PrecompileCategoryOfRowsAsAdditiveClosureOfRingAsCategory.g
@@ -1,0 +1,109 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "FreydCategoriesForCAP", false );
+#! true
+ReadPackage( "FreydCategoriesForCAP",
+    "gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi");
+#! true
+
+# We only compile one very special case:
+# The homomorphism structure for homalg exterior rings over fields.
+
+QQ := HomalgFieldOfRationalsInSingular( );;
+QQxy := QQ * "x,y";;
+EEE := KoszulDualRing( QQxy );;
+
+# We need special JIT arguments, so we have to compile manually and
+# hack the result into the category_constructor.
+
+rows := CategoryOfRowsAsAdditiveClosureOfRingAsCategory( EEE );;
+
+dist_object := DistinguishedObjectOfHomomorphismStructure( rows );;
+o := CategoryOfRowsObject( rows, 1 );;
+id_o := IdentityMorphism( o );;
+H_o_o := HomomorphismStructureOnObjects( o, o );;
+nu_id_o :=
+  InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure(
+    id_o
+);;
+
+function_name1 := "HomomorphismStructureOnMorphismsWithGivenObjects";;
+Length( rows!.added_functions.(function_name1) );
+#! 1
+compiled_tree1 := CapJitCompiledFunctionAsEnhancedSyntaxTree(
+    rows!.added_functions.(function_name1)[1][1],
+    [ rows, H_o_o, id_o, id_o, H_o_o ]
+);;
+
+function_name2 := Concatenation(
+    "InterpretMorphismAsMorphismFromDistinguishedObject",
+    "ToHomomorphismStructureWithGivenObjects"
+);;
+Length( rows!.added_functions.(function_name2) );
+#! 1
+compiled_tree2 := CapJitCompiledFunctionAsEnhancedSyntaxTree(
+    rows!.added_functions.(function_name2)[1][1],
+    [ rows, dist_object, id_o, H_o_o ]
+);;
+
+function_name3 :=
+  "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism";;
+Length( rows!.added_functions.(function_name3) );
+#! 1
+compiled_tree3 := CapJitCompiledFunctionAsEnhancedSyntaxTree(
+    rows!.added_functions.(function_name3)[1][1],
+    [ rows, o, o, nu_id_o ]
+);;
+
+function_names := [ function_name1, function_name2, function_name3 ];;
+compiled_trees := [ compiled_tree1, compiled_tree2, compiled_tree3 ];;
+
+CATEGORY_OF_ROWS_HACKY_EXTENDER := function ( rows )
+    Perform( [ 1 .. Length( function_names ) ], function( i )
+        rows!.compiled_functions_trees.(function_names[i])[1] :=
+            compiled_trees[i]; end ); end;;
+
+# we have to work hard to not write semicolons so AutoDoc
+# does not begin a new statement
+category_constructor := EvalString( ReplacedString( """function( homalg_ring )
+  local rows@
+    
+    rows := CategoryOfRowsAsAdditiveClosureOfRingAsCategory( homalg_ring )@
+    
+    if IsBoundGlobal( "CATEGORY_OF_ROWS_HACKY_EXTENDER" ) then
+        
+        ValueGlobal( "CATEGORY_OF_ROWS_HACKY_EXTENDER" )( rows )@
+        
+    fi@
+    
+    return rows@
+    
+end""", "@", ";" ) );;
+
+given_arguments := [ EEE ];;
+package_name := "FreydCategoriesForCAP";;
+compiled_category_name := Concatenation(
+    "CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOf",
+    "HomalgExteriorRingOverFieldPrecompiled"
+);;
+operations := [
+    "DistinguishedObjectOfHomomorphismStructure",
+    "HomomorphismStructureOnObjects",
+    function_name1,
+    function_name2,
+    function_name3,
+];;
+
+CapJitPrecompileCategoryAndCompareResult(
+    category_constructor,
+    given_arguments,
+    package_name,
+    compiled_category_name :
+    operations := operations
+);
+
+#! @EndExample

--- a/CompilerForCAP/examples/PrecompileCategoryOfRowsAsAdditiveClosureOfRingAsCategory.g
+++ b/CompilerForCAP/examples/PrecompileCategoryOfRowsAsAdditiveClosureOfRingAsCategory.g
@@ -106,4 +106,9 @@ CapJitPrecompileCategoryAndCompareResult(
     operations := operations
 );
 
+# check that the compiled code is loaded automatically
+cat := CategoryOfRows( EEE );;
+CanCompute( cat, "HomomorphismStructureOnMorphismsWithGivenObjects" );
+#! true
+
 #! @EndExample

--- a/CompilerForCAP/gap/CompilerHints.gi
+++ b/CompilerForCAP/gap/CompilerHints.gi
@@ -219,18 +219,6 @@ InstallGlobalFunction( CapJitReplacedGlobalVariablesByCategoryAttributes, functi
         
         # add some attributes by default
         
-        if HasObjectType( category ) then
-            
-            Add( attribute_names, "ObjectType" );
-            
-        fi;
-        
-        if HasMorphismType( category ) then
-            
-            Add( attribute_names, "MorphismType" );
-            
-        fi;
-        
         if HasRangeCategoryOfHomomorphismStructure( category ) then
             
             Add( attribute_names, "RangeCategoryOfHomomorphismStructure" );

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -261,18 +261,6 @@ CapJitAddLogicTemplate(
     )
 );
 
-# MatElm( List( list, func ), index1, index2 ) => List( list, func )[ index1 ][ index2 ]
-# We only apply this if the first argument of `MatElm` is a call to `List` to make sure
-# we actually have a list (this can be changes once we have a proper type system).
-CapJitAddLogicTemplate(
-    rec(
-        variable_names := [ "list", "func", "index1", "index2" ],
-        src_template := "MatElm( List( list, func ), index1, index2 )",
-        dst_template := "List( list, func )[ index1 ][ index2 ]",
-        returns_value := true,
-    )
-);
-
 # List( L{poss}, f ) => List( L, f ){poss}
 CapJitAddLogicTemplate(
     rec(

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gd
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gd
@@ -9,9 +9,8 @@
 
 #! @Description
 #!   Resolves global variables (except those which are listed in `CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES`):
-#!   * Replaces a global variable referencing an integer, a string, or a boolean by EXPR_INT, EXPR_STRING, EXPR_TRUE or EXPR_FALSE.
 #!   * Replaces a global variable referencing a plain function by the syntax tree of this function in case the function is annotated with the pragma `CAP_JIT_RESOLVE_FUNCTION`.
-#!   * Replaces a record access of a global function by the value of this record access.
+#!   * Computes attributes of categories stored in global variables and places the results into global variables again.
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitResolvedGlobalVariables" );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -18,159 +18,69 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
     Info( InfoCapJit, 1, "Resolving global variables." );
     
     pre_func := function ( tree, additional_arguments )
-      local funccall_does_not_return_fail, is_attribute_or_component_of_category, value, inline_tree, name, global_variable_name;
-        
-        funccall_does_not_return_fail := false;
-        is_attribute_or_component_of_category := false;
+      local value, resolved_tree, name, attr, cat, global_variable_name;
         
         if not (IsBound( tree.CAP_JIT_NOT_RESOLVABLE ) and tree.CAP_JIT_NOT_RESOLVABLE) then
             
+            # try to resolve global functions
             if tree.type = "EXPR_REF_GVAR" and not tree.gvar in CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES then
                 
                 value := ValueGlobal( tree.gvar );
                 
-                # will only be used if <value> is a function
-                funccall_does_not_return_fail := IsBound( tree.does_not_return_fail ) and tree.does_not_return_fail = true;
-                
-            elif tree.type = "EXPR_ELM_COMOBJ_NAME" and tree.comobj.type = "EXPR_REF_GVAR" and not tree.comobj.gvar in CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES then
-                
-                value := ValueGlobal( tree.comobj.gvar )!.(tree.name);
-                
-                if IsCapCategory( ValueGlobal( tree.comobj.gvar ) ) then
-                    
-                    is_attribute_or_component_of_category := true;
-                    
-                fi;
-                
-            elif tree.type = "EXPR_ELM_REC_NAME" and tree.record.type = "EXPR_REF_GVAR" and not tree.record.gvar in CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES then
-                
-                value := ValueGlobal( tree.record.gvar ).(tree.name);
-                
-            elif tree.type = "EXPR_FUNCCALL" and tree.funcref.type = "EXPR_REF_GVAR" and ForAll( tree.args, a -> a.type in [ "EXPR_REF_GVAR", "EXPR_INT", "EXPR_STRING", "EXPR_TRUE", "EXPR_FALSE" ] ) and not NameFunction( ValueGlobal( tree.funcref.gvar ) ) in Concatenation( CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES, RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ), RecNames( CAP_JIT_INTERNAL_KNOWN_METHODS ) ) then
-                
-                value := CallFuncList( ValueGlobal( tree.funcref.gvar ), AsListMut( List( tree.args, function ( a )
-                    
-                    if a.type = "EXPR_REF_GVAR" then
-                        
-                        return ValueGlobal( a.gvar );
-                        
-                    elif a.type = "EXPR_INT" or a.type = "EXPR_STRING" then
-                        
-                        return a.value;
-                        
-                    elif a.type = "EXPR_TRUE" then
-                        
-                        return true;
-                        
-                    elif a.type = "EXPR_FALSE" then
-                        
-                        return false;
-                        
-                    else
-                        
-                        # COVERAGE_IGNORE_NEXT_LINE
-                        Error( "this should never happen" );
-                        
-                    fi;
-                
-                end ) ) );
-                
-                if tree.args.length = 1 and tree.args.1.type = "EXPR_REF_GVAR" and IsCapCategory( ValueGlobal( tree.args.1.gvar ) ) then
-                    
-                    is_attribute_or_component_of_category := true;
-                    
-                fi;
-                
-            fi;
-            
-            if IsBound( value ) then
-                
-                if IsInt( value ) then
-                    
-                    return rec(
-                        type := "EXPR_INT",
-                        value := value,
-                    );
-                    
-                elif IsString( value ) then
-                    
-                    return rec(
-                        type := "EXPR_STRING",
-                        value := value,
-                    );
-                
-                elif value = true then
-                    
-                    return rec(
-                        type := "EXPR_TRUE",
-                    );
-                
-                elif value = false then
-                    
-                    return rec(
-                        type := "EXPR_FALSE",
-                    );
-                
-                elif IsFunction( value ) then
+                if IsFunction( value ) then
                     
                     if not IsKernelFunction( value ) and not IsOperation( value ) then
                         
-                        inline_tree := ENHANCED_SYNTAX_TREE( value : globalize_hvars := true, only_if_CAP_JIT_RESOLVE_FUNCTION := true );
+                        resolved_tree := ENHANCED_SYNTAX_TREE( value : globalize_hvars := true, only_if_CAP_JIT_RESOLVE_FUNCTION := true );
                         
-                        if inline_tree <> fail then
+                        if resolved_tree <> fail then
                             
-                            if funccall_does_not_return_fail then
+                            if IsBound( tree.does_not_return_fail ) and tree.does_not_return_fail = true then
                                 
-                                inline_tree := CapJitRemovedReturnFail( inline_tree );
+                                resolved_tree := CapJitRemovedReturnFail( resolved_tree );
                                 
                             fi;
                             
-                            return inline_tree;
+                            return resolved_tree;
                             
                         fi;
                         
                     fi;
                     
+                    # normalize to the "official" name
                     name := NameFunction( value );
                     
-                    if IsBoundGlobal( name ) and IsIdenticalObj( value, ValueGlobal( name ) ) then
+                    if name <> tree.gvar and IsBoundGlobal( name ) and IsIdenticalObj( value, ValueGlobal( name ) ) then
                         
-                        tree := rec(
-                            type := "EXPR_REF_GVAR",
-                            gvar := name,
-                        );
+                        tree := ShallowCopy( tree );
                         
-                        if funccall_does_not_return_fail then
-                            
-                            tree.does_not_return_fail := true;
-                            
-                        fi;
+                        tree.gvar := name;
+                        tree.CAP_JIT_NOT_RESOLVABLE := true;
+                        
+                        return tree;
                         
                     fi;
                     
                 fi;
                 
-                # could not resolve to another value
-                # store attributes or components of categories in a new global variable (because those can be turned back into code using compiler hints)
-                if is_attribute_or_component_of_category then
-                    
-                    global_variable_name := CapJitGetOrCreateGlobalVariable( value );
-                    
-                    return rec(
-                        type := "EXPR_REF_GVAR",
-                        gvar := global_variable_name,
-                        CAP_JIT_NOT_RESOLVABLE := true,
-                    );
-                    
-                else
-                    
-                    tree := ShallowCopy( tree );
-                    
-                    tree.CAP_JIT_NOT_RESOLVABLE := true;
-                    
-                    return tree;
-                    
-                fi;
+                # do not consider this tree again
+                tree := ShallowCopy( tree );
+                
+                tree.CAP_JIT_NOT_RESOLVABLE := true;
+                
+                return tree;
+                
+            # resolve category attributes
+            elif CapJitIsCallToGlobalFunction( tree, gvar -> not NameFunction( ValueGlobal( gvar ) ) in Concatenation( CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES, RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ), RecNames( CAP_JIT_INTERNAL_KNOWN_METHODS ) ) ) and tree.args.length = 1 and tree.args.1.type = "EXPR_REF_GVAR" and IsCapCategory( ValueGlobal( tree.args.1.gvar ) ) then
+                
+                value := ValueGlobal( tree.funcref.gvar )( ValueGlobal( tree.args.1.gvar ) );
+                
+                global_variable_name := CapJitGetOrCreateGlobalVariable( value );
+                
+                return rec(
+                    type := "EXPR_REF_GVAR",
+                    gvar := global_variable_name,
+                );
                 
             fi;
             

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.11-06",
+Version := "2021.11-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/examples/AdditiveClosure.g
+++ b/FreydCategoriesForCAP/examples/AdditiveClosure.g
@@ -8,28 +8,28 @@ LoadPackage( "FreydCategoriesForCAP" );;
 QQ := HomalgFieldOfRationalsInSingular();;
 
 R := QQ * "x,y,z";;
-CR := RingAsCategory( R );;
-CRplus := AdditiveClosure( CR );;
+rows := CategoryOfRowsAsAdditiveClosureOfRingAsCategory( R );;
+CR := UnderlyingCategory( UnderlyingCategory( rows ) );;
 
 M := HomalgMatrix( "[[x^2,4*y]]", 1, 2, R );;
 N := HomalgMatrix( "[[1,3*x], [2*y^3,5*y]]", 2, 2, R );;
 P := M * N;;
 
-o := AsAdditiveClosureObject( RingAsCategoryUniqueObject( CR ) );;
+o := ObjectConstructor( rows, AsAdditiveClosureObject( RingAsCategoryUniqueObject( CR ) ) );;
 
 A := o;;
 B := DirectSum( o, o );;
 
-alpha := AdditiveClosureMorphism( A, M, B );;
+alpha := CategoryOfRowsMorphism( rows, A, M, B );;
 IsWellDefined( alpha );
 #! true
-beta := AdditiveClosureMorphism( B, N, B );;
+beta := CategoryOfRowsMorphism( rows, B, N, B );;
 IsWellDefined( beta );
 #! true
 gamma := PreCompose( alpha, beta );;
 IsWellDefined( gamma );
 #! true
-MorphismMatrix( gamma ) = P;
+UnderlyingMatrix( gamma ) = P;
 #! true
 delta := Lift( gamma, beta );;
 IsWellDefined( delta );
@@ -40,28 +40,28 @@ IsCongruentForMorphisms( gamma, PreCompose( delta, beta ) );
 
 # E and EE are both occupied by GAP
 EEE := KoszulDualRing( R );;
-CEEE := RingAsCategory( EEE );;
-CEEEplus := AdditiveClosure( CEEE );;
+rows := CategoryOfRowsAsAdditiveClosureOfRingAsCategory( EEE );;
+CEEE := UnderlyingCategory( UnderlyingCategory( rows ) );;
 
 M := HomalgMatrix( "[[e0*e1,3*e0]]", 1, 2, EEE );;
 N := HomalgMatrix( "[[1,e0*e2], [2*e0*e1*e2,5*e2]]", 2, 2, EEE );;
 P := M * N;;
 
-o := AsAdditiveClosureObject( RingAsCategoryUniqueObject( CEEE ) );;
+o := ObjectConstructor( rows, AsAdditiveClosureObject( RingAsCategoryUniqueObject( CEEE ) ) );;
 
 A := o;;
 B := DirectSum( o, o );;
 
-alpha := AdditiveClosureMorphism( A, M, B );;
+alpha := CategoryOfRowsMorphism( rows, A, M, B );;
 IsWellDefined( alpha );
 #! true
-beta := AdditiveClosureMorphism( B, N, B );;
+beta := CategoryOfRowsMorphism( rows, B, N, B );;
 IsWellDefined( beta );
 #! true
 gamma := PreCompose( alpha, beta );;
 IsWellDefined( gamma );
 #! true
-MorphismMatrix( gamma ) = P;
+UnderlyingMatrix( gamma ) = P;
 #! true
 delta := Lift( gamma, beta );;
 IsWellDefined( delta );

--- a/FreydCategoriesForCAP/examples/generate_documentation.g
+++ b/FreydCategoriesForCAP/examples/generate_documentation.g
@@ -9,7 +9,7 @@ LoadPackage( "FreydCategoriesForCAP", false );
 
 QQ := HomalgFieldOfRationalsInSingular( );;
 QQxy := QQ * "x,y";;
-EEE := KoszulDualRing( QQxy );;
+EEE := KoszulDualRing( QQxy * "a,b" );;
 
 CAP_INTERNAL_GENERATE_DOCUMENTATION_FOR_CATEGORY_INSTANCES(
     [

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -43,12 +43,6 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE" );
 
 #! @Description
 #! The argument is an Ab-category $C$. The output is its additive closure $C^\oplus$.
-#! 
-#! If <A>C</A> is a &homalg; ring considered as a category via `RingAsCategory`,
-#! &homalg; matrices are used as the underlying data structure for morphisms.
-#! In all other cases, lists of lists are used as the underlying data structure for morphisms.
-#! This can be changed via the two options `matrix_element_as_morphism` and `list_list_as_matrix`, see
-#! <Ref Func="AdditiveClosureMorphism" Label="for IsAdditiveClosureObject, IsObject, IsAdditiveClosureObject" /> for details.
 #! @Arguments C
 #! @Returns the category $C^\oplus$
 DeclareAttribute( "AdditiveClosure",
@@ -71,29 +65,14 @@ DeclareAttribute( "AsAdditiveClosureObject",
 
 #! @Description
 #! The arguments are formal direct sums $A=A_1\oplus\dots\oplus A_m$, $B=B_1\oplus\dots\oplus B_n$ in some additive category $C^\oplus$
-#! and an $m\times n$ matrix (see below) $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
+#! and an $m\times n$ matrix $M :=(\alpha_{ij}:A_i\to B_j)_{ij}$ for $i=1,\dots,m,j=1,\dots,n$.
 #! The output is the formal morphism between $A$ and $B$ that is defined by $M$.
-#! 
-#! If $m \neq 0 \neq n$, <A>M</A> has to provide access to its elements via the operation `[,]`. In case that the elements of <A>M</A> first have to be wrapped
-#! to actually obtain morphisms in $C$, you can provide the function `matrix_element_as_morphism` (fallback: `IdFunc`) as an option to
-#! <Ref Attr="AdditiveClosure" Label="for IsCapCategory" /> which will internally be automatically applied to the elements of <A>M</A>.
-#! In this case you also have to provide the function `list_list_as_matrix` (fallback: `ReturnFirst`) as an option to
-#! <Ref Attr="AdditiveClosure" Label="for IsCapCategory" />: It gets passed a list of list of morphisms $\alpha_{ij}$ as well as $m$ and $n$
-#! as above and has to return the corresponding matrix <A>M</A>.
-#! If `IsMatrixObj( <A>M</A> )`, then `NrRows( M )` resp. `NrCols( M )` must be $m$ resp. $n$.
-#! 
-#! The fallback values of `matrix_element_as_morphism` and `list_list_as_matrix` allow to use lists of lists as the data structure of <A>M</A>.
-#! See <Ref Attr="AdditiveClosure" Label="for IsCapCategory" /> for the default data structures.
 #! @Arguments A, M, B
 #! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
 DeclareOperation( "AdditiveClosureMorphism",
-                  [ IsAdditiveClosureObject, IsObject, IsAdditiveClosureObject ] );
+                  [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
 
-#! @Description
-#! Input and return value are the same as for `AdditiveClosureMorphism` except that the matrix `M`
-#! can be given as a list (of lists) <A>L</A> to which `list_list_as_matrix` will be applied automatically.
-#! @Arguments A, L, B
-#! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
+# deprecated
 DeclareOperation( "AdditiveClosureMorphismListList",
                   [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -120,9 +120,9 @@ InstallMethod( AsAdditiveClosureObject,
 end );
 
 ##
-InstallMethodWithCache( AdditiveClosureObject,
-                        [ IsList, IsAdditiveClosureCategory ],
-               
+InstallMethodForCompilerForCAP( AdditiveClosureObject,
+                                [ IsList, IsAdditiveClosureCategory ],
+                                
   function( list_of_objects, category )
     
     return ObjectifyObjectForCAPWithAttributes(
@@ -147,11 +147,16 @@ InstallMethod( AsAdditiveClosureMorphism,
 end );
 
 ##
-InstallMethod( AdditiveClosureMorphism,
-               [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ],
-               
+InstallMethodForCompilerForCAP( AdditiveClosureMorphism,
+                                [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ],
+                                
   function( source, listlist, range )
     local category;
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, Length( listlist ) = Length( ObjectList( source ) ) );
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, ForAll( listlist, row -> Length( row ) = Length( ObjectList( range ) ) ) );
     
     category := CapCategory( source );
 
@@ -481,7 +486,7 @@ InstallMethod( \[\,\],
         
     fi;
     
-    return MorphismMatrix( morphism )[i, j];
+    return MorphismMatrix( morphism )[i][j];
     
 end );
 
@@ -515,15 +520,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
     local compare_morphisms, underlying_category, range_category;
     
     underlying_category := UnderlyingCategory( category );
-    
-    ##
-    AddIsEqualForCacheForObjects( category,
-      { cat, obj1, obj2 } -> IsIdenticalObj( obj1, obj2 ) );
-    
-    ##
-    AddIsEqualForCacheForMorphisms( category,
-      { cat, mor1, mor2 } -> IsIdenticalObj( mor1, mor2 ) );
-
     
     ## Well-defined for objects and morphisms
     ##
@@ -780,6 +776,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                                         Range( morphism ) );
         
     end );
+    
     ##
     AddZeroObject( category,
       function( cat )
@@ -958,8 +955,8 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                         )
                     );
                 
-                source_direct_sums := List( [ 1 .. size_j ], j -> DirectSum( range_category, List( [ 1 .. size_s ], s -> H_B_C[j, s] ) ) );
-                range_direct_sums := List( [ 1 .. size_i ], i -> DirectSum( range_category, List( [ 1 .. size_t ], t -> H_A_D[i, t] ) ) );
+                source_direct_sums := List( [ 1 .. size_j ], j -> DirectSum( range_category, List( [ 1 .. size_s ], s -> H_B_C[j][s] ) ) );
+                range_direct_sums := List( [ 1 .. size_i ], i -> DirectSum( range_category, List( [ 1 .. size_t ], t -> H_A_D[i][t] ) ) );
                 
                 return MorphismBetweenDirectSumsWithGivenDirectSums(
                     range_category,
@@ -970,13 +967,13 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                             MorphismBetweenDirectSumsWithGivenDirectSums(
                                 range_category,
                                 source_direct_sums[j],
-                                List( [ 1 .. size_s ], s -> H_B_C[j, s] ),
+                                List( [ 1 .. size_s ], s -> H_B_C[j][s] ),
                                 List( [ 1 .. size_s ], s ->
                                     List( [ 1 .. size_t ], t ->
-                                        HomomorphismStructureOnMorphismsWithGivenObjects( UnderlyingCategory( cat ), H_B_C[j, s], alpha[i, j], beta[s, t], H_A_D[i, t] )
+                                        HomomorphismStructureOnMorphismsWithGivenObjects( UnderlyingCategory( cat ), H_B_C[j][s], alpha[i, j], beta[s, t], H_A_D[i][t] )
                                     )
                                 ),
-                                List( [ 1 .. size_t ], t -> H_A_D[i, t] ),
+                                List( [ 1 .. size_t ], t -> H_A_D[i][t] ),
                                 range_direct_sums[i]
                             )
                         )
@@ -1064,7 +1061,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                         )
                     );
                 
-                direct_sums := List( [ 1 .. size_j ], j -> DirectSum( range_category, List( [ 1 .. size_s ], s -> H_B_C[j, s] ) ) );
+                direct_sums := List( [ 1 .. size_j ], j -> DirectSum( range_category, List( [ 1 .. size_s ], s -> H_B_C[j][s] ) ) );
                 
                 return UniversalMorphismIntoDirectSumWithGivenDirectSum(
                     range_category,
@@ -1072,7 +1069,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                     distinguished_object,
                     List( [ 1 .. size_j ], j ->
                         UniversalMorphismIntoDirectSumWithGivenDirectSum( range_category,
-                            List( [ 1 .. size_s ], s -> H_B_C[j, s] ),
+                            List( [ 1 .. size_s ], s -> H_B_C[j][s] ),
                             distinguished_object,
                             List( [ 1 .. size_s ], s ->
                                 InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( UnderlyingCategory( cat ), alpha[j, s] )
@@ -1106,12 +1103,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
                 size_i := Length( obj_list_A );
                 
                 size_j := Length( obj_list_B );
-                
-                if size_i = 0 or size_j = 0 then
-                    
-                    return ZeroMorphism( cat, A, B );
-                    
-                fi;
                 
                 summands := 
                   Concatenation(

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gd
@@ -65,6 +65,15 @@ KeyDependentOperation( "StandardRowMorphism",
 DeclareAttribute( "UnderlyingRing",
                   IsCategoryOfRows );
 
+DeclareAttribute( "GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure",
+                  IsCategoryOfRows );
+
+DeclareAttribute( "ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure",
+                  IsCategoryOfRows );
+
+DeclareAttribute( "RingInclusionForHomomorphismStructure",
+                  IsCategoryOfRows );
+
 DeclareAttribute( "RankOfObject",
                   IsCategoryOfRowsObject );
 

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -100,7 +100,14 @@ InstallMethodForCompilerForCAP( CategoryOfRowsObjectOp,
                
   function( category, rank )
     
-    return ObjectConstructor( category, rank );
+    if not IsInt( rank ) or rank < 0 then
+        
+        Error( "the object datum must be a non-negative integer" );
+        
+    fi;
+    
+    return ObjectifyObjectForCAPWithAttributes( rec( ), category,
+                                                RankOfObject, rank );
     
 end );
 
@@ -135,7 +142,35 @@ InstallOtherMethodForCompilerForCAP( CategoryOfRowsMorphism,
                                      
   function( cat, source, homalg_matrix, range )
     
-    return MorphismConstructor( cat, source, homalg_matrix, range );
+    if not IsHomalgMatrix( homalg_matrix ) then
+        
+        Error( "the morphism datum must be a homalg matrix" );
+        
+    fi;
+    
+    if not IsIdenticalObj( HomalgRing( homalg_matrix ), UnderlyingRing( cat ) ) then
+        
+        Error( "the matrix is defined over a different ring than the category" );
+        
+    fi;
+    
+    if NrRows( homalg_matrix ) <> RankOfObject( source ) then
+        
+        Error( "the number of rows has to be equal to the rank of the source" );
+        
+    fi;
+    
+    if NrColumns( homalg_matrix ) <> RankOfObject( range ) then
+        
+        Error( "the number of columns has to be equal to the rank of the range" );
+        
+    fi;
+    
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat,
+                                           source,
+                                           range,
+                                           UnderlyingMatrix, homalg_matrix
+    );
     
 end );
 
@@ -320,13 +355,13 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         
         if NrRows( homalg_matrix ) <> ObjectDatum( cat, source ) then
             
-            Error( "the number of rows has to be equal to the dimension of the source" );
+            Error( "the number of rows has to be equal to the rank of the source" );
             
         fi;
         
         if NrColumns( homalg_matrix ) <> ObjectDatum( cat, range ) then
             
-            Error( "the number of columns has to be equal to the dimension of the range" );
+            Error( "the number of columns has to be equal to the rank of the range" );
             
         fi;
         
@@ -542,11 +577,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
     ##
     AddDirectSum( category,
       function( cat, object_list )
-      local dimension;
+      local rank;
       
-      dimension := Sum( List( object_list, object -> RankOfObject( object ) ) );
+      rank := Sum( List( object_list, object -> RankOfObject( object ) ) );
       
-      return CategoryOfRowsObject( cat, dimension );
+      return CategoryOfRowsObject( cat, rank );
       
     end );
     

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gd
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Declarations
+#
+#! @Chapter Category of rows
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareOperation( "CategoryOfRowsAsAdditiveClosureOfRingAsCategory",
+                  [ IsHomalgRing ] );

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Implementations
+#
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
+               [ IsHomalgRing ],
+               
+  function( homalg_ring )
+    local ring_as_category, add, object_constructor, object_datum, morphism_constructor, morphism_datum, category_object_filter, wrapper;
+    
+    ring_as_category := RingAsCategory( homalg_ring : FinalizeCategory := true );
+    
+    add := AdditiveClosure( ring_as_category : FinalizeCategory := true );
+    
+    object_constructor := function ( cat, object_datum )
+        
+        return CategoryOfRowsObject( cat, Length( ObjectList( object_datum ) ) );
+        
+    end;
+    
+    object_datum := function ( cat, object )
+      local add, ring_as_category, unique_object;
+        
+        add := UnderlyingCategory( cat );
+        ring_as_category := UnderlyingCategory( add );
+        
+        unique_object := RingAsCategoryUniqueObject( ring_as_category );
+        
+        return AdditiveClosureObject( ListWithIdenticalEntries( RankOfObject( object ), unique_object ), add );
+        
+    end;
+    
+    morphism_constructor := function ( cat, source, morphism_datum, range )
+      local matrix_entries, homalg_matrix;
+        
+        matrix_entries := List( MorphismMatrix( morphism_datum ),
+            row -> List( row,
+                c -> UnderlyingRingElement( c )
+            )
+        );
+        
+        homalg_matrix := HomalgMatrix( matrix_entries, RankOfObject( source ), RankOfObject( range ), UnderlyingRing( cat ) );
+        
+        return CategoryOfRowsMorphism( cat, source, homalg_matrix, range );
+        
+    end;
+    
+    morphism_datum := function ( cat, morphism )
+      local add, ring_as_category, unique_object, nr_rows, nr_cols, source, range, matrix_entries, listlist;
+        
+        add := UnderlyingCategory( cat );
+        ring_as_category := UnderlyingCategory( add );
+        
+        unique_object := RingAsCategoryUniqueObject( ring_as_category );
+        
+        nr_rows := NrRows( UnderlyingMatrix( morphism ) );
+        nr_cols := NrCols( UnderlyingMatrix( morphism ) );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, RankOfObject( Source( morphism ) ) = nr_rows );
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, RankOfObject( Range( morphism ) ) = nr_cols );
+        
+        source := AdditiveClosureObject( ListWithIdenticalEntries( nr_rows, unique_object ), add );
+        range := AdditiveClosureObject( ListWithIdenticalEntries( nr_cols, unique_object ), add );
+        
+        matrix_entries := EntriesOfHomalgMatrixAsListList( UnderlyingMatrix( morphism ) );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, Length( matrix_entries ) = nr_rows );
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, ForAll( matrix_entries, row -> Length( row ) = nr_cols ) );
+        
+        listlist := List( matrix_entries,
+            row -> List( row,
+                c -> RingAsCategoryMorphism( ring_as_category, c )
+            )
+        );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, Length( listlist ) = Length( ObjectList( source ) ) );
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, ForAll( listlist, row -> Length( row ) = Length( ObjectList( range ) ) ) );
+        
+        return AdditiveClosureMorphism( source, listlist, range );
+        
+    end;
+    
+    if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring ) then
+        
+        category_object_filter := IsCategoryOfRowsObject and HasIsProjective and IsProjective;
+        
+    else
+        
+        category_object_filter := IsCategoryOfRowsObject;
+        
+    fi;
+    
+    wrapper := WrapperCategory( add, rec(
+        name := Concatenation( "Rows( ", RingName( homalg_ring )," )" ),
+        category_filter := IsCategoryOfRows,
+        category_object_filter := category_object_filter,
+        category_morphism_filter := IsCategoryOfRowsMorphism and HasUnderlyingMatrix,
+        object_constructor := object_constructor,
+        object_datum := object_datum,
+        morphism_constructor := morphism_constructor,
+        morphism_datum := morphism_datum,
+        only_primitive_operations := true,
+    ) : FinalizeCategory := false );
+    
+    SetUnderlyingRing( wrapper, homalg_ring );
+    
+    wrapper!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingRing",
+        ],
+        source_and_range_attributes_from_morphism_attribute := rec(
+            object_attribute_name := "RankOfObject",
+            morphism_attribute_name := "UnderlyingMatrix",
+            source_attribute_getter_name := "NrRows",
+            range_attribute_getter_name := "NrColumns",
+        ),
+    );
+    
+    if HasRangeCategoryOfHomomorphismStructure( ring_as_category ) then
+        
+        SetGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( wrapper, GeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure( ring_as_category ) );
+        SetColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( wrapper, ColumnVectorOfGeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure( ring_as_category ) );
+        SetRingInclusionForHomomorphismStructure( wrapper, RingInclusionForHomomorphismStructure( ring_as_category ) );
+        
+        Add( wrapper!.compiler_hints.category_attribute_names, "GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure" );
+        Add( wrapper!.compiler_hints.category_attribute_names, "ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure" );
+        Add( wrapper!.compiler_hints.category_attribute_names, "RingInclusionForHomomorphismStructure" );
+        
+    fi;
+    
+    if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then
+        
+        SetIsSkeletalCategory( wrapper, true );
+        
+    fi;
+    
+    if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring ) then
+        
+        SetIsAbelianCategory( wrapper, true );
+        
+    fi;
+    
+    Finalize( wrapper );
+    
+    return wrapper;
+    
+end );

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
@@ -1,0 +1,317 @@
+CapJitAddLogicFunction( function( tree, jit_args )
+  local pre_func, additional_arguments_func;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Apply logic for HomalgMatrix." );
+    
+    pre_func := function( tree, func_stack )
+      local args, list, func_id, ring_element, condition_func, right;
+        
+        # find HomalgMatrix( ... )
+        if CapJitIsCallToGlobalFunction( tree, "HomalgMatrix" ) then
+            
+            args := tree.args;
+
+            # check if ... = [ [ ... ], ... ]
+            if args.1.type = "EXPR_LIST" then
+                
+                list := args.1.list;
+                
+                func_id := Last( func_stack).id;
+                
+                # check if all elements of the matrix are multiplied by the same ring element from the left
+                if list.length > 0 and ForAll( list, l -> l.type = "EXPR_PROD" and l.left = list.1.left ) then
+                    
+                    ring_element := list.1.left;
+                    
+                    # check if ring_element is independent of local variables
+                    condition_func := function( tree, path )
+                        
+                        if PositionSublist( tree.type, "FVAR" ) <> fail and tree.func_id = func_id then
+                            
+                            return true;
+                            
+                        fi;
+                        
+                        return false;
+                        
+                    end;
+                    
+                    if CapJitFindNodeDeep( ring_element, condition_func ) = fail then
+                        
+                        tree := rec(
+                            type := "EXPR_PROD",
+                            left := ring_element,
+                            right := StructuralCopy( tree ),
+                        );
+                        
+                        tree.right.args.1.list := List( list, l -> l.right );
+
+                        return tree;
+                        
+                    fi;
+                    
+                fi;
+                
+                # check if all elements of the matrix are multiplied by the same ring element from the right
+                if list.length > 0 and ForAll( list, l -> l.type = "EXPR_PROD" and l.right = list.1.right ) then
+                    
+                    ring_element := list.1.right;
+                    
+                    # check if ring_element is independent of local variables
+                    condition_func := function( tree, path )
+                        
+                        if PositionSublist( tree.type, "FVAR" ) <> fail and tree.func_id = func_id then
+                            
+                            return true;
+                            
+                        fi;
+                        
+                        return false;
+                        
+                    end;
+                    
+                    if CapJitFindNodeDeep( ring_element, condition_func ) = fail then
+                        
+                        tree := rec(
+                            type := "EXPR_PROD",
+                            left := StructuralCopy( tree ),
+                            right := ring_element,
+                        );
+                        
+                        tree.left.args.1.list := List( list, l -> l.left );
+
+                        return tree;
+                        
+                    fi;
+                    
+                fi;
+                
+            fi;
+
+        fi;
+            
+        return tree;
+        
+    end;
+    
+    additional_arguments_func := function( tree, key, func_stack )
+        
+        if tree.type = "EXPR_DECLARATIVE_FUNC" then
+            
+            Assert( 0, IsBound( tree.id ) );
+            
+            return Concatenation( func_stack, [ tree ] );
+            
+        else
+            
+            return func_stack;
+            
+        fi;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, additional_arguments_func, [] );
+    
+end );
+
+# typed version of an official template
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "func", "list", "index" ],
+        variable_filters := [ IsFunction, IsList, IsPosInt ],
+        src_template := "func( list[index] )",
+        dst_template := "List( list, func )[index]",
+        returns_value := true,
+    )
+);
+
+# Length( ListWithIdenticalEntries( number, obj ) ) => number
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number", "obj" ],
+        src_template := "Length( ListWithIdenticalEntries( number, obj ) )",
+        dst_template := "number",
+        returns_value := true,
+    )
+);
+
+# List( ListWithIdenticalEntries( number, obj ), func ) => ListWithIdenticalEntries( number, func( obj ) )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number", "obj", "func" ],
+        src_template := "List( ListWithIdenticalEntries( number, obj ), func )",
+        dst_template := "ListWithIdenticalEntries( number, func( obj ) )",
+        returns_value := true,
+    )
+);
+
+# List( L, x -> x ) => L
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "list" ],
+        src_template := "List( list, x -> x )",
+        dst_template := "list",
+        returns_value := true,
+    )
+);
+
+# EntriesOfHomalgMatrixAsListList( matrix )[row][col] => matrix[row][col]
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "matrix", "row", "col" ],
+        src_template := "EntriesOfHomalgMatrixAsListList( matrix )[row][col]",
+        dst_template := "matrix[row, col]",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfRows( CoercedMatrix( R, S, M ) )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring2", "nr_cols", "list", "ring1", "matrix" ],
+        src_template := "UnionOfRows( ring2, nr_cols, List( list, l -> CoercedMatrix( ring1, ring2, matrix ) ) )",
+        dst_template := "CoercedMatrix( ring1, ring2, UnionOfRows( ring1, nr_cols, List( list, l -> matrix ) ) )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfColumns( CoercedMatrix( R, S, M ) )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring2", "nr_rows", "list", "ring1", "matrix" ],
+        src_template := "UnionOfColumns( ring2, nr_rows, List( list, l -> CoercedMatrix( ring1, ring2, matrix ) ) )",
+        dst_template := "CoercedMatrix( ring1, ring2, UnionOfColumns( ring1, nr_rows, List( list, l -> matrix ) ) )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfRows( CoefficientsWithGivenMonomials )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring", "nr_cols", "list", "matrix", "monomials" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgMatrix" ],
+        src_template := "UnionOfRows( ring, nr_cols, List( list, l -> CoefficientsWithGivenMonomials( matrix, monomials ) ) )",
+        dst_template := "CoefficientsWithGivenMonomials( UnionOfRows( ring, NrCols( monomials ), List( list, l -> matrix ) ), monomials )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfColumns( CoefficientsWithGivenMonomials )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring", "nr_rows", "list", "matrix", "monomials" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgMatrix" ],
+        src_template := "UnionOfColumns( ring, nr_rows, List( list, l -> CoefficientsWithGivenMonomials( matrix, monomials ) ) )",
+        dst_template := "CoefficientsWithGivenMonomials( UnionOfColumns( ring, nr_rows, List( list, l -> matrix ) ), DiagMat( ring, List( list, x -> monomials ) ) )",
+        new_funcs := [ [ "x" ] ],
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfRows( a * B ) => a * UnionOfRows( B )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "homalg_ring", "nr_cols", "list", "ring_element", "matrix" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgRingElement", "IsHomalgMatrix" ],
+        src_template := "UnionOfRows( homalg_ring, nr_cols, List( list, l -> ring_element * matrix ) )",
+        dst_template := "ring_element * UnionOfRows( homalg_ring, nr_cols, List( list, l -> matrix ) )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfRows( A * b ) => UnionOfRows( A ) * b
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "homalg_ring", "nr_cols", "list", "matrix", "ring_element" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgRingElement" ],
+        src_template := "UnionOfRows( homalg_ring, nr_cols, List( list, l -> matrix * ring_element ) )",
+        dst_template := "UnionOfRows( homalg_ring, nr_cols, List( list, l -> matrix ) ) * ring_element",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfColumns( a * B ) => a * UnionOfColumns( B )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "homalg_ring", "nr_rows", "list", "ring_element", "matrix" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgRingElement", "IsHomalgMatrix" ],
+        src_template := "UnionOfColumns( homalg_ring, nr_rows, List( list, l -> ring_element * matrix ) )",
+        dst_template := "ring_element * UnionOfColumns( homalg_ring, nr_rows, List( list, l -> matrix ) )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# UnionOfColumns( A * b ) => UnionOfColumns( A ) * b
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "homalg_ring", "nr_rows", "list", "matrix", "ring_element" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgRingElement" ],
+        src_template := "UnionOfColumns( homalg_ring, nr_rows, List( list, l -> matrix * ring_element ) )",
+        dst_template := "UnionOfColumns( homalg_ring, nr_rows, List( list, l -> matrix ) ) * ring_element",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# DualKroneckerMat( A, B )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring", "nr_cols", "nr_rows", "matrix1", "matrix2" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgMatrix" ],
+        src_template := """
+            UnionOfRows( ring, nr_cols, List( [ 1 .. NrRows( matrix2 ) ], i ->
+                UnionOfColumns( ring, nr_rows, List( [ 1 .. NrColumns( matrix2 ) ], j ->
+                    matrix1 * matrix2[i,j]
+                ) )
+            ) )
+        """,
+        dst_template := "DualKroneckerMat( matrix1, matrix2 )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.06.27" ] ],
+    )
+);
+
+# KroneckerMat( TransposedMatrix( A ), B )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring", "nr_cols", "nr_rows", "matrix1", "matrix2" ],
+        variable_filters := [ IsObject, IsObject, IsObject, "IsHomalgMatrix", "IsHomalgMatrix" ],
+        src_template := """
+            UnionOfRows( ring, nr_cols, List( [ 1 .. NrColumns( matrix1 ) ], j ->
+                UnionOfColumns( ring, nr_rows, List( [ 1 .. NrRows( matrix1 ) ], i ->
+                    matrix1[i,j] * matrix2
+                ) )
+            ) )
+        """,
+        dst_template := "KroneckerMat( TransposedMatrix( matrix1 ), matrix2 )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.05.19" ] ],
+    )
+);
+
+# ConvertMatrixToRow( M )
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "ring", "matrix" ],
+        variable_filters := [ "IsHomalgRing", "IsHomalgMatrix" ],
+        src_template := """
+            UnionOfColumns( ring, 1, List( [ 1 .. NrRows( matrix ) ], i ->
+                UnionOfColumns( ring, 1, List( [ 1 .. NrColumns( matrix ) ], j ->
+                    HomalgMatrix( [ matrix[i, j] ], 1, 1, ring )
+                ) )
+            ) )
+        """,
+        dst_template := "ConvertMatrixToRow( matrix )",
+        returns_value := true,
+        needed_packages := [ [ "MatricesForHomalg", ">= 2020.06.27" ] ],
+    )
+);

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
@@ -53,6 +53,15 @@ DeclareAttribute( "UnderlyingRingElement",
 DeclareAttribute( "UnderlyingRing",
                   IsRingAsCategory );
 
+DeclareAttribute( "GeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure",
+                  IsRingAsCategory );
+
+DeclareAttribute( "ColumnVectorOfGeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure",
+                  IsRingAsCategory );
+
+DeclareAttribute( "RingInclusionForHomomorphismStructure",
+                  IsRingAsCategory );
+
 ####################################
 ##
 #! @Section Operations

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -243,9 +243,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
     range_category := fail;
     
     ## Homomorphism structure for homalg exterior rings over fields
-    if IsHomalgRing( ring ) and HasIsExteriorRing( ring ) and IsExteriorRing( ring ) and IsField( CoefficientsRing( ring ) ) then
+    if IsHomalgRing( ring ) and HasIsExteriorRing( ring ) and IsExteriorRing( ring ) and IsField( BaseRing( ring ) ) then
         
-        field := CoefficientsRing( ring );
+        field := BaseRing( ring );
         
         range_category := CategoryOfRows( field );
         

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -24,6 +24,9 @@ InstallMethod( RingAsCategory,
     category!.compiler_hints := rec(
         category_attribute_names := [
             "UnderlyingRing",
+            "GeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure",
+            "ColumnVectorOfGeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure",
+            "RingInclusionForHomomorphismStructure",
         ],
     );
     
@@ -58,20 +61,20 @@ InstallMethod( RingAsCategoryUniqueObject,
 end );
 
 ##
-InstallMethod( RingAsCategoryMorphismOp,
-               [ IsRingAsCategory, IsObject ],
-               
+InstallMethodForCompilerForCAP( RingAsCategoryMorphismOp,
+                                [ IsRingAsCategory, IsObject ],
+                                
   function( category, element )
     local unique_object;
     
     unique_object := RingAsCategoryUniqueObject( category );
     
-    ## this is a "compiled" version of ObjectifyMorphismForCAPWithAttributes
-    return ObjectifyWithAttributes( rec(), category!.morphism_type,
-                                    Source, unique_object,
-                                    Range, unique_object,
-                                    UnderlyingRingElement, element,
-                                    CapCategory, category
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes(
+        rec(),
+        category,
+        unique_object,
+        unique_object,
+        UnderlyingRingElement, element
     );
     
 end );
@@ -263,10 +266,20 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
         
         generating_system_as_column := HomalgMatrix( generating_system, Length( generating_system ), 1, ring );
         
-        ring_as_module := CategoryOfRowsObjectOp( range_category, Length( generating_system ) );
+        ring_as_module := function ( )
+            #% CAP_JIT_RESOLVE_FUNCTION
+            
+            return CategoryOfRowsObject( range_category, Length( generating_system ) );
+            
+        end;
         
         # field^{1 x 1}
-        distinguished_object := CategoryOfRowsObjectOp( range_category, 1 );
+        distinguished_object := function( )
+            #% CAP_JIT_RESOLVE_FUNCTION
+            
+            return CategoryOfRowsObject( range_category, 1 );
+            
+        end;
         
         interpret_element_as_row_vector := function( r )
             #% CAP_JIT_RESOLVE_FUNCTION
@@ -290,10 +303,20 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
         
         generating_system_as_column := HomalgMatrix( generating_system, Length( generating_system ), 1, ring );
         
-        ring_as_module := CategoryOfRowsObjectOp( range_category, Length( generating_system ) );
+        ring_as_module := function ( )
+            #% CAP_JIT_RESOLVE_FUNCTION
+            
+            return CategoryOfRowsObject( range_category, Length( generating_system ) );
+            
+        end;
         
         # ring^{1 x 1}
-        distinguished_object := CategoryOfRowsObjectOp( range_category, 1 );
+        distinguished_object := function( )
+            #% CAP_JIT_RESOLVE_FUNCTION
+            
+            return CategoryOfRowsObject( range_category, 1 );
+            
+        end;
         
         interpret_element_as_row_vector := function( r )
             #% CAP_JIT_RESOLVE_FUNCTION
@@ -311,14 +334,22 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
     
     if range_category <> fail then
         
+        # set attributes
+        MakeImmutable( generating_system );
+        SetGeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure( category, generating_system );
+        
+        SetColumnVectorOfGeneratingSystemAsModuleInRangeCategoryOfHomomorphismStructure( category, generating_system_as_column );
+        
+        SetRingInclusionForHomomorphismStructure( category, ring_inclusion );
+        
         ##
         SetRangeCategoryOfHomomorphismStructure( category, range_category );
         
         ##
-        AddDistinguishedObjectOfHomomorphismStructure( category, {cat} -> distinguished_object );
+        AddDistinguishedObjectOfHomomorphismStructure( category, { cat } -> distinguished_object( ) );
         
         ##
-        AddHomomorphismStructureOnObjects( category, {cat, a, b} -> ring_as_module );
+        AddHomomorphismStructureOnObjects( category, { cat, a, b } -> ring_as_module( ) );
         
         ##
         AddHomomorphismStructureOnMorphisms( category,
@@ -339,7 +370,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
                 
             end );
             
-            return morphism_constructor( range_category, ring_as_module, UnionOfRows( UnderlyingRing( range_category ), Length( generating_system ), rows ), ring_as_module );
+            return morphism_constructor( range_category, ring_as_module( ), UnionOfRows( UnderlyingRing( range_category ), Length( generating_system ), rows ), ring_as_module( ) );
             
         end );
         
@@ -350,7 +381,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
             
             decomposition := interpret_element_as_row_vector( UnderlyingRingElement( alpha ) );
             
-            return morphism_constructor( range_category, distinguished_object, decomposition, ring_as_module );
+            return morphism_constructor( range_category, distinguished_object( ), decomposition, ring_as_module( ) );
             
         end );
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -179,15 +179,16 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := UnderlyingMatrix( arg2_1 );
-    deduped_1_1 := NumberRows( deduped_3_1 );
-    deduped_2_1 := NumberColumns( deduped_3_1 );
-    if not true then
-        return false;
-    elif deduped_1_1 <> deduped_1_1 then
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
+    deduped_2_1 := NumberRows( deduped_4_1 );
+    deduped_3_1 := NumberColumns( deduped_4_1 );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif deduped_2_1 <> deduped_2_1 then
+        return false;
+    elif deduped_3_1 <> deduped_3_1 then
         return false;
     else
         return true;
@@ -203,7 +204,9 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if not true then
+    local deduped_1_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif RankOfObject( arg2_1 ) < 0 then
         return false;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -328,15 +328,16 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := UnderlyingMatrix( arg2_1 );
-    deduped_1_1 := NumberRows( deduped_3_1 );
-    deduped_2_1 := NumberColumns( deduped_3_1 );
-    if not true then
-        return false;
-    elif deduped_1_1 <> deduped_1_1 then
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
+    deduped_2_1 := NumberRows( deduped_4_1 );
+    deduped_3_1 := NumberColumns( deduped_4_1 );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif deduped_2_1 <> deduped_2_1 then
+        return false;
+    elif deduped_3_1 <> deduped_3_1 then
         return false;
     else
         return true;
@@ -352,7 +353,9 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if not true then
+    local deduped_1_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif RankOfObject( arg2_1 ) < 0 then
         return false;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -389,15 +389,16 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := UnderlyingMatrix( arg2_1 );
-    deduped_1_1 := NumberRows( deduped_3_1 );
-    deduped_2_1 := NumberColumns( deduped_3_1 );
-    if not true then
-        return false;
-    elif deduped_1_1 <> deduped_1_1 then
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
+    deduped_2_1 := NumberRows( deduped_4_1 );
+    deduped_3_1 := NumberColumns( deduped_4_1 );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif deduped_2_1 <> deduped_2_1 then
+        return false;
+    elif deduped_3_1 <> deduped_3_1 then
         return false;
     else
         return true;
@@ -413,7 +414,9 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if not true then
+    local deduped_1_1;
+    deduped_1_1 := OppositeCategory( UnderlyingCategory( cat_1 ) );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif RankOfObject( arg2_1 ) < 0 then
         return false;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled", function ( cat )
+    
+    ##
+    AddDistinguishedObjectOfHomomorphismStructure( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, 1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddHomomorphismStructureOnObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, Sum( Concatenation( ListWithIdenticalEntries( RankOfObject( arg2_1 ), ListWithIdenticalEntries( RankOfObject( arg3_1 ), Length( GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 ) ) ) ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
+        
+########
+function ( cat_1, source_1, alpha_1, beta_1, range_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
+    deduped_4_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
+    deduped_5_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := UnderlyingMatrix( alpha_1 );
+    deduped_7_1 := ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 );
+    deduped_8_1 := UnderlyingMatrix( beta_1 );
+    hoisted_1_1 := deduped_5_1;
+    hoisted_2_1 := deduped_7_1;
+    hoisted_3_1 := DiagMat( deduped_5_1, List( [ 1 .. NumberColumns( deduped_8_1 ) ], function ( logic_new_func_x_2 )
+              return hoisted_2_1;
+          end ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), deduped_4_1, source_1, range_1, UnderlyingMatrix, CoercedMatrix( deduped_5_1, UnderlyingRing( deduped_4_1 ), CoefficientsWithGivenMonomials( KroneckerMat( TransposedMatrix( deduped_6_1 ), DualKroneckerMat( UnionOfRows( deduped_5_1, NumberColumns( deduped_7_1 ), List( GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 ), function ( generator_2 )
+                        return HomalgMatrix( [ generator_2 ], 1, 1, hoisted_1_1 );
+                    end ) ), deduped_8_1 ) ), DiagMat( deduped_5_1, List( [ 1 .. NumberRows( deduped_6_1 ) ], function ( logic_new_func_x_2 )
+                    return hoisted_3_1;
+                end ) ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( cat,
+        
+########
+function ( cat_1, source_1, alpha_1, range_1 )
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_4_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
+    deduped_5_1 := UnderlyingRing( cat_1 );
+    deduped_6_1 := UnderlyingMatrix( alpha_1 );
+    hoisted_2_1 := ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 );
+    hoisted_3_1 := DiagMat( deduped_5_1, List( [ 1 .. NumberColumns( deduped_6_1 ) ], function ( logic_new_func_x_2 )
+              return hoisted_2_1;
+          end ) );
+    morphism_attr_1_1 := CoercedMatrix( deduped_5_1, UnderlyingRing( deduped_4_1 ), CoefficientsWithGivenMonomials( ConvertMatrixToRow( deduped_6_1 ), DiagMat( deduped_5_1, List( [ 1 .. NumberRows( deduped_6_1 ) ], function ( logic_new_func_x_2 )
+                  return hoisted_3_1;
+              end ) ) ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), deduped_4_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), deduped_4_1, RankOfObject, 1 ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), deduped_4_1, RankOfObject, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
+end
+########
+        
+    , 101 );
+    
+    ##
+    AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1, arg4_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := RankOfObject( arg3_1 );
+    deduped_9_1 := RankOfObject( arg2_1 );
+    deduped_8_1 := [ 1 .. deduped_9_1 ];
+    hoisted_1_1 := deduped_10_1;
+    hoisted_2_1 := Concatenation( ListWithIdenticalEntries( deduped_9_1, ListWithIdenticalEntries( deduped_10_1, Length( GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 ) ) ) ) );
+    hoisted_3_1 := UnderlyingMatrix( arg4_1 );
+    hoisted_4_1 := [ 1 .. deduped_10_1 ];
+    hoisted_5_1 := List( deduped_8_1, function ( logic_new_func_x_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := hoisted_1_1 * (logic_new_func_x_2 - 1);
+            return List( hoisted_4_1, function ( logic_new_func_x_3 )
+                    local deduped_1_3, deduped_2_3;
+                    deduped_2_3 := hoisted_1_2 + logic_new_func_x_3;
+                    deduped_1_3 := Sum( hoisted_2_1{[ 1 .. deduped_2_3 - 1 ]} ) + 1;
+                    return CertainColumns( hoisted_3_1, [ deduped_1_3 .. deduped_1_3 - 1 + hoisted_2_1[deduped_2_3] ] );
+                end );
+        end );
+    hoisted_6_1 := RingInclusionForHomomorphismStructure( cat_1 );
+    hoisted_7_1 := ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, arg2_1, arg3_1, UnderlyingMatrix, HomalgMatrix( List( deduped_8_1, function ( logic_new_func_x_2 )
+                local hoisted_1_2;
+                hoisted_1_2 := hoisted_5_1[logic_new_func_x_2];
+                return List( hoisted_4_1, function ( logic_new_func_x_3 )
+                        return EntriesOfHomalgMatrix( Pullback( hoisted_6_1, hoisted_1_2[logic_new_func_x_3] ) * hoisted_7_1 )[1];
+                    end );
+            end ), deduped_9_1, deduped_10_1, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled", function ( homalg_ring )
+  local category_constructor, cat;
+    
+    category_constructor := 
+        
+        
+        function ( homalg_ring )
+    local rows;
+    rows := CategoryOfRowsAsAdditiveClosureOfRingAsCategory( homalg_ring );
+    if IsBoundGlobal( "CATEGORY_OF_ROWS_HACKY_EXTENDER" ) then
+        ValueGlobal( "CATEGORY_OF_ROWS_HACKY_EXTENDER" )( rows );
+    fi;
+    return rows;
+end;
+        
+        
+    
+    cat := category_constructor( homalg_ring : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/FreydCategoriesForCAP/init.g
+++ b/FreydCategoriesForCAP/init.g
@@ -7,6 +7,7 @@
 ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategoriesForCAP.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfRows.gd" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfColumns.gd" );
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfColumnsAsOppositeOfCategoryOfRows.gd" );

--- a/FreydCategoriesForCAP/read.g
+++ b/FreydCategoriesForCAP/read.g
@@ -6,6 +6,7 @@
 ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategoriesForCAP.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfRows.gi" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfColumns.gi" );
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfColumnsAsOppositeOfCategoryOfRows.gi" );

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -2104,7 +2104,7 @@ end
 function ( cat_1, arg2_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( arg2_1 );
-    if not true then
+    if not IS_IDENTICAL_OBJ( cat_1, cat_1 ) then
         return false;
     elif NumberRows( deduped_1_1 ) <> Dimension( Source( arg2_1 ) ) then
         return false;
@@ -2124,7 +2124,7 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if not true then
+    if not IS_IDENTICAL_OBJ( cat_1, cat_1 ) then
         return false;
     elif Dimension( arg2_1 ) < 0 then
         return false;

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -359,14 +359,15 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_1_1, deduped_2_1;
-    deduped_2_1 := Opposite( arg2_1 );
-    deduped_1_1 := UnderlyingMatrix( deduped_2_1 );
-    if not true then
+    local deduped_1_1, deduped_2_1, deduped_3_1;
+    deduped_3_1 := Opposite( arg2_1 );
+    deduped_1_1 := UnderlyingMatrix( deduped_3_1 );
+    deduped_2_1 := OppositeCategory( cat_1 );
+    if not IS_IDENTICAL_OBJ( deduped_2_1, deduped_2_1 ) then
         return false;
-    elif NumberRows( deduped_1_1 ) <> Dimension( Source( deduped_2_1 ) ) then
+    elif NumberRows( deduped_1_1 ) <> Dimension( Source( deduped_3_1 ) ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> Dimension( Range( deduped_2_1 ) ) then
+    elif NumberColumns( deduped_1_1 ) <> Dimension( Range( deduped_3_1 ) ) then
         return false;
     else
         return true;
@@ -382,7 +383,9 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if not true then
+    local deduped_1_1;
+    deduped_1_1 := OppositeCategory( cat_1 );
+    if not IS_IDENTICAL_OBJ( deduped_1_1, deduped_1_1 ) then
         return false;
     elif Dimension( Opposite( arg2_1 ) ) < 0 then
         return false;


### PR DESCRIPTION
In particular, CategoryOfRows of an exterior algebra over a field now has a homomorphism structure and can thus solve linear systems, i.e. the FreydCategory of such a category of rows now has lifts.

As preparation, remove support for matrix_element_as_morphism and list_list_as_matrix in AdditiveClosure because those can be covered by a wrapper category with custom object and morphism constructors.