### PR TITLE
Make Opposite() work for MonoidalCategories

### DIFF
--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -94,6 +94,28 @@ end
     , 100 );
     
     ##
+    AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := RankOfObject( a_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, function (  )
+              if deduped_1_1 = 0 then
+                  return HomalgZeroMatrix( RankOfObject( r_1 ), RankOfObject( s_1 ), deduped_2_1 );
+              else
+                  return ConvertMatrixToRow( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
         
 ########

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -30,6 +30,26 @@ end
     , 100 );
     
     ##
+    AddBraidingInverseWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, a_1, b_1, r_1 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1;
+    deduped_3_1 := RankOfObject( s_1 );
+    hoisted_2_1 := RankOfObject( a_1 );
+    hoisted_1_1 := RankOfObject( b_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
+                    local deduped_1_2;
+                    deduped_1_2 := i_2 - 1;
+                    return REM_INT( deduped_1_2, hoisted_1_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_1_1 ) + 1;
+                end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddBraidingWithGivenTensorProducts( cat,
         
 ########

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -70,6 +70,52 @@ end
     , 100 );
     
     ##
+    AddCoDualOnMorphismsWithGivenCoDuals( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, r_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, TransposedMatrix( UnderlyingMatrix( alpha_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoDualOnObjects( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, RankOfObject, RankOfObject( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := RankOfObject( a_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, function (  )
+              if deduped_1_1 = 0 then
+                  return HomalgZeroMatrix( RankOfObject( r_1 ), RankOfObject( s_1 ), deduped_2_1 );
+              else
+                  return ConvertMatrixToColumn( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoevaluationForDualWithGivenTensorProduct( cat,
         
 ########
@@ -452,6 +498,18 @@ function ( cat_1, arg2_1 )
              ), deduped_2_1, ObjectifyObjectForCAPWithAttributes( rec(
                ), deduped_2_1, RankOfObject, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
                ), deduped_2_1, RankOfObject, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismFromCoBidualWithGivenCoBidual( cat,
+        
+########
+function ( cat_1, a_1, s_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( RankOfObject( a_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -91,6 +91,52 @@ end
     , 100 );
     
     ##
+    AddCoDualOnMorphismsWithGivenCoDuals( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, r_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, TransposedMatrix( UnderlyingMatrix( alpha_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoDualOnObjects( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, RankOfObject, RankOfObject( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := RankOfObject( a_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, function (  )
+              if deduped_1_1 = 0 then
+                  return HomalgZeroMatrix( RankOfObject( r_1 ), RankOfObject( s_1 ), deduped_2_1 );
+              else
+                  return ConvertMatrixToColumn( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
         
 ########
@@ -542,6 +588,18 @@ function ( cat_1, arg2_1 )
              ), deduped_2_1, ObjectifyObjectForCAPWithAttributes( rec(
                ), deduped_2_1, RankOfObject, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
                ), deduped_2_1, RankOfObject, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismFromCoBidualWithGivenCoBidual( cat,
+        
+########
+function ( cat_1, a_1, s_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, a_1, UnderlyingMatrix, HomalgIdentityMatrix( RankOfObject( a_1 ), UnderlyingRing( cat_1 ) ) );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -115,6 +115,28 @@ end
     , 100 );
     
     ##
+    AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingRing( cat_1 );
+    deduped_1_1 := RankOfObject( a_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, function (  )
+              if deduped_1_1 = 0 then
+                  return HomalgZeroMatrix( RankOfObject( r_1 ), RankOfObject( s_1 ), deduped_2_1 );
+              else
+                  return ConvertMatrixToRow( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
         
 ########

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -51,6 +51,26 @@ end
     , 100 );
     
     ##
+    AddBraidingInverseWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, a_1, b_1, r_1 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1;
+    deduped_3_1 := RankOfObject( s_1 );
+    hoisted_2_1 := RankOfObject( a_1 );
+    hoisted_1_1 := RankOfObject( b_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, UnderlyingMatrix, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
+                    local deduped_1_2;
+                    deduped_1_2 := i_2 - 1;
+                    return REM_INT( deduped_1_2, hoisted_1_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_1_1 ) + 1;
+                end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddBraidingWithGivenTensorProducts( cat,
         
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -4661,75 +4661,75 @@ end
         
 ########
 function ( cat_1, s_1, a_1, b_1, r_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
-    deduped_25_1 := UnderlyingRing( cat_1 );
-    deduped_24_1 := Dimension( b_1 );
-    deduped_23_1 := Dimension( a_1 );
-    deduped_22_1 := deduped_24_1 * 1;
-    deduped_21_1 := deduped_23_1 * 1;
-    deduped_20_1 := deduped_23_1 * deduped_24_1;
-    deduped_19_1 := deduped_22_1 * deduped_23_1;
-    deduped_18_1 := deduped_20_1 * deduped_20_1;
-    deduped_17_1 := deduped_21_1 * deduped_22_1;
-    deduped_16_1 := HomalgIdentityMatrix( 1, deduped_25_1 );
-    deduped_15_1 := HomalgIdentityMatrix( deduped_24_1, deduped_25_1 );
-    deduped_14_1 := HomalgIdentityMatrix( deduped_23_1, deduped_25_1 );
-    deduped_13_1 := deduped_20_1 * deduped_17_1;
-    deduped_12_1 := HomalgIdentityMatrix( deduped_22_1, deduped_25_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_21_1, deduped_25_1 );
-    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_25_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_17_1, deduped_25_1 );
-    hoisted_8_1 := deduped_24_1;
-    hoisted_7_1 := deduped_22_1;
-    hoisted_6_1 := deduped_23_1;
-    hoisted_5_1 := deduped_17_1;
-    hoisted_4_1 := deduped_20_1;
-    morphism_attr_3_1 := KroneckerMat( deduped_14_1, deduped_15_1 ) * (KroneckerMat( function (  )
-                      if (deduped_20_1 = 0) then
-                          return HomalgZeroMatrix( 1, deduped_18_1, deduped_25_1 );
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1;
+    deduped_23_1 := UnderlyingRing( cat_1 );
+    deduped_22_1 := Dimension( b_1 );
+    deduped_21_1 := Dimension( a_1 );
+    deduped_20_1 := deduped_22_1 * 1;
+    deduped_19_1 := deduped_21_1 * 1;
+    deduped_18_1 := deduped_21_1 * deduped_22_1;
+    deduped_17_1 := deduped_20_1 * deduped_21_1;
+    deduped_16_1 := deduped_18_1 * deduped_18_1;
+    deduped_15_1 := deduped_19_1 * deduped_20_1;
+    deduped_14_1 := HomalgIdentityMatrix( 1, deduped_23_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_22_1, deduped_23_1 );
+    deduped_12_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
+    deduped_11_1 := deduped_18_1 * deduped_15_1;
+    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
+    deduped_9_1 := HomalgIdentityMatrix( deduped_19_1, deduped_23_1 );
+    deduped_8_1 := HomalgIdentityMatrix( deduped_18_1, deduped_23_1 );
+    deduped_7_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    hoisted_6_1 := deduped_22_1;
+    hoisted_5_1 := deduped_20_1;
+    hoisted_4_1 := deduped_21_1;
+    hoisted_3_1 := deduped_15_1;
+    hoisted_2_1 := deduped_18_1;
+    morphism_attr_1_1 := KroneckerMat( deduped_12_1, deduped_13_1 ) * (KroneckerMat( function (  )
+                      if (deduped_18_1 = 0) then
+                          return HomalgZeroMatrix( 1, deduped_16_1, deduped_23_1 );
                       else
-                          return ConvertMatrixToRow( deduped_10_1 );
+                          return ConvertMatrixToRow( deduped_8_1 );
                       fi;
                       return;
-                  end(  ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+                  end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                             local deduped_1_2;
                             deduped_1_2 := (i_2 - 1);
-                            return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                        end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_25_1 ), deduped_9_1 ) * KroneckerMat( deduped_10_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
+                            return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                        end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_8_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                      end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_25_1 ) ) * KroneckerMat( TransposedMatrix( deduped_10_1 ), (KroneckerMat( KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                          return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
+                      end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_8_1 ), (KroneckerMat( KroneckerMat( deduped_9_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
-                                return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                            end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_25_1 ) ), deduped_15_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_11_1, deduped_14_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_21_1 ], function ( i_2 )
+                                return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
+                            end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ) ), deduped_13_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_9_1, deduped_12_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
                                       local deduped_1_2;
                                       deduped_1_2 := (i_2 - 1);
-                                      return (REM_INT( deduped_1_2, 1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                                  end ) ), deduped_21_1 ), deduped_21_1, deduped_21_1, deduped_25_1 ), deduped_14_1 ) * KroneckerMat( deduped_16_1, function (  )
-                              if (deduped_23_1 = 0) then
-                                  return HomalgZeroMatrix( (deduped_23_1 * deduped_23_1), 1, deduped_25_1 );
+                                      return (REM_INT( deduped_1_2, 1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, 1 ) + 1);
+                                  end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_23_1 ), deduped_12_1 ) * KroneckerMat( deduped_14_1, function (  )
+                              if (deduped_21_1 = 0) then
+                                  return HomalgZeroMatrix( (deduped_21_1 * deduped_21_1), 1, deduped_23_1 );
                               else
-                                  return ConvertMatrixToColumn( deduped_14_1 );
+                                  return ConvertMatrixToColumn( deduped_12_1 );
                               fi;
                               return;
-                          end(  ) )), deduped_12_1 ), deduped_15_1 ) * KroneckerMat( deduped_16_1, (KroneckerMat( deduped_12_1, deduped_15_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_22_1 ], function ( i_2 )
+                          end(  ) )), deduped_10_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, (KroneckerMat( deduped_10_1, deduped_13_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
                                   local deduped_1_2;
                                   deduped_1_2 := (i_2 - 1);
-                                  return (REM_INT( deduped_1_2, 1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                              end ) ), deduped_22_1 ), deduped_22_1, deduped_22_1, deduped_25_1 ), deduped_15_1 ) * KroneckerMat( deduped_16_1, function (  )
-                          if (deduped_24_1 = 0) then
-                              return HomalgZeroMatrix( (deduped_24_1 * deduped_24_1), 1, deduped_25_1 );
+                                  return (REM_INT( deduped_1_2, 1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, 1 ) + 1);
+                              end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_23_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, function (  )
+                          if (deduped_22_1 = 0) then
+                              return HomalgZeroMatrix( (deduped_22_1 * deduped_22_1), 1, deduped_23_1 );
                           else
-                              return ConvertMatrixToColumn( deduped_15_1 );
+                              return ConvertMatrixToColumn( deduped_13_1 );
                           fi;
                           return;
                       end(  ) )) )) ));
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -364,36 +364,36 @@ end
         
 ########
 function ( cat_1, a_1, b_1, r_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := UnderlyingRing( cat_1 );
-    deduped_11_1 := Dimension( a_1 );
-    deduped_10_1 := Dimension( b_1 );
-    deduped_9_1 := deduped_10_1 * deduped_11_1;
-    deduped_8_1 := deduped_10_1 * deduped_10_1;
-    deduped_7_1 := HomalgIdentityMatrix( deduped_11_1, deduped_12_1 );
-    deduped_6_1 := HomalgIdentityMatrix( deduped_10_1, deduped_12_1 );
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
-    morphism_attr_3_1 := KroneckerMat( function (  )
-                  if (deduped_10_1 = 0) then
-                      return HomalgZeroMatrix( 1, deduped_8_1, deduped_12_1 );
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := Dimension( a_1 );
+    deduped_8_1 := Dimension( b_1 );
+    deduped_7_1 := deduped_8_1 * deduped_9_1;
+    deduped_6_1 := deduped_8_1 * deduped_8_1;
+    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_8_1;
+    morphism_attr_1_1 := KroneckerMat( function (  )
+                  if (deduped_8_1 = 0) then
+                      return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
                   else
-                      return ConvertMatrixToRow( deduped_6_1 );
+                      return ConvertMatrixToRow( deduped_4_1 );
                   fi;
                   return;
-              end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+              end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                    end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_12_1 ), deduped_7_1 ) * KroneckerMat( deduped_6_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_9_1 ], function ( i_2 )
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                       local deduped_1_2;
                       deduped_1_2 := (i_2 - 1);
-                      return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                  end ) ), deduped_9_1 ), deduped_9_1, deduped_9_1, deduped_12_1 ) );
+                      return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
+                  end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -1050,30 +1050,30 @@ end
         
 ########
 function ( cat_1, a_1, b_1, s_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := UnderlyingRing( cat_1 );
-    deduped_9_1 := Dimension( a_1 );
-    deduped_8_1 := Dimension( b_1 );
-    deduped_7_1 := deduped_9_1 * deduped_8_1;
-    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    hoisted_5_1 := deduped_9_1;
-    hoisted_4_1 := deduped_8_1;
-    morphism_attr_3_1 := KroneckerMat( HomalgIdentityMatrix( deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
+    deduped_8_1 := UnderlyingRing( cat_1 );
+    deduped_7_1 := Dimension( a_1 );
+    deduped_6_1 := Dimension( b_1 );
+    deduped_5_1 := deduped_7_1 * deduped_6_1;
+    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    hoisted_3_1 := deduped_7_1;
+    hoisted_2_1 := deduped_6_1;
+    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_8_1, deduped_10_1 ), function (  )
-                if (deduped_9_1 = 0) then
-                    return HomalgZeroMatrix( (deduped_9_1 * deduped_9_1), 1, deduped_10_1 );
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
+                if (deduped_7_1 = 0) then
+                    return HomalgZeroMatrix( (deduped_7_1 * deduped_7_1), 1, deduped_8_1 );
                 else
-                    return ConvertMatrixToColumn( deduped_6_1 );
+                    return ConvertMatrixToColumn( deduped_4_1 );
                 fi;
                 return;
             end(  ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -1621,12 +1621,12 @@ end
         
 ########
 function ( cat_1, s_1, alpha_1, beta_1, r_1 )
-    local morphism_attr_3_1;
-    morphism_attr_3_1 := KroneckerMat( TransposedMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( beta_1 ) );
+    local morphism_attr_1_1;
+    morphism_attr_1_1 := KroneckerMat( TransposedMatrix( UnderlyingMatrix( alpha_1 ) ), UnderlyingMatrix( beta_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -2478,12 +2478,12 @@ end
         
 ########
 function ( cat_1, a_1, b_1 )
-    local morphism_attr_3_1;
-    morphism_attr_3_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
+    local morphism_attr_1_1;
+    morphism_attr_1_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -2677,12 +2677,12 @@ end
         
 ########
 function ( cat_1, a_1, b_1 )
-    local morphism_attr_3_1;
-    morphism_attr_3_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
+    local morphism_attr_1_1;
+    morphism_attr_1_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3664,12 +3664,12 @@ end
         
 ########
 function ( cat_1, s_1, a_1, b_1, r_1 )
-    local morphism_attr_3_1;
-    morphism_attr_3_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
+    local morphism_attr_1_1;
+    morphism_attr_1_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3836,12 +3836,12 @@ end
         
 ########
 function ( cat_1, s_1, a_1, b_1, r_1 )
-    local morphism_attr_3_1;
-    morphism_attr_3_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
+    local morphism_attr_1_1;
+    morphism_attr_1_1 := HomalgIdentityMatrix( Dimension( a_1 ) * Dimension( b_1 ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1649,30 +1649,30 @@ end
         
 ########
 function ( cat_1, b_1, c_1, g_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := UnderlyingRing( cat_1 );
-    deduped_9_1 := Dimension( b_1 );
-    deduped_8_1 := Dimension( c_1 );
-    deduped_7_1 := deduped_9_1 * deduped_8_1;
-    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    hoisted_5_1 := deduped_9_1;
-    hoisted_4_1 := deduped_8_1;
-    morphism_attr_3_1 := KroneckerMat( UnderlyingMatrix( g_1 ), deduped_6_1 ) * (KroneckerMat( HomalgIdentityMatrix( deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
+    deduped_8_1 := UnderlyingRing( cat_1 );
+    deduped_7_1 := Dimension( b_1 );
+    deduped_6_1 := Dimension( c_1 );
+    deduped_5_1 := deduped_7_1 * deduped_6_1;
+    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    hoisted_3_1 := deduped_7_1;
+    hoisted_2_1 := deduped_6_1;
+    morphism_attr_1_1 := KroneckerMat( UnderlyingMatrix( g_1 ), deduped_4_1 ) * (KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_8_1, deduped_10_1 ), function (  )
-                  if (deduped_9_1 = 0) then
-                      return HomalgZeroMatrix( (deduped_9_1 * deduped_9_1), 1, deduped_10_1 );
+                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                      end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
+                  if (deduped_7_1 = 0) then
+                      return HomalgZeroMatrix( (deduped_7_1 * deduped_7_1), 1, deduped_8_1 );
                   else
-                      return ConvertMatrixToColumn( deduped_6_1 );
+                      return ConvertMatrixToColumn( deduped_4_1 );
                   fi;
                   return;
               end(  ) ));
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -2847,29 +2847,29 @@ end
         
 ########
 function ( cat_1, a_1, b_1, alpha_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := UnderlyingRing( cat_1 );
-    deduped_9_1 := Dimension( a_1 );
-    deduped_8_1 := Dimension( b_1 );
-    deduped_7_1 := deduped_9_1 * deduped_8_1;
-    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    hoisted_5_1 := deduped_9_1;
-    hoisted_4_1 := deduped_8_1;
-    morphism_attr_3_1 := KroneckerMat( UnderlyingMatrix( alpha_1 ), deduped_6_1 ) * (KroneckerMat( HomalgIdentityMatrix( deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
+    deduped_8_1 := UnderlyingRing( cat_1 );
+    deduped_7_1 := Dimension( a_1 );
+    deduped_6_1 := Dimension( b_1 );
+    deduped_5_1 := deduped_7_1 * deduped_6_1;
+    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    hoisted_3_1 := deduped_7_1;
+    hoisted_2_1 := deduped_6_1;
+    morphism_attr_1_1 := KroneckerMat( UnderlyingMatrix( alpha_1 ), deduped_4_1 ) * (KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_8_1, deduped_10_1 ), function (  )
-                  if (deduped_9_1 = 0) then
-                      return HomalgZeroMatrix( (deduped_9_1 * deduped_9_1), 1, deduped_10_1 );
+                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                      end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
+                  if (deduped_7_1 = 0) then
+                      return HomalgZeroMatrix( (deduped_7_1 * deduped_7_1), 1, deduped_8_1 );
                   else
-                      return ConvertMatrixToColumn( deduped_6_1 );
+                      return ConvertMatrixToColumn( deduped_4_1 );
                   fi;
                   return;
               end(  ) ));
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, a_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -5114,36 +5114,36 @@ end
         
 ########
 function ( cat_1, a_1, b_1, f_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := UnderlyingRing( cat_1 );
-    deduped_11_1 := Dimension( a_1 );
-    deduped_10_1 := Dimension( b_1 );
-    deduped_9_1 := deduped_10_1 * deduped_11_1;
-    deduped_8_1 := deduped_10_1 * deduped_10_1;
-    deduped_7_1 := HomalgIdentityMatrix( deduped_11_1, deduped_12_1 );
-    deduped_6_1 := HomalgIdentityMatrix( deduped_10_1, deduped_12_1 );
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
-    morphism_attr_3_1 := KroneckerMat( function (  )
-                    if (deduped_10_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_8_1, deduped_12_1 );
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := Dimension( a_1 );
+    deduped_8_1 := Dimension( b_1 );
+    deduped_7_1 := deduped_8_1 * deduped_9_1;
+    deduped_6_1 := deduped_8_1 * deduped_8_1;
+    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_8_1;
+    morphism_attr_1_1 := KroneckerMat( function (  )
+                    if (deduped_8_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
                     else
-                        return ConvertMatrixToRow( deduped_6_1 );
+                        return ConvertMatrixToRow( deduped_4_1 );
                     fi;
                     return;
-                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_12_1 ), deduped_7_1 ) * KroneckerMat( deduped_6_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_9_1 ], function ( i_2 )
+                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                    end ) ), deduped_9_1 ), deduped_9_1, deduped_9_1, deduped_12_1 ) ) * KroneckerMat( TransposedMatrix( deduped_6_1 ), UnderlyingMatrix( f_1 ) );
+                        return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( f_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrColumns( morphism_attr_3_1 ) ), UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -5698,35 +5698,35 @@ end
         
 ########
 function ( cat_1, t_1, a_1, alpha_1 )
-    local morphism_attr_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := UnderlyingRing( cat_1 );
-    deduped_11_1 := Dimension( t_1 );
-    deduped_10_1 := Dimension( a_1 );
-    deduped_9_1 := deduped_10_1 * deduped_11_1;
-    deduped_8_1 := deduped_10_1 * deduped_10_1;
-    deduped_7_1 := HomalgIdentityMatrix( deduped_11_1, deduped_12_1 );
-    deduped_6_1 := HomalgIdentityMatrix( deduped_10_1, deduped_12_1 );
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
-    morphism_attr_3_1 := KroneckerMat( function (  )
-                    if (deduped_10_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_8_1, deduped_12_1 );
+    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := Dimension( t_1 );
+    deduped_8_1 := Dimension( a_1 );
+    deduped_7_1 := deduped_8_1 * deduped_9_1;
+    deduped_6_1 := deduped_8_1 * deduped_8_1;
+    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_8_1;
+    morphism_attr_1_1 := KroneckerMat( function (  )
+                    if (deduped_8_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
                     else
-                        return ConvertMatrixToRow( deduped_6_1 );
+                        return ConvertMatrixToRow( deduped_4_1 );
                     fi;
                     return;
-                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_12_1 ), deduped_7_1 ) * KroneckerMat( deduped_6_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_9_1 ], function ( i_2 )
+                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                    end ) ), deduped_9_1 ), deduped_9_1, deduped_9_1, deduped_12_1 ) ) * KroneckerMat( TransposedMatrix( deduped_6_1 ), UnderlyingMatrix( alpha_1 ) );
+                        return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_3_1 ) ), a_1, UnderlyingMatrix, morphism_attr_3_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), a_1, UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -117,6 +117,33 @@ end
     , 100 );
     
     ##
+    AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Opposite( s_1 );
+    deduped_4_1 := Opposite( r_1 );
+    deduped_3_1 := OppositeCategory( cat_1 );
+    deduped_2_1 := UnderlyingRing( deduped_3_1 );
+    deduped_1_1 := Dimension( Opposite( a_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, Opposite, function (  )
+              if deduped_1_1 = 0 then
+                  return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+                         ), deduped_3_1, deduped_4_1, deduped_5_1, UnderlyingMatrix, HomalgZeroMatrix( Dimension( deduped_4_1 ), Dimension( deduped_5_1 ), deduped_2_1 ) );
+              else
+                  return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+                         ), deduped_3_1, deduped_4_1, deduped_5_1, UnderlyingMatrix, ConvertMatrixToRow( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
         
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -727,6 +727,45 @@ end
     , 100 );
     
     ##
+    AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, beta_1, r_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), Opposite( s_1 ), Opposite( r_1 ), UnderlyingMatrix, KroneckerMat( UnderlyingMatrix( Opposite( alpha_1 ) ), UnderlyingMatrix( Opposite( beta_1 ) ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorProductOnObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), Dimension, Dimension( Opposite( arg2_1 ) ) * Dimension( Opposite( arg3_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorUnit( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, Opposite, ObjectifyObjectForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), Dimension, 1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
         
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -69,6 +69,29 @@ end
     , 100 );
     
     ##
+    AddBraidingInverseWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, a_1, b_1, r_1 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Opposite( s_1 );
+    deduped_4_1 := OppositeCategory( cat_1 );
+    deduped_3_1 := Dimension( deduped_5_1 );
+    hoisted_2_1 := Dimension( Opposite( a_1 ) );
+    hoisted_1_1 := Dimension( Opposite( b_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), deduped_4_1, deduped_5_1, Opposite( r_1 ), UnderlyingMatrix, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
+                      local deduped_1_2;
+                      deduped_1_2 := i_2 - 1;
+                      return REM_INT( deduped_1_2, hoisted_1_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_1_1 ) + 1;
+                  end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, UnderlyingRing( deduped_4_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
         
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -92,6 +92,58 @@ end
     , 100 );
     
     ##
+    AddCoDualOnMorphismsWithGivenCoDuals( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, r_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), OppositeCategory( cat_1 ), Opposite( r_1 ), Opposite( s_1 ), UnderlyingMatrix, TransposedMatrix( UnderlyingMatrix( Opposite( alpha_1 ) ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoDualOnObjects( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, Opposite, Opposite( a_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
+        
+########
+function ( cat_1, s_1, a_1, r_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Opposite( s_1 );
+    deduped_4_1 := Opposite( r_1 );
+    deduped_3_1 := OppositeCategory( cat_1 );
+    deduped_2_1 := UnderlyingRing( deduped_3_1 );
+    deduped_1_1 := Dimension( Opposite( a_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, r_1, Opposite, function (  )
+              if deduped_1_1 = 0 then
+                  return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+                         ), deduped_3_1, deduped_4_1, deduped_5_1, UnderlyingMatrix, HomalgZeroMatrix( Dimension( deduped_4_1 ), Dimension( deduped_5_1 ), deduped_2_1 ) );
+              else
+                  return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+                         ), deduped_3_1, deduped_4_1, deduped_5_1, UnderlyingMatrix, ConvertMatrixToColumn( HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ) ) );
+              fi;
+              return;
+          end(  ) );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
         
 ########
@@ -640,6 +692,22 @@ end
 ########
 function ( cat_1, arg2_1 )
     return Opposite( arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismFromCoBidualWithGivenCoBidual( cat,
+        
+########
+function ( cat_1, a_1, s_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := Opposite( a_1 );
+    deduped_1_1 := OppositeCategory( cat_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, s_1, a_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+             ), deduped_1_1, deduped_2_1, Opposite( s_1 ), UnderlyingMatrix, HomalgIdentityMatrix( Dimension( deduped_2_1 ), UnderlyingRing( deduped_1_1 ) ) ) );
 end
 ########
         

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2021.11-04",
+Version := "2021.11-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/BraidedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/BraidedMonoidalCategories.gd
@@ -34,7 +34,7 @@ DeclareOperation( "BraidingWithGivenTensorProducts",
 
 #! @Description
 #! The arguments are two objects $a,b$.
-#! The output is the inverse of the braiding $ B_{a,b}^{-1}: b \otimes a \rightarrow a \otimes b$.
+#! The output is the inverse braiding $ B_{a,b}^{-1}: b \otimes a \rightarrow a \otimes b$.
 #! @Returns a morphism in $\mathrm{Hom}( b \otimes a, a \otimes b )$.
 #! @Arguments a,b
 DeclareOperation( "BraidingInverse",
@@ -44,7 +44,7 @@ DeclareOperation( "BraidingInverse",
 #! The arguments are an object $s = b \otimes a$, 
 #! two objects $a,b$,
 #! and an object $r = a \otimes b$.
-#! The output is the braiding $ B_{a,b}^{-1}: b \otimes a \rightarrow a \otimes b$.
+#! The output is the inverse braiding $ B_{a,b}^{-1}: b \otimes a \rightarrow a \otimes b$.
 #! @Returns a morphism in $\mathrm{Hom}( b \otimes a, a \otimes b )$.
 #! @Arguments s,a,b,r
 DeclareOperation( "BraidingInverseWithGivenTensorProducts",

--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
 #
+# Pre processor functions for dual operations
+#
+
+BindGlobal( "DualPreProcessorFuncBraidingWithGivenTensorProducts",
+              { cat, s, a, b, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( s ) ] );
+
+BindGlobal( "DualPreProcessorFuncBraidingInverseWithGivenTensorProducts",
+              { cat, s, a, b, r } -> [ Opposite( cat ), Opposite( s ), Opposite( a ), Opposite( b ), Opposite( r ) ] );
+
 # Implementations
 #
 
@@ -12,12 +21,19 @@ Braiding := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, a, b )",
   output_range_getter_string := "TensorProductOnObjects( cat, b, a )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "BraidingInverse",
+  dual_arguments_reversed := false,
+),
 
 BraidingWithGivenTensorProducts := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "BraidingInverseWithGivenTensorProducts",
+  dual_preprocessor_func := DualPreProcessorFuncBraidingWithGivenTensorProducts,
+  dual_arguments_reversed := false,
+),
 
 BraidingInverse := rec(
   filter_list := [ "category", "object", "object" ],
@@ -25,12 +41,19 @@ BraidingInverse := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, b, a )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, b )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "Braiding",
+  dual_arguments_reversed := false,
+),
 
 BraidingInverseWithGivenTensorProducts := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "BraidingWithGivenTensorProducts",
+  dual_preprocessor_func := DualPreProcessorFuncBraidingInverseWithGivenTensorProducts,
+  dual_arguments_reversed := false,
+),
 
 ) );
 

--- a/MonoidalCategories/gap/ClosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategories.gd
@@ -54,7 +54,7 @@ DeclareOperation( "InternalHomOnMorphismsWithGivenInternalHoms",
 #! The output is the evaluation morphism $\mathrm{ev}_{a,b}: \mathrm{\underline{Hom}}(a,b) \otimes a \rightarrow b$, i.e.,
 #! the counit of the tensor hom adjunction.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a,b) \otimes a, b )$.
-#! @Arguments a,b
+#! @Arguments a, b
 DeclareOperation( "EvaluationMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
@@ -64,7 +64,7 @@ DeclareOperation( "EvaluationMorphism",
 #! The output is the evaluation morphism $\mathrm{ev}_{a,b}: \mathrm{\underline{Hom}}(a,b) \otimes a \rightarrow b$, i.e.,
 #! the counit of the tensor hom adjunction.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a,b) \otimes a, b )$.
-#! @Arguments a,b, s
+#! @Arguments a, b, s
 DeclareOperation( "EvaluationMorphismWithGivenSource",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
@@ -73,7 +73,7 @@ DeclareOperation( "EvaluationMorphismWithGivenSource",
 #! The output is the coevaluation morphism $\mathrm{coev}_{a,b}: a \rightarrow \mathrm{\underline{Hom}}(b, a \otimes b)$, i.e.,
 #! the unit of the tensor hom adjunction.
 #! @Returns a morphism in $\mathrm{Hom}( a, \mathrm{\underline{Hom}}(b, a \otimes b) )$.
-#! @Arguments a,b
+#! @Arguments a, b
 DeclareOperation( "CoevaluationMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
@@ -83,7 +83,7 @@ DeclareOperation( "CoevaluationMorphism",
 #! The output is the coevaluation morphism $\mathrm{coev}_{a,b}: a \rightarrow \mathrm{\underline{Hom}}(b, a \otimes b)$, i.e.,
 #! the unit of the tensor hom adjunction.
 #! @Returns a morphism in $\mathrm{Hom}( a, \mathrm{\underline{Hom}}(b, a \otimes b) )$.
-#! @Arguments a,b,r
+#! @Arguments a, b, r
 DeclareOperation( "CoevaluationMorphismWithGivenRange",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
@@ -208,7 +208,7 @@ DeclareAttribute( "MorphismToBidual",
 DeclareOperation( "MorphismToBidualWithGivenBidual",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
-## The four objects are given are given as a list because otherwise the WithGiven operation would
+## The four objects are given as a list because otherwise the WithGiven operation would
 ## exceed the maximal number of arguments for an operation (6)
 #! @Description
 #! The argument is a list of four objects $[ a, a', b, b' ]$.

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,27 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
 #
+# Pre processor functions for dual operations
+#
+
+BindGlobal( "DualPreProcessorFuncEvaluationMorphismWithGivenSource", { cat, a, b, s } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( s ) ] );
+
+BindGlobal( "DualPreProcessorFuncInternalHomToTensorProductAdjunctionMap", { cat, a, b, g } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( g ) ] );
+
+BindGlobal( "DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphism",
+              { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ] ]
+);
+
+BindGlobal( "DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismWithGivenObjects",
+              { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ], Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncTensorProductDualityCompatibilityMorphismWithGivenObjects",
+              { cat, s, a, b, r} -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncLambdaElimination", { cat, a, b, alpha } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( alpha ) ] );
+
 # Implementations
 #
 
@@ -9,7 +30,10 @@ InstallValue( CLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD, rec(
 InternalHomOnObjects := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "i" ] ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "InternalCoHomOnObjects",
+  dual_arguments_reversed := true,
+),
 
 InternalHomOnMorphisms := rec(
   filter_list := [ "category", "morphism", "morphism" ],
@@ -17,12 +41,18 @@ InternalHomOnMorphisms := rec(
   output_source_getter_string := "InternalHomOnObjects( cat, Range( alpha ), Source( beta ) )",
   output_range_getter_string := "InternalHomOnObjects( cat, Source( alpha ), Range( beta ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomOnMorphisms",
+  dual_arguments_reversed := true,
+),
 
 InternalHomOnMorphismsWithGivenInternalHoms := rec(
   filter_list := [ "category", "object", "morphism", "morphism", "object" ],
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
+  dual_arguments_reversed := true,
+),
 
 EvaluationMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -30,12 +60,19 @@ EvaluationMorphism := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, InternalHomOnObjects( cat, a, b ), a )",
   output_range_getter_string := "b",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedEvaluationMorphism",
+  dual_arguments_reversed := true,
+),
 
 EvaluationMorphismWithGivenSource := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "a", "b", "s" ], [ "s", "b" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedEvaluationMorphismWithGivenRange",
+  dual_preprocessor_func := DualPreProcessorFuncEvaluationMorphismWithGivenSource,
+  dual_arguments_reversed := false,
+),
 
 CoevaluationMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -43,23 +80,34 @@ CoevaluationMorphism := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "InternalHomOnObjects( cat, b, TensorProductOnObjects( cat, a, b ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedCoevaluationMorphism",
+  dual_arguments_reversed := false,
+),
 
 CoevaluationMorphismWithGivenRange := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "a", "b", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedCoevaluationMorphismWithGivenSource",
+  dual_arguments_reversed := false,
+),
 
 TensorProductToInternalHomAdjunctionMap := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "a", "b", "f" ], [ "a", "i" ] ],
   return_type := "morphism",
+  dual_operation := "TensorProductToInternalCoHomAdjunctionMap",
+  dual_arguments_reversed := false,
 ),
 
 InternalHomToTensorProductAdjunctionMap := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "b", "c", "g" ], [ "t", "c" ] ],
   return_type := "morphism",
+  dual_operation := "InternalCoHomToTensorProductAdjunctionMap",
+  dual_preprocessor_func := DualPreProcessorFuncInternalHomToTensorProductAdjunctionMap,
+  dual_arguments_reversed := false,
 ),
 
 MonoidalPreComposeMorphism := rec(
@@ -68,12 +116,18 @@ MonoidalPreComposeMorphism := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, InternalHomOnObjects( cat, a, b ), InternalHomOnObjects( cat, b, c ) )",
   output_range_getter_string := "InternalHomOnObjects( cat, a, c )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPreCoComposeMorphism",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPreComposeMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPreCoComposeMorphismWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPostComposeMorphism := rec(
   filter_list := [ "category", "object", "object", "object" ],
@@ -81,17 +135,25 @@ MonoidalPostComposeMorphism := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, InternalHomOnObjects( cat, b, c ), InternalHomOnObjects( cat, a, b ) )",
   output_range_getter_string := "InternalHomOnObjects( cat, a, c )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPostCoComposeMorphism",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPostComposeMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPostCoComposeMorphismWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 DualOnObjects := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "ad" ] ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "CoDualOnObjects",
+),
 
 DualOnMorphisms := rec(
   filter_list := [ "category", "morphism" ],
@@ -99,12 +161,17 @@ DualOnMorphisms := rec(
   output_source_getter_string := "DualOnObjects( cat, Range( alpha ) )",
   output_range_getter_string := "DualOnObjects( cat, Source( alpha ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoDualOnMorphisms",
+),
 
 DualOnMorphismsWithGivenDuals := rec(
   filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoDualOnMorphismsWithGivenCoDuals",
+  dual_arguments_reversed := true,
+),
 
 EvaluationForDual := rec(
   filter_list := [ "category", "object" ],
@@ -112,12 +179,17 @@ EvaluationForDual := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, DualOnObjects( cat, a ), a )",
   output_range_getter_string := "TensorUnit( cat )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedEvaluationForCoDual",
+),
 
 EvaluationForDualWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "s", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedEvaluationForCoDualWithGivenTensorProduct",
+  dual_arguments_reversed := true,
+),
 
 MorphismToBidual := rec(
   filter_list := [ "category", "object" ],
@@ -125,12 +197,17 @@ MorphismToBidual := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "DualOnObjects( cat, DualOnObjects( cat, a ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromCoBidual",
+),
 
 MorphismToBidualWithGivenBidual := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromCoBidualWithGivenCoBidual",
+  dual_arguments_reversed := false,
+),
 
 TensorProductInternalHomCompatibilityMorphism := rec(
   filter_list := [ "category", "list_of_objects" ],
@@ -138,14 +215,22 @@ TensorProductInternalHomCompatibilityMorphism := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, InternalHomOnObjects( cat, list[1], list[2] ), InternalHomOnObjects( cat, list[3], list[4] ) )",
   output_range_getter_string := "InternalHomOnObjects( cat, TensorProductOnObjects( cat, list[1], list[3] ), TensorProductOnObjects( cat, list[2], list[4] ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomTensorProductCompatibilityMorphism",
+  dual_preprocessor_func := DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphism,
+  dual_arguments_reversed := false,
+),
 
 TensorProductInternalHomCompatibilityMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object" ],
   input_arguments_names := [ "cat", "source", "list", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 TensorProductDualityCompatibilityMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -153,12 +238,19 @@ TensorProductDualityCompatibilityMorphism := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, DualOnObjects( cat, a ), DualOnObjects( cat, b ) )",
   output_range_getter_string := "DualOnObjects( cat, TensorProductOnObjects( cat, a, b ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoDualityTensorProductCompatibilityMorphism",
+  dual_arguments_reversed := false,
+),
 
 TensorProductDualityCompatibilityMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncTensorProductDualityCompatibilityMorphismWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 MorphismFromTensorProductToInternalHom := rec(
   filter_list := [ "category", "object", "object" ],
@@ -166,41 +258,55 @@ MorphismFromTensorProductToInternalHom := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, DualOnObjects( cat, a ), b )",
   output_range_getter_string := "InternalHomOnObjects( cat, a, b )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromInternalCoHomToTensorProduct",
+  dual_arguments_reversed := true,
+),
 
 MorphismFromTensorProductToInternalHomWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromInternalCoHomToTensorProductWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 IsomorphismFromInternalHomToDual := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "i", "d" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromCoDualToInternalCoHom",
 ),
 
 IsomorphismFromDualToInternalHom := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "d", "i" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalCoHomToCoDual",
 ),
 
 UniversalPropertyOfDual := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "t", "a", "alpha" ], [ "t", "d" ] ],
   return_type := "morphism",
+  dual_operation := "UniversalPropertyOfCoDual",
+  dual_arguments_reversed := false,
 ),
 
 LambdaIntroduction := rec(
   filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "u", "i" ] ],
   return_type := "morphism",
+  dual_operation := "CoLambdaIntroduction",
 ),
 
 LambdaElimination := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "a", "b", "alpha" ], [ "a", "b" ] ],
   return_type := "morphism",
+  dual_operation := "CoLambdaElimination",
+  dual_preprocessor_func := DualPreProcessorFuncLambdaElimination,
+  dual_arguments_reversed := false,
 ),
 
 IsomorphismFromObjectToInternalHom := rec(
@@ -209,12 +315,17 @@ IsomorphismFromObjectToInternalHom := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "InternalHomOnObjects( cat, TensorUnit( cat ), a )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalCoHomToObject",
+),
 
 IsomorphismFromObjectToInternalHomWithGivenInternalHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom",
+  dual_arguments_reversed := false,
+),
 
 IsomorphismFromInternalHomToObject := rec(
   filter_list := [ "category", "object" ],
@@ -222,12 +333,17 @@ IsomorphismFromInternalHomToObject := rec(
   output_source_getter_string := "InternalHomOnObjects( cat, TensorUnit( cat ), a )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromObjectToInternalCoHom",
+),
 
 IsomorphismFromInternalHomToObjectWithGivenInternalHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom",
+  dual_arguments_reversed := false,
+),
 
 ) );
 

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.gd
@@ -51,53 +51,42 @@ DeclareOperation( "InternalCoHomOnMorphismsWithGivenInternalCoHoms",
 
 #! @Description
 #! The arguments are two objects $a, b$.
-#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a,b}: a \rightarrow b \otimes \mathrm{\underline{coHom}}(a,b)$, i.e.,
+#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a,b}: a \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes b$, i.e.,
 #! the unit of the cohom tensor adjunction.
-#! @Returns a morphism in $\mathrm{Hom}( a, b \otimes \mathrm{\underline{coHom}}(a,b) )$.
-#! @Arguments a,b
+#! @Returns a morphism in $\mathrm{Hom}( a, \mathrm{\underline{coHom}}(a,b) \otimes b )$.
+#! @Arguments a, b
 DeclareOperation( "CoclosedEvaluationMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
-## 3rd argument is $b \otimes \mathrm{\underline{coHom}}(a,b)$
 #! @Description
-#! The arguments are two objects $a,b$ and an object $r = b \otimes \mathrm{\underline{coHom}}(a,b)$.
-#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a,b}: a \rightarrow b \otimes \mathrm{\underline{coHom}}(a,b)$, i.e.,
+#! The arguments are two objects $a,b$ and an object $r = \mathrm{\underline{coHom}}(a,b) \otimes b$.
+#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a,b}: a \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes b$, i.e.,
 #! the unit of the cohom tensor adjunction.
-#! @Returns a morphism in $\mathrm{Hom}( a, b \otimes \mathrm{\underline{coHom}}(a,b) )$.
-#! @Arguments a,b, r
+#! @Returns a morphism in $\mathrm{Hom}( a, \mathrm{\underline{coHom}}(a,b) \otimes b )$.
+#! @Arguments a, b, r
 DeclareOperation( "CoclosedEvaluationMorphismWithGivenRange",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
 #! The arguments are two objects $a,b$.
-#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, a) \rightarrow b$, i.e.,
+#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, b) \rightarrow a$, i.e.,
 #! the counit of the cohom tensor adjunction.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, a), b )$.
-#! @Arguments a,b
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, b), a )$.
+#! @Arguments a, b
 DeclareOperation( "CoclosedCoevaluationMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
-## 3rd argument is $\mathrm{\underline{coHom}}(a \otimes b, a)$
 #! @Description
-#! The arguments are two objects $a,b$ and an object $s = \mathrm{\underline{coHom}(a \otimes b, a)}$.
-#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, a) \rightarrow b$, i.e.,
+#! The arguments are two objects $a,b$ and an object $s = \mathrm{\underline{coHom}(a \otimes b, b)}$.
+#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a,b}: \mathrm{\underline{coHom}}(a \otimes b, b) \rightarrow a$, i.e.,
 #! the unit of the cohom tensor adjunction.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, a), b )$.
-#! @Arguments a,b,s
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a \otimes b, b), b )$.
+#! @Arguments a, b, s
 DeclareOperation( "CoclosedCoevaluationMorphismWithGivenSource",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
-#! The arguments are objects $a,b$ and a morphism $f: \mathrm{\underline{coHom}}(a,b) \rightarrow c$.
-#! The output is a morphism $g: a \rightarrow b \otimes c$ corresponding to $f$ under the
-#! cohom tensor adjunction.
-#! @Returns a morphism in $\mathrm{Hom}(a, b \otimes c)$.
-#! @Arguments a, b, f
-DeclareOperation( "InternalCoHomToTensorProductAdjunctionMap",
-                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
-
-#! @Description
-#! The arguments are objects $b,c$ and a morphism $g: a \rightarrow b \otimes c$.
+#! The arguments are objects $c,b$ and a morphism $g: a \rightarrow c \otimes b$.
 #! The output is a morphism $f: \mathrm{\underline{coHom}}(a,b) \rightarrow c$
 #! corresponding to $g$ under the cohom tensor adjunction.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), c )$.
@@ -106,10 +95,19 @@ DeclareOperation( "TensorProductToInternalCoHomAdjunctionMap",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
 
 #! @Description
+#! The arguments are objects $a,b$ and a morphism $f: \mathrm{\underline{coHom}}(a,b) \rightarrow c$.
+#! The output is a morphism $g: a \rightarrow c \otimes b$ corresponding to $f$ under the
+#! cohom tensor adjunction.
+#! @Returns a morphism in $\mathrm{Hom}(a, c \otimes b)$.
+#! @Arguments a, b, f
+DeclareOperation( "InternalCoHomToTensorProductAdjunctionMap",
+                  [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
 #! The arguments are three objects $a,b,c$.
 #! The output is the precocomposition morphism
-#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
+#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
 #! @Arguments a,b,c
 DeclareOperation( "MonoidalPreCoComposeMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
@@ -120,8 +118,8 @@ DeclareOperation( "MonoidalPreCoComposeMorphism",
 #! three objects $a,b,c$,
 #! and an object $r = \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
 #! The output is the precocomposition morphism
-#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
+#! $\mathrm{MonoidalPreCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
 #! @Arguments s,a,b,c,r
 DeclareOperation( "MonoidalPreCoComposeMorphismWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
@@ -129,8 +127,8 @@ DeclareOperation( "MonoidalPreCoComposeMorphismWithGivenObjects",
 #! @Description
 #! The arguments are three objects $a,b,c$.
 #! The output is the postcocomposition morphism
-#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
 #! @Arguments a,b,c
 DeclareOperation( "MonoidalPostCoComposeMorphism",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
@@ -141,8 +139,8 @@ DeclareOperation( "MonoidalPostCoComposeMorphism",
 #! three objects $a,b,c$,
 #! and an object $r = \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
 #! The output is the postcocomposition morphism
-#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(b,c) \otimes \mathrm{\underline{coHom}}(a,b) )$.
+#! $\mathrm{MonoidalPostCoComposeMorphismWithGivenObjects}_{a,b,c}: \mathrm{\underline{coHom}}(a,c) \rightarrow \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c)$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,c), \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(b,c) )$.
 #! @Arguments s,a,b,c,r
 DeclareOperation( "MonoidalPostCoComposeMorphismWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
@@ -175,19 +173,18 @@ DeclareOperation( "CoDualOnMorphismsWithGivenCoDuals",
 
 #! @Description
 #! The argument is an object $a$.
-#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a}: 1 \rightarrow a \otimes a_{\vee}$.
-#! @Returns a morphism in $\mathrm{Hom}( 1, a \otimes a_{\vee} )$.
+#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a}: 1 \rightarrow a_{\vee} \otimes a$.
+#! @Returns a morphism in $\mathrm{Hom}( 1, a_{\vee} \otimes a )$.
 #! @Arguments a
 DeclareAttribute( "CoclosedEvaluationForCoDual",
                   IsCapCategoryObject );
 
-
 #! @Description
 #! The arguments are an object $s = 1$,
 #! an object $a$,
-#! and an object $r = a \otimes a_{\vee}$.
-#! The output is the coclosed evaluation morphism $\mathrm{cocloev}_{a}: 1 \rightarrow a \otimes a_{\vee}$.
-#! @Returns a morphism in $\mathrm{Hom}( 1, a \otimes a_{\vee} )$.
+#! and an object $r = a_{\vee} \otimes a$.
+#! The output is the coclosed evaluation morphism $\mathrm{coclev}_{a}: 1 \rightarrow a_{\vee} \otimes a$.
+#! @Returns a morphism in $\mathrm{Hom}( 1, a_{\vee} \otimes a )$.
 #! @Arguments s,a,r
 DeclareOperation( "CoclosedEvaluationForCoDualWithGivenTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
@@ -209,7 +206,7 @@ DeclareAttribute( "MorphismFromCoBidual",
 DeclareOperation( "MorphismFromCoBidualWithGivenCoBidual",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
-## The four objects are given are given as a list because otherwise the WithGiven operation would
+## The four objects are given as a list because otherwise the WithGiven operation would
 ## exceed the maximal number of arguments for an operation (6)
 #! @Description
 #! The argument is a list of four objects $[ a, a', b, b' ]$.
@@ -252,8 +249,8 @@ DeclareOperation( "CoDualityTensorProductCompatibilityMorphismWithGivenObjects",
 
 #! @Description
 #! The arguments are two objects $a,b$.
-#! The output is the natural morphism $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow a \otimes b_{\vee}$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), a \otimes b_{\vee} )$.
+#! The output is the natural morphism $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow b_{\vee} \otimes a$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), b_{\vee} \otimes a )$.
 #! @Arguments a,b
 DeclareOperation( "MorphismFromInternalCoHomToTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
@@ -261,7 +258,7 @@ DeclareOperation( "MorphismFromInternalCoHomToTensorProduct",
 #! @Description
 #! The arguments are an object $s = \mathrm{\underline{coHom}}(a,b)$,
 #! two objects $a,b$,
-#! and an object $r = a \otimes b_{\vee}$.
+#! and an object $r = b_{\vee} \otimes a$.
 #! The output is the natural morphism $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow a \otimes b_{\vee}$.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), a \otimes b_{\vee} )$.
 #! @Arguments s,a,b,r
@@ -287,12 +284,12 @@ DeclareAttribute( "IsomorphismFromInternalCoHomToCoDual",
                   IsCapCategoryObject );
 
 #! @Description
-#! The arguments are two objects $a,t$,
-#! and a morphism $\alpha: 1 \rightarrow a \otimes t$.
+#! The arguments are two objects $t,a$,
+#! and a morphism $\alpha: 1 \rightarrow t \otimes a$.
 #! The output is the morphism $a_{\vee} \rightarrow t$
 #! given by the universal property of $a_{\vee}$.
 #! @Returns a morphism in $\mathrm{Hom}(a_{\vee}, t)$.
-#! @Arguments a, t, alpha
+#! @Arguments t, a, alpha
 DeclareOperation( "UniversalPropertyOfCoDual",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ] );
 

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDoc.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDoc.gd
@@ -13,7 +13,7 @@
 ####################################
 
 #! A monoidal category $\mathbf{C}$
-#! which has for each functor $b \otimes -: \mathbf{C} \rightarrow \mathbf{C}$
+#! which has for each functor $- \otimes b: \mathbf{C} \rightarrow \mathbf{C}$
 #! a left adjoint (denoted by $\mathrm{\underline{coHom}}(-,b)$)
 #! is called a <Emph>coclosed monoidal category</Emph>.
 

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,27 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
 #
+# Preprocessor functions for dual operations
+#
+
+BindGlobal( "DualPreProcessorFuncCoclosedEvaluationMorphismWithGivenRange", { cat, a, b, r } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( r ) ] );
+
+BindGlobal( "DualPreProcessorFuncInternalCoHomToTensorProductAdjunctionMap", { cat, a, b, f } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( f ) ] );
+
+BindGlobal( "DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphism",
+              { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ] ]
+);
+
+BindGlobal( "DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
+              { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ], Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncCoDualityTensorProductCompatibilityMorphismWithGivenObjects",
+              { cat, s, a, b, r} -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncCoLambdaElimination", { cat, a, b, alpha } -> [ Opposite( cat ), Opposite( b ), Opposite( a ), Opposite( alpha ) ] );
+
 # Implementations
 #
 
@@ -9,7 +30,10 @@ InstallValue( COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD, rec(
 InternalCoHomOnObjects := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "i" ] ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "InternalHomOnObjects",
+  dual_arguments_reversed := true,
+),
 
 InternalCoHomOnMorphisms := rec(
   filter_list := [ "category", "morphism", "morphism" ],
@@ -17,12 +41,18 @@ InternalCoHomOnMorphisms := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, Source( alpha ), Range( beta ) )",
   output_range_getter_string := "InternalCoHomOnObjects( cat, Range( alpha ), Source( beta ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalHomOnMorphisms",
+  dual_arguments_reversed := true,
+),
 
 InternalCoHomOnMorphismsWithGivenInternalCoHoms := rec(
   filter_list := [ "category", "object", "morphism", "morphism", "object" ],
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalHomOnMorphismsWithGivenInternalHoms",
+  dual_arguments_reversed := true,
+),
 
 CoclosedEvaluationMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -30,12 +60,19 @@ CoclosedEvaluationMorphism := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "TensorProductOnObjects( cat, b, InternalCoHomOnObjects( cat, a, b ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "EvaluationMorphism",
+  dual_arguments_reversed := true,
+),
 
 CoclosedEvaluationMorphismWithGivenRange := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "a", "b", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "EvaluationMorphismWithGivenSource",
+  dual_preprocessor_func := DualPreProcessorFuncCoclosedEvaluationMorphismWithGivenRange,
+  dual_arguments_reversed := false,
+),
 
 CoclosedCoevaluationMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -43,23 +80,34 @@ CoclosedCoevaluationMorphism := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, TensorProductOnObjects( cat, a, b ), a )",
   output_range_getter_string := "b",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoevaluationMorphism",
+  dual_arguments_reversed := false,
+),
 
 CoclosedCoevaluationMorphismWithGivenSource := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "a", "b", "s" ], [ "s", "b" ] ],
-  return_type := "morphism" ),
-
-InternalCoHomToTensorProductAdjunctionMap := rec(
-  filter_list := [ "category", "object", "object", "morphism" ],
-  io_type := [ [ "a", "b", "f" ], [ "a", "t" ] ],
   return_type := "morphism",
+  dual_operation := "CoevaluationMorphismWithGivenRange",
+  dual_arguments_reversed := false,
 ),
 
 TensorProductToInternalCoHomAdjunctionMap := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "b", "c", "g" ], [ "i", "c" ] ],
   return_type := "morphism",
+  dual_operation := "TensorProductToInternalHomAdjunctionMap",
+  dual_arguments_reversed := false,
+),
+
+InternalCoHomToTensorProductAdjunctionMap := rec(
+  filter_list := [ "category", "object", "object", "morphism" ],
+  io_type := [ [ "a", "b", "f" ], [ "a", "t" ] ],
+  return_type := "morphism",
+  dual_operation := "InternalHomToTensorProductAdjunctionMap",
+  dual_preprocessor_func := DualPreProcessorFuncInternalCoHomToTensorProductAdjunctionMap,
+  dual_arguments_reversed := false,
 ),
 
 MonoidalPreCoComposeMorphism := rec(
@@ -68,12 +116,18 @@ MonoidalPreCoComposeMorphism := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, a, c )",
   output_range_getter_string := "TensorProductOnObjects( cat, InternalCoHomOnObjects( cat, a, b ), InternalCoHomOnObjects( cat, b, c ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPreComposeMorphism",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPreCoComposeMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPreComposeMorphismWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPostCoComposeMorphism := rec(
   filter_list := [ "category", "object", "object", "object" ],
@@ -81,17 +135,25 @@ MonoidalPostCoComposeMorphism := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, a, c )",
   output_range_getter_string := "TensorProductOnObjects( cat, InternalCoHomOnObjects( cat, b, c ), InternalCoHomOnObjects( cat, a, b ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPostComposeMorphism",
+  dual_arguments_reversed := true,
+),
 
 MonoidalPostCoComposeMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MonoidalPostComposeMorphismWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 CoDualOnObjects := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "acd" ] ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "DualOnObjects",
+),
 
 CoDualOnMorphisms := rec(
   filter_list := [ "category", "morphism" ],
@@ -99,12 +161,17 @@ CoDualOnMorphisms := rec(
   output_source_getter_string := "CoDualOnObjects( cat, Range( alpha ) )",
   output_range_getter_string := "CoDualOnObjects( cat, Source( alpha ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "DualOnMorphisms",
+),
 
 CoDualOnMorphismsWithGivenCoDuals := rec(
   filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "DualOnMorphismsWithGivenDuals",
+  dual_arguments_reversed := true,
+),
 
 CoclosedEvaluationForCoDual := rec(
   filter_list := [ "category", "object" ],
@@ -112,12 +179,17 @@ CoclosedEvaluationForCoDual := rec(
   output_source_getter_string := "TensorUnit( cat )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, CoDualOnObjects( cat, a ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "EvaluationForDual",
+),
 
 CoclosedEvaluationForCoDualWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "s", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "EvaluationForDualWithGivenTensorProduct",
+  dual_arguments_reversed := true,
+),
 
 MorphismFromCoBidual := rec(
   filter_list := [ "category", "object" ],
@@ -125,12 +197,17 @@ MorphismFromCoBidual := rec(
   output_source_getter_string := "CoDualOnObjects( cat, CoDualOnObjects( cat, a ) )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismToBidual",
+),
 
 MorphismFromCoBidualWithGivenCoBidual := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismToBidualWithGivenBidual",
+  dual_arguments_reversed := false,
+),
 
 InternalCoHomTensorProductCompatibilityMorphism := rec(
   filter_list := [ "category", "list_of_objects" ],
@@ -138,14 +215,22 @@ InternalCoHomTensorProductCompatibilityMorphism := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, TensorProductOnObjects( cat, list[1], list[2] ), TensorProductOnObjects( cat, list[3], list[4] ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, InternalCoHomOnObjects( cat, list[1], list[3] ), InternalCoHomOnObjects( cat, list[2], list[4] ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductInternalHomCompatibilityMorphism",
+  dual_preprocessor_func := DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphism,
+  dual_arguments_reversed := false,
+),
 
 InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object" ],
   input_arguments_names := [ "cat", "source", "list", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductInternalHomCompatibilityMorphismWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 CoDualityTensorProductCompatibilityMorphism := rec(
   filter_list := [ "category", "object", "object" ],
@@ -153,12 +238,19 @@ CoDualityTensorProductCompatibilityMorphism := rec(
   output_source_getter_string := "CoDualOnObjects( cat, TensorProductOnObjects( cat, a, b ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, CoDualOnObjects( cat, a ), CoDualOnObjects( cat, b ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductDualityCompatibilityMorphism",
+  dual_arguments_reversed := false,
+),
 
 CoDualityTensorProductCompatibilityMorphismWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductDualityCompatibilityMorphismWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncCoDualityTensorProductCompatibilityMorphismWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 MorphismFromInternalCoHomToTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
@@ -166,41 +258,55 @@ MorphismFromInternalCoHomToTensorProduct := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, a, b )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromTensorProductToInternalHom",
+  dual_arguments_reversed := true,
+),
 
 MorphismFromInternalCoHomToTensorProductWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromTensorProductToInternalHomWithGivenObjects",
+  dual_arguments_reversed := true,
+),
 
 IsomorphismFromCoDualToInternalCoHom := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "i", "d" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalHomToDual",
 ),
 
 IsomorphismFromInternalCoHomToCoDual := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "d", "i" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromDualToInternalHom",
 ),
 
 UniversalPropertyOfCoDual := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "a", "t", "alpha" ], [ "d", "t" ] ],
   return_type := "morphism",
+  dual_operation := "UniversalPropertyOfDual",
+  dual_arguments_reversed := false,
 ),
 
 CoLambdaIntroduction := rec(
   filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "u", "i" ] ],
   return_type := "morphism",
+  dual_operation := "LambdaIntroduction",
 ),
 
 CoLambdaElimination := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
   io_type := [ [ "a", "b", "alpha" ], [ "a", "b" ] ],
   return_type := "morphism",
+  dual_operation := "LambdaElimination",
+  dual_preprocessor_func := DualPreProcessorFuncCoLambdaElimination,
+  dual_arguments_reversed := false,
 ),
 
 IsomorphismFromObjectToInternalCoHom := rec(
@@ -209,12 +315,17 @@ IsomorphismFromObjectToInternalCoHom := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "InternalCoHomOnObjects( cat, a, TensorUnit( cat ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalHomToObject",
+),
 
 IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalHomToObjectWithGivenInternalHom",
+  dual_arguments_reversed := false,
+),
 
 IsomorphismFromInternalCoHomToObject := rec(
   filter_list := [ "category", "object" ],
@@ -222,12 +333,17 @@ IsomorphismFromInternalCoHomToObject := rec(
   output_source_getter_string := "InternalCoHomOnObjects( cat, a, TensorUnit( cat ) )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromObjectToInternalHom",
+),
 
 IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "IsomorphismFromObjectToInternalHomWithGivenInternalHom",
+  dual_arguments_reversed := false,
+),
 
 ) );
 

--- a/MonoidalCategories/gap/MonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
 #
+# Preprocessor functions for dual operations
+#
+
+BindGlobal( "DualPreProcessorFuncAssociatorRightToLeftWithGivenTensorProducts",
+              { cat, s, a, b, c, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( c ), Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncAssociatorLeftToRightWithGivenTensorProducts",
+              { cat, s, a, b, c, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( c ), Opposite( s ) ]
+);
+
 # Implementations
 #
 
@@ -14,12 +25,18 @@ TensorProductOnMorphisms := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, Source( alpha ), Source( beta ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, Range( alpha ), Range( beta ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductOnMorphisms",
+  dual_arguments_reversed := false,
+),
 
 TensorProductOnMorphismsWithGivenTensorProducts := rec(
   filter_list := [ "category", "object", "morphism", "morphism", "object" ],
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductOnMorphismsWithGivenTensorProducts",
+  dual_arguments_reversed := false,
+),
 
 AssociatorRightToLeft := rec(
   filter_list := [ "category", "object", "object", "object" ],
@@ -27,12 +44,19 @@ AssociatorRightToLeft := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, a, TensorProductOnObjects( cat, b, c ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, TensorProductOnObjects( cat, a, b ), c )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "AssociatorLeftToRight",
+  dual_arguments_reversed := false,
+),
 
 AssociatorRightToLeftWithGivenTensorProducts := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "AssociatorLeftToRightWithGivenTensorProducts",
+  dual_preprocessor_func := DualPreProcessorFuncAssociatorRightToLeftWithGivenTensorProducts,
+  dual_arguments_reversed := false,
+),
 
 AssociatorLeftToRight := rec(
   filter_list := [ "category", "object", "object", "object" ],
@@ -40,12 +64,19 @@ AssociatorLeftToRight := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, TensorProductOnObjects( cat, a, b ), c )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, TensorProductOnObjects( cat, b, c ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "AssociatorRightToLeft",
+  dual_arguments_reversed := false,
+),
 
 AssociatorLeftToRightWithGivenTensorProducts := rec(
   filter_list := [ "category", "object", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "c", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "AssociatorRightToLeftWithGivenTensorProducts",
+  dual_preprocessor_func := DualPreProcessorFuncAssociatorLeftToRightWithGivenTensorProducts,
+  dual_arguments_reversed := false,
+),
 
 LeftUnitor := rec(
   filter_list := [ "category", "object" ],
@@ -53,12 +84,17 @@ LeftUnitor := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, TensorUnit( cat ), a )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftUnitorInverse",
+),
 
 LeftUnitorWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftUnitorInverseWithGivenTensorProduct",
+  dual_arguments_reversed := false,
+),
 
 LeftUnitorInverse := rec(
   filter_list := [ "category", "object" ],
@@ -66,12 +102,17 @@ LeftUnitorInverse := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "TensorProductOnObjects( cat, TensorUnit( cat ), a )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftUnitor",
+),
 
 LeftUnitorInverseWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftUnitorWithGivenTensorProduct",
+  dual_arguments_reversed := false,
+),
 
 RightUnitor := rec(
   filter_list := [ "category", "object" ],
@@ -79,12 +120,17 @@ RightUnitor := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, a, TensorUnit( cat ) )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightUnitorInverse",
+),
 
 RightUnitorWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightUnitorInverseWithGivenTensorProduct",
+  dual_arguments_reversed := false,
+),
 
 RightUnitorInverse := rec(
   filter_list := [ "category", "object" ],
@@ -92,12 +138,17 @@ RightUnitorInverse := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "TensorProductOnObjects( cat, a, TensorUnit( cat ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightUnitor",
+),
 
 RightUnitorInverseWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightUnitorWithGivenTensorProduct",
+  dual_arguments_reversed := false,
+),
 
 ) );
 

--- a/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitMethodRecord.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitMethodRecord.gi
@@ -8,11 +8,16 @@ InstallValue( MONOIDAL_CATEGORIES_BASIC_METHOD_NAME_RECORD, rec(
 
 TensorProductOnObjects := rec(
   filter_list := [ "category", "object", "object" ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "TensorProductOnObjects",
+  dual_arguments_reversed := false,
+),
 
 TensorUnit := rec(
   filter_list := [ "category" ],
-  return_type := "object" ),
+  return_type := "object",
+  dual_operation := "TensorUnit",
+),
 
 ) );
 

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategories.gd
@@ -24,13 +24,21 @@ DeclareOperation( "IsomorphismFromTensorProductToInternalHom",
 
 #! @Description
 #! The arguments are two objects $a,b$.
+#! The output is the inverse of $\mathrm{IsomorphismFromTensorProductToInternalHom}$, namely
+#! $\mathrm{IsomorphismFromInternalHomToTensorProduct}_{a,b}: \mathrm{\underline{Hom}}(a,b) \rightarrow a^{\vee} \otimes b$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a,b), a^{\vee} \otimes b )$.
+#! @Arguments a,b
+DeclareOperation( "IsomorphismFromInternalHomToTensorProduct",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are two objects $a,b$.
 #! The output is the inverse of $\mathrm{MorphismFromTensorProductToInternalHomWithGivenObjects}$, namely
 #! $\mathrm{MorphismFromInternalHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{Hom}}(a,b) \rightarrow a^{\vee} \otimes b$.
 #! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a,b), a^{\vee} \otimes b )$.
 #! @Arguments a,b
 DeclareOperation( "MorphismFromInternalHomToTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
-
 
 #! @Description
 #! The arguments are an object $s = \mathrm{\underline{Hom}}(a,b)$,
@@ -43,22 +51,13 @@ DeclareOperation( "MorphismFromInternalHomToTensorProduct",
 DeclareOperation( "MorphismFromInternalHomToTensorProductWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
-#! @Description
-#! The arguments are two objects $a,b$.
-#! The output is the inverse of $\mathrm{IsomorphismFromTensorProductToInternalHom}$, namely
-#! $\mathrm{IsomorphismFromInternalHomToTensorProduct}_{a,b}: \mathrm{\underline{Hom}}(a,b) \rightarrow a^{\vee} \otimes b$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a,b), a^{\vee} \otimes b )$.
-#! @Arguments a,b
-DeclareOperation( "IsomorphismFromInternalHomToTensorProduct",
-                  [ IsCapCategoryObject, IsCapCategoryObject ] );
-
-## The four objects are given are given as a list because otherwise the WithGiven operation would
+## The four objects are given as a list because otherwise the WithGiven operation would
 ## exceed the maximal number of arguments for an operation (6)
 #! @Description
 #! The argument is a list of four objects $[ a, a', b, b' ]$.
 #! The output is the natural morphism
 #! $\mathrm{TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b') \rightarrow \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b')$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b'), \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b'))$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b'), \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b') )$.
 #! @Arguments list
 DeclareOperation( "TensorProductInternalHomCompatibilityMorphismInverse",
                   [ IsList ] );
@@ -68,7 +67,7 @@ DeclareOperation( "TensorProductInternalHomCompatibilityMorphismInverse",
 #! and two objects $s = \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b')$ and $r = \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b')$.
 #! The output is the natural morphism
 #! $\mathrm{TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b') \rightarrow \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b')$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b'), \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b'))$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{Hom}}(a \otimes b,a' \otimes b'), \mathrm{\underline{Hom}}(a,a') \otimes \mathrm{\underline{Hom}}(b,b') )$.
 #! @Arguments s, list, r
 DeclareOperation( "TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects",
                   [ IsCapCategoryObject, IsList, IsCapCategoryObject ] );
@@ -92,7 +91,7 @@ DeclareOperation( "CoevaluationForDualWithGivenTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
-#! The argument is an endomorphism $\alpha: A \rightarrow A$.
+#! The argument is an endomorphism $\alpha: a \rightarrow a$.
 #! The output is the trace morphism $\mathrm{trace}_{\alpha}: 1 \rightarrow 1$.
 #! @Returns a morphism in $\mathrm{Hom}(1,1)$.
 #! @Arguments alpha

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -7,9 +7,11 @@
 ##
 AddDerivationToCAP( InternalHomOnObjects,
                   
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return Source( IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ) );
+    # Source( Hom(a,b) -> a^v x b )
+
+    return Source( IsomorphismFromInternalHomToTensorProduct( cat, a, b ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalHomOnObjects as the source of IsomorphismFromInternalHomToTensorProduct" );
@@ -17,9 +19,11 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalHomOnObjects,
                   
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
+
+    # Range( a^v x b -> Hom(a,b) )
     
-    return Range( IsomorphismFromTensorProductToInternalHom( cat, object_1, object_2 ) );
+    return Range( IsomorphismFromTensorProductToInternalHom( cat, a, b ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalHomOnObjects as the range of IsomorphismFromTensorProductToInternalHom" );
@@ -27,15 +31,32 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalHomOnMorphismsWithGivenInternalHoms,
                   
-  function( cat, internal_hom_source, morphism_1, morphism_2, internal_hom_range )
-    local dual_morphism;
+  function( cat, internal_hom_source, alpha, beta, internal_hom_range )
+    local dual_alpha;
+
+    # alpha: a -> a'
+    # beta: b -> b'
+    #
+    # Hom(a',b)
+    #     |
+    #     |
+    #     v
+    # a'^v x b
+    #     |
+    #     | Dual(alpha) x beta
+    #     v
+    # a^v x b'
+    #     |
+    #     |
+    #     v
+    # Hom(a,b')
     
-    dual_morphism := DualOnMorphisms( cat, morphism_1 );
+    dual_alpha := DualOnMorphisms( cat, alpha );
     
     return PreComposeList( cat, [
-             IsomorphismFromInternalHomToTensorProduct( cat, Range( morphism_1 ), Source( morphism_2 ) ),
-             TensorProductOnMorphisms( cat, dual_morphism, morphism_2 ),
-             IsomorphismFromTensorProductToInternalHom( cat, Source( morphism_1 ), Range( morphism_2 ) )
+             IsomorphismFromInternalHomToTensorProduct( cat, Range( alpha ), Source( beta ) ),
+             TensorProductOnMorphisms( cat, dual_alpha, beta ),
+             IsomorphismFromTensorProductToInternalHom( cat, Source( alpha ), Range( beta ) )
            ] );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
@@ -44,9 +65,11 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromBidualWithGivenBidual,
                   
-  function( cat, object, bidual )
+  function( cat, a, bidual )
+
+    # Inverse( a -> (a^v)^v )
     
-    return InverseForMorphisms( cat, MorphismToBidualWithGivenBidual( cat, object, bidual ) );
+    return InverseForMorphisms( cat, MorphismToBidualWithGivenBidual( cat, a, bidual ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromBidualWithGivenBidual as the inverse of MorphismToBidualWithGivenBidual" );
@@ -54,9 +77,11 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismToBidualWithGivenBidual,
                   
-  function( cat, object, bidual )
+  function( cat, a, bidual )
+
+    # Inverse( (a^v)^v -> a )
     
-    return InverseForMorphisms( cat, MorphismFromBidualWithGivenBidual( cat, object, bidual ) );
+    return InverseForMorphisms( cat, MorphismFromBidualWithGivenBidual( cat, a, bidual ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismToBidualWithGivenBidual as the inverse of MorphismFromBidualWithGivenBidual" );
@@ -64,25 +89,47 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( EvaluationMorphismWithGivenSource,
                   
-  function( cat, object_1, object_2, internal_hom_tensored_object_1 )
+  function( cat, a, b, internal_hom_tensored_a )
     local morphism;
+
+    # Hom(a,b) x a
+    #      |
+    #      | Isomorphism x id_a
+    #      v
+    # (a^v x b) x a
+    #      |
+    #      | B_( Dual(a), b ) x id_a
+    #      v
+    # (b x a^v) x a
+    #      |
+    #      | α_( ( b, a^v ), a )
+    #      v
+    # b x (a^v x a)
+    #      |
+    #      | id_b x ev_a
+    #      v
+    #    b x 1
+    #      |
+    #      | ρ_b
+    #      v
+    #      b
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat, 
-                    IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
+                    IsomorphismFromInternalHomToTensorProduct( cat, a, b ),
+                    IdentityMorphism( cat, a ) ),
                     
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, DualOnObjects( cat, object_1 ), object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
+                    Braiding( cat, DualOnObjects( cat, a ), b ),
+                    IdentityMorphism( cat, a ) ),
                     
-                  AssociatorLeftToRight( cat, object_2, DualOnObjects( cat, object_1 ), object_1 ),
+                  AssociatorLeftToRight( cat, b, DualOnObjects( cat, a ), a ),
                   
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, object_2 ),
-                    EvaluationForDual( cat, object_1 ) ),
+                    IdentityMorphism( cat, b ),
+                    EvaluationForDual( cat, a ) ),
                     
-                  RightUnitor( cat, object_2 )
+                  RightUnitor( cat, b )
                 ] );
       
     return morphism;
@@ -93,21 +140,35 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( EvaluationMorphismWithGivenSource,
                     
-  function( cat, object_1, object_2, internal_hom_tensored_object_1 )
+  function( cat, a, b, internal_hom_tensored_a )
     local morphism;
+
+    # Hom(a,b) x a
+    #      |
+    #      | Isomorphism x id_a
+    #      v
+    # a^v x b x a
+    #      |
+    #      | B_( Dual(a), b ) x id_a
+    #      v
+    # b x a^v x a
+    #      |
+    #      | id_b x ev_a
+    #      v
+    #    b x 1
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat, 
-                    IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
+                    IsomorphismFromInternalHomToTensorProduct( cat, a, b ),
+                    IdentityMorphism( cat, a ) ),
                     
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, DualOnObjects( cat, object_1 ), object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
+                    Braiding( cat, DualOnObjects( cat, a ), b ),
+                    IdentityMorphism( cat, a ) ),
                     
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, object_2 ),
-                    EvaluationForDual( cat, object_1 ) )
+                    IdentityMorphism( cat, b ),
+                    EvaluationForDual( cat, a ) )
                 ] );
                     
     return morphism;
@@ -118,33 +179,59 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory and IsStrictMonoi
 ##
 AddDerivationToCAP( CoevaluationMorphismWithGivenRange,
                     
-  function( cat, object_1, object_2, internal_hom )
-    local morphism, dual_2, id_1;
+  function( cat, a, b, internal_hom )
+    local morphism, dual_b, id_a;
+
+    #      a
+    #      |
+    #      | (λ_a)^-1
+    #      v
+    #    1 x a
+    #      |
+    #      | coev_b x id_a
+    #      v
+    # (b x b^v) x a
+    #      |
+    #      | B_( b, b^v ) x id_a
+    #      v
+    # (b^v x b) x a
+    #      |
+    #      | α_( ( b^v, b ), a )
+    #      v
+    # b^v x (b x a)
+    #      |
+    #      | id_(b^v) x B_( b, a )
+    #      v
+    # b^v x (a x b)
+    #      |
+    #      | Isomorphism
+    #      v
+    # Hom(b, a x b)
     
-    dual_2 := DualOnObjects( cat, object_2 );
+    dual_b := DualOnObjects( cat, b );
     
-    id_1 := IdentityMorphism( cat, object_1 );
+    id_a := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
-                  LeftUnitorInverse( cat, object_1 ),
+                  LeftUnitorInverse( cat, a ),
                     
                   TensorProductOnMorphisms( cat,
-                    CoevaluationForDual( cat, object_2 ),
-                    id_1 ),
+                    CoevaluationForDual( cat, b ),
+                    id_a ),
                     
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, object_2, dual_2 ),
-                    id_1 ),
+                    Braiding( cat, b, dual_b ),
+                    id_a ),
                     
-                  AssociatorLeftToRight( cat, dual_2, object_2, object_1 ),
+                  AssociatorLeftToRight( cat, dual_b, b, a ),
                     
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, dual_2 ),
-                    Braiding( cat, object_2, object_1 ) ),
+                    IdentityMorphism( cat, dual_b ),
+                    Braiding( cat, b, a ) ),
                     
                   IsomorphismFromTensorProductToInternalHom( cat,
-                    object_2,
-                    TensorProductOnObjects( cat, object_1, object_2 ) )
+                    b,
+                    TensorProductOnObjects( cat, a, b ) )
                 ] );
                     
     return morphism;
@@ -155,29 +242,47 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoevaluationMorphismWithGivenRange,
                     
-  function( cat, object_1, object_2, internal_hom )
-    local morphism, dual_2, id_1;
+  function( cat, a, b, internal_hom )
+    local morphism, dual_b, id_a;
+
+    # 1 x a
+    #   |
+    #   | coev_b x id_a
+    #   v
+    # b x b^v x a
+    #   |
+    #   | B_( b, b^v ) x id_a
+    #   v
+    # b^v x b x a
+    #   |
+    #   | id_(b^v) x B_( b, a )
+    #   v
+    # b^v x a x b
+    #   |
+    #   | Isomorphism
+    #   v
+    # Hom(b, a x b)
     
-    dual_2 := DualOnObjects( cat, object_2 );
+    dual_b := DualOnObjects( cat, b );
     
-    id_1 := IdentityMorphism( cat, object_1 );
+    id_a := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat,
-                    CoevaluationForDual( cat, object_2 ),
-                    id_1 ),
+                    CoevaluationForDual( cat, b ),
+                    id_a ),
                     
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, object_2, dual_2 ),
-                    id_1 ),
+                    Braiding( cat, b, dual_b ),
+                    id_a ),
                     
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, dual_2 ),
-                    Braiding( cat, object_2, object_1 ) ),
+                    IdentityMorphism( cat, dual_b ),
+                    Braiding( cat, b, a ) ),
                     
                   IsomorphismFromTensorProductToInternalHom( cat,
-                    object_2,
-                    TensorProductOnObjects( cat, object_1, object_2 ) )
+                    b,
+                    TensorProductOnObjects( cat, a, b ) )
                 ] );
     
     return morphism;
@@ -188,9 +293,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory and IsStrictMonoi
 ##
 AddDerivationToCAP( MorphismFromTensorProductToInternalHomWithGivenObjects,
                   
-  function( cat, tensor_object, object_1, object_2, internal_hom )
+  function( cat, tensor_object, a, b, internal_hom )
     
-    return IsomorphismFromTensorProductToInternalHom( cat, object_1, object_2 );
+    return IsomorphismFromTensorProductToInternalHom( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromTensorProductToInternalHomWithGivenObjects using IsomorphismFromTensorProductToInternalHom" );
@@ -198,9 +303,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromInternalHomToTensorProductWithGivenObjects,
                   
-  function( cat, tensor_object, object_1, object_2, internal_hom )
+  function( cat, tensor_object, a, b, internal_hom )
     
-    return IsomorphismFromInternalHomToTensorProduct( cat, object_1, object_2 );
+    return IsomorphismFromInternalHomToTensorProduct( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromInternalHomToTensorProductWithGivenObjects using IsomorphismFromInternalHomToTensorProduct" );
@@ -208,9 +313,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromInternalHomToTensorProduct,
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return MorphismFromInternalHomToTensorProduct( cat, object_1, object_2 );
+    return MorphismFromInternalHomToTensorProduct( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToTensorProduct using MorphismFromInternalHomToTensorProduct" );
@@ -218,9 +323,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromTensorProductToInternalHom,
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return MorphismFromTensorProductToInternalHom( cat, object_1, object_2 );
+    return MorphismFromTensorProductToInternalHom( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalHom using MorphismFromTensorProductToInternalHom" );
@@ -228,15 +333,29 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoevaluationForDualWithGivenTensorProduct,
                     
-  function( cat, unit, object, tensor_object )
+  function( cat, unit, a, tensor_object )
     local morphism;
+
+    #    1
+    #    |
+    #    | LambdaIntro( id_a )
+    #    v
+    # Hom(a,a)
+    #    |
+    #    | Isomorphism
+    #    v
+    # a^v x a
+    #    |
+    #    | B_( a^v, a )
+    #    v
+    # a x a^v
     
-    morphism := IdentityMorphism( cat, object );
+    morphism := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
                   LambdaIntroduction( cat, morphism ),
-                  IsomorphismFromInternalHomToTensorProduct( cat, object, object ),
-                  Braiding( cat, DualOnObjects( cat, object ), object )
+                  IsomorphismFromInternalHomToTensorProduct( cat, a, a ),
+                  Braiding( cat, DualOnObjects( cat, a ), a )
                 ] );
                             
     return morphism;
@@ -247,15 +366,31 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( TraceMap,
                     
-  function( cat, morphism )
-    local result_morphism, object;
+  function( cat, alpha )
+    local result_morphism, a;
+
+    # alpha: a -> a
+    #
+    #    1
+    #    |
+    #    | LambdaIntro( alpha )
+    #    v
+    # Hom(a,a)
+    #    |
+    #    | Isomorphism
+    #    v
+    # a^v x a
+    #    |
+    #    | ev_a
+    #    v
+    #    1
     
-    object := Source( morphism );
+    a := Source( alpha );
     
     result_morphism := PreComposeList( cat, [
-                         LambdaIntroduction( cat, morphism ),
-                         IsomorphismFromInternalHomToTensorProduct( cat, object, object ),
-                         EvaluationForDual( cat, object )
+                         LambdaIntroduction( cat, alpha ),
+                         IsomorphismFromInternalHomToTensorProduct( cat, a, a ),
+                         EvaluationForDual( cat, a )
                        ] );
     
     return result_morphism;
@@ -266,9 +401,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( RankMorphism,
                     
-  function( cat, object )
+  function( cat, a )
     
-    return TraceMap( cat, IdentityMorphism( cat, object ) );
+    return TraceMap( cat, IdentityMorphism( cat, a ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "Rank of an object as the trace of its identity" );
@@ -277,6 +412,8 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects,
                     
   function( cat, source, list, range )
+
+    # Inverse( Hom(a,a') x Hom(b,b') -> Hom(a x b, a' x b') )
     
     return InverseForMorphisms( cat, TensorProductInternalHomCompatibilityMorphismWithGivenObjects( cat, source, list, range ) );
     
@@ -309,9 +446,9 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalHom,
                       IsomorphismFromTensorProductToInternalHom,
                       IsomorphismFromInternalHomToTensorProduct ],
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, object_1 ), object_2 ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, a ), b ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalHom as the identity of (Dual(a) tensored b)" );
@@ -336,9 +473,9 @@ AddFinalDerivation( IsomorphismFromInternalHomToTensorProduct,
                       IsomorphismFromTensorProductToInternalHom,
                       IsomorphismFromInternalHomToTensorProduct ],
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, object_1 ), object_2 ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, a ), b ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToTensorProduct as the identity of (Dual(a) tensored b)" );

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDoc.gd
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDoc.gd
@@ -14,7 +14,7 @@
 
 #! A symmetric closed monoidal category $\mathbf{C}$ satisfying
 #! * the natural morphism
-#!  $\mathrm{\underline{Hom}}(a_1,b_1) \otimes \mathrm{\underline{Hom}}(a_2,b_2) \rightarrow \mathrm{\underline{Hom}}(a_1 \otimes a_2,b_1 \otimes b_2)$
+#!  $\mathrm{\underline{Hom}}(a, a') \otimes \mathrm{\underline{Hom}}(b, b') \rightarrow \mathrm{\underline{Hom}}(a \otimes b, a' \otimes b')$
 #!  is an isomorphism,
 #! * the natural morphism
 #!  $a \rightarrow \mathrm{\underline{Hom}}(\mathrm{\underline{Hom}}(a, 1), 1)$

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
+# Pre processor functions for dual operations
 #
+
+BindGlobal( "DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismInverse",
+              { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[2] ) ] ]
+);
+
+BindGlobal( "DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects",
+              { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[2] ) ], Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncMorphismFromInternalHomToTensorProductWithGivenObjects",
+              { cat, s, a, b, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( s ) ]
+);
+
 # Implementations
 #
 
@@ -12,12 +26,17 @@ CoevaluationForDual := rec(
   output_source_getter_string := "TensorUnit( cat )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, DualOnObjects( cat, a ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedCoevaluationForCoDual",
+),
 
 CoevaluationForDualWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "s", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoclosedCoevaluationForCoDualWithGivenTensorProduct",
+  dual_arguments_reversed := true,
+),
 
 MorphismFromBidual := rec(
   filter_list := [ "category", "object" ],
@@ -25,12 +44,17 @@ MorphismFromBidual := rec(
   output_source_getter_string := "DualOnObjects( cat, DualOnObjects( cat, a ) )",
   output_range_getter_string := "a",
   with_given_object_position := "Source",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismToCoBidual",
+),
 
 MorphismFromBidualWithGivenBidual := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismToCoBidualWithGivenCoBidual",
+  dual_arguments_reversed := false,
+),
 
 TensorProductInternalHomCompatibilityMorphismInverse := rec(
   filter_list := [ "category", "list_of_objects" ],
@@ -38,14 +62,22 @@ TensorProductInternalHomCompatibilityMorphismInverse := rec(
   output_source_getter_string := "InternalHomOnObjects( cat, TensorProductOnObjects( cat, list[1], list[3] ), TensorProductOnObjects( cat, list[2], list[4] ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, InternalHomOnObjects( cat, list[1], list[2] ), InternalHomOnObjects( cat, list[3], list[4] ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomTensorProductCompatibilityMorphismInverse",
+  dual_preprocessor_func := DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismInverse,
+  dual_arguments_reversed := false,
+),
 
 TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object" ],
   input_arguments_names := [ "cat", "source", "list", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncTensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 MorphismFromInternalHomToTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
@@ -53,37 +85,50 @@ MorphismFromInternalHomToTensorProduct := rec(
   output_source_getter_string := "InternalHomOnObjects( cat, a, b )",
   output_range_getter_string := "TensorProductOnObjects( cat, DualOnObjects( cat, a ), b )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromTensorProductToInternalCoHom",
+  dual_arguments_reversed := false,
+),
 
 MorphismFromInternalHomToTensorProductWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromTensorProductToInternalCoHomWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncMorphismFromInternalHomToTensorProductWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 TraceMap := rec(
   filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "u", "u" ] ],
   return_type := "morphism",
+  dual_operation := "CoTraceMap",
 ),
 
 RankMorphism := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "u", "u" ] ],
   return_type := "morphism",
+  dual_operation := "CoRankMorphism",
 ),
 
 IsomorphismFromTensorProductToInternalHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "t", "i" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalCoHomToTensorProduct",
+  dual_arguments_reversed := true,
 ),
 
 IsomorphismFromInternalHomToTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "i", "t" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromTensorProductToInternalCoHom",
+  dual_arguments_reversed := false,
 ),
-  
+
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( RIGID_SYMMETRIC_CLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategories.gd
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategories.gd
@@ -16,83 +16,82 @@ DeclareGlobalVariable( "RIGID_SYMMETRIC_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME
 
 #! @Description
 #! The arguments are two objects $a,b$.
-#! The output is the natural morphism $\mathrm{IsomorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow a \otimes b_{\vee}$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), a \otimes b_{\vee} )$.
+#! The output is the natural morphism $\mathrm{IsomorphismFromInternalCoHomToTensorProductWithGivenObjects}_{a,b}: \mathrm{\underline{coHom}}(a,b) \rightarrow b_{\vee} \otimes a$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b), b_{\vee} \otimes a )$.
 #! @Arguments a,b
 DeclareOperation( "IsomorphismFromInternalCoHomToTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
 #! The arguments are two objects $a,b$.
+#! The output is the inverse of $\mathrm{IsomorphismFromInternalCoHomToTensorProduct}$, namely
+#! $\mathrm{IsomorphismFromTensorProductToInternalCoHom}_{a,b}: a_{\vee} \otimes b \rightarrow \mathrm{\underline{coHom}}(b,a)$.
+#! @Returns a morphism in $\mathrm{Hom}( a_{\vee} \otimes b, \mathrm{\underline{coHom}}(b,a)$.
+#! @Arguments a,b
+DeclareOperation( "IsomorphismFromTensorProductToInternalCoHom",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are two objects $a,b$.
 #! The output is the inverse of $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}$, namely
-#! $\mathrm{MorphismFromTensorProductToInternalCoHomWithGivenObjects}_{a,b}: a \otimes b_{\vee} \rightarrow \mathrm{\underline{coHom}}(a,b)$.
-#! @Returns a morphism in $\mathrm{Hom}( a \otimes b_{\vee}, \mathrm{\underline{coHom}}(a,b) )$.
+#! $\mathrm{MorphismFromTensorProductToInternalCoHomWithGivenObjects}_{a,b}: a_{\vee} \otimes b \rightarrow \mathrm{\underline{coHom}}(b,a)$.
+#! @Returns a morphism in $\mathrm{Hom}( a_{\vee} \otimes b, \mathrm{\underline{coHom}}(b,a) )$.
 #! @Arguments a,b
 DeclareOperation( "MorphismFromTensorProductToInternalCoHom",
                   [ IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
-#! The arguments are an object $s = a \otimes b_{\vee}$,
+#! The arguments are an object $s_{\vee} = a \otimes b$,
 #! two objects $a,b$,
-#! and an object $r = \mathrm{\underline{coHom}}(a,b)$.
+#! and an object $r = \mathrm{\underline{coHom}}(b,a)$.
 #! The output is the inverse of $\mathrm{MorphismFromInternalCoHomToTensorProductWithGivenObjects}$, namely
-#! $\mathrm{MorphismFromTensorProductToInternalCoHomWithGivenObjects}_{a,b}: a \otimes b_{\vee} \rightarrow \mathrm{\underline{coHom}}(a,b)$.
-#! @Returns a morphism in $\mathrm{Hom}( a \otimes b_{\vee}, \mathrm{\underline{coHom}}(a,b)$.
+#! $\mathrm{MorphismFromTensorProductToInternalCoHomWithGivenObjects}_{a,b}: a_{\vee} \otimes b \rightarrow \mathrm{\underline{coHom}}(b,a)$.
+#! @Returns a morphism in $\mathrm{Hom}( a_{\vee} \otimes b, \mathrm{\underline{coHom}}(b,a)$.
 #! @Arguments s,a,b,r
 DeclareOperation( "MorphismFromTensorProductToInternalCoHomWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
-#! @Description
-#! The arguments are two objects $a,b$.
-#! The output is the inverse of $\mathrm{IsomorphismFromInternalCoHomToTensorProduct}$, namely
-#! $\mathrm{IsomorphismFromTensorProductToInternalCoHom}_{a,b}: a \otimes b_{\vee} \rightarrow \mathrm{\underline{coHom}}(a,b)$.
-#! @Returns a morphism in $\mathrm{Hom}( a \otimes b_{\vee}, \mathrm{\underline{coHom}}(a,b)$.
-#! @Arguments a,b
-DeclareOperation( "IsomorphismFromTensorProductToInternalCoHom",
-                  [ IsCapCategoryObject, IsCapCategoryObject ] );
-
-## The four objects are given are given as a list because otherwise the WithGiven operation would
+## The four objects are given as a list because otherwise the WithGiven operation would
 ## exceed the maximal number of arguments for an operation (6)
 #! @Description
 #! The argument is a list of four objects $[ a, a', b, b' ]$.
 #! The output is the natural morphism
-#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a_1, a_2) \otimes \mathrm{\underline{coHom}}(b_1, b_2) \rightarrow \mathrm{\underline{coHom}}(a_1 \otimes b_1, a_2 \otimes b_2)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a_1, a_2) \otimes \mathrm{\underline{coHom}}(b_1, b_2), \mathrm{\underline{coHom}}(a_1 \otimes b_1, a_2 \otimes b_2)$.
+#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b') \rightarrow \mathrm{\underline{coHom}}(a \otimes a', b \otimes b')$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b'), \mathrm{\underline{coHom}}(a \otimes a', b \otimes b' )$.
 #! @Arguments list
 DeclareOperation( "InternalCoHomTensorProductCompatibilityMorphismInverse",
                   [ IsList ] );
 
 #! @Description
 #! The arguments are a list of four objects $[ a, a', b, b' ]$,
-#! and two objects $s = \mathrm{\underline{coHom}}(a_1, a_2) \otimes \mathrm{\underline{coHom}}(b_1, b_2)$ and $r = \mathrm{\underline{coHom}}(a_1 \otimes b_1, a_2 \otimes b_2)$.
+#! and two objects $s = \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b')$ and $r = \mathrm{\underline{coHom}}(a \otimes a', b \otimes b')$.
 #! The output is the natural morphism
-#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a_1, a_2) \otimes \mathrm{\underline{coHom}}(b_1, b_2) \rightarrow \mathrm{\underline{coHom}}(a_1 \otimes b_1, a_2 \otimes b_2)$.
-#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a_1, a_2) \otimes \mathrm{\underline{coHom}}(b_1, b_2), \mathrm{\underline{coHom}}(a_1 \otimes b_1, a_2 \otimes b_2) )$.
+#! $\mathrm{InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects}_{a,a',b,b'}: \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b') \rightarrow \mathrm{\underline{coHom}}(a \otimes a', b \otimes b')$.
+#! @Returns a morphism in $\mathrm{Hom}( \mathrm{\underline{coHom}}(a,b) \otimes \mathrm{\underline{coHom}}(a',b'), \mathrm{\underline{coHom}}(a \otimes a', b \otimes b' )$.
 #! @Arguments s, list, r
 DeclareOperation( "InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects",
                   [ IsCapCategoryObject, IsList, IsCapCategoryObject ] );
 
 #! @Description
 #! The argument is an object $a$.
-#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a}: a_{\vee} \otimes a \rightarrow 1$.
-#! @Returns a morphism in $\mathrm{Hom}(a_{\vee} \otimes a, 1)$.
+#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a}: a \otimes a_{\vee} \rightarrow 1$.
+#! @Returns a morphism in $\mathrm{Hom}(a \otimes a_{\vee}, 1)$.
 #! @Arguments a
 DeclareAttribute( "CoclosedCoevaluationForCoDual",
                   IsCapCategoryObject );
 
-
 #! @Description
-#! The arguments are an object $s = a_{\vee} \otimes a$,
+#! The arguments are an object $s = a \otimes a_{\vee}$,
 #! an object $a$,
 #! and an object $r = 1$.
-#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a}: a_{\vee} \otimes a \rightarrow 1$.
-#! @Returns a morphism in $\mathrm{Hom}(a_{\vee} \otimes a, 1)$.
+#! The output is the coclosed coevaluation morphism $\mathrm{coclcoev}_{a}: a \otimes a_{\vee} \rightarrow 1$.
+#! @Returns a morphism in $\mathrm{Hom}(a \otimes a_{\vee}, 1)$.
 #! @Arguments s,a,r
 DeclareOperation( "CoclosedCoevaluationForCoDualWithGivenTensorProduct",
                   [ IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryObject ] );
 
 #! @Description
-#! The argument is an endomorphism $\alpha: A \rightarrow A$.
+#! The argument is an endomorphism $\alpha: a \rightarrow a$.
 #! The output is the cotrace morphism $\mathrm{cotrace}_{\alpha}: 1 \rightarrow 1$.
 #! @Returns a morphism in $\mathrm{Hom}(1,1)$.
 #! @Arguments alpha

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -7,9 +7,11 @@
 ##
 AddDerivationToCAP( InternalCoHomOnObjects,
                   
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
+
+    # Source( Cohom(a,b) -> b_v x a )
     
-    return Source( IsomorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 ) );
+    return Source( IsomorphismFromInternalCoHomToTensorProduct( cat, a, b ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "InternalCoHomOnObjects as the source of IsomorphismFromInternalCoHomToTensorProduct" );
@@ -17,9 +19,11 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalCoHomOnObjects,
                   
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
+
+    # Range( b_v x a -> Cohom(a,b) )
     
-    return Range( IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) );
+    return Range( IsomorphismFromTensorProductToInternalCoHom( cat, b, a ) );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "InternalCoHomOnObjects as the range of IsomorphismFromTensorProductToInternalCoHom" );
@@ -27,15 +31,32 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalCoHomOnMorphismsWithGivenInternalCoHoms,
                   
-  function( cat, internal_cohom_source, morphism_1, morphism_2, internal_cohom_range )
-    local codual_morphism;
+  function( cat, internal_cohom_source, alpha, beta, internal_cohom_range )
+    local codual_beta;
+
+    # alpha: a -> a'
+    # beta: b -> b'
+    #
+    # Cohom(a,b')
+    #     |
+    #     |
+    #     v
+    # b'^v x a
+    #     |
+    #     | Codual(beta) x alpha
+    #     v
+    # b^v x a'
+    #     |
+    #     |
+    #     v
+    # Cohom(a',b)
     
-    codual_morphism := CoDualOnMorphisms( cat, morphism_2 );
+    codual_beta := CoDualOnMorphisms( cat, beta );
     
     return PreComposeList( cat, [
-             IsomorphismFromInternalCoHomToTensorProduct( cat, Source( morphism_1 ), Range( morphism_2 ) ),
-             TensorProductOnMorphisms( cat, morphism_1, codual_morphism ),
-             IsomorphismFromTensorProductToInternalCoHom( cat, Range( morphism_1 ), Source( morphism_2 ) ) 
+             IsomorphismFromInternalCoHomToTensorProduct( cat, Source( alpha ), Range( beta ) ),
+             TensorProductOnMorphisms( cat, codual_beta, alpha ),
+             IsomorphismFromTensorProductToInternalCoHom( cat, Range( alpha ), Source( beta ) )
            ] );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
@@ -44,9 +65,11 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismToCoBidualWithGivenCoBidual,
                   
-  function( cat, object, cobidual )
+  function( cat, a, cobidual )
+
+    # Inverse( (a_v)_v -> a )
     
-    return InverseForMorphisms( cat, MorphismFromCoBidualWithGivenCoBidual( cat, object, cobidual ) );
+    return InverseForMorphisms( cat, MorphismFromCoBidualWithGivenCoBidual( cat, a, cobidual ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "MorphismToCoBidualWithGivenCoBidual as the inverse of MorphismFromCoBidualWithGivenCoBidual" );
@@ -54,9 +77,11 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
                   
-  function( cat, object, cobidual )
+  function( cat, a, cobidual )
+
+    # Inverse( a -> (a_v)_v )
     
-    return InverseForMorphisms( cat, MorphismToCoBidualWithGivenCoBidual( cat, object, cobidual ) );
+    return InverseForMorphisms( cat, MorphismToCoBidualWithGivenCoBidual( cat, a, cobidual ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "MorphismFromCoBidualWithGivenCoBidual as the inverse of MorphismToCoBidualWithGivenCoBidual" );
@@ -64,25 +89,47 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoclosedEvaluationMorphismWithGivenRange,
                   
-  function( cat, object_1, object_2, object_2_tensored_internal_cohom )
+  function( cat, a, b, internal_cohom_tensored_b )
     local morphism;
+
+    #      a
+    #      |
+    #      | (ρ_a)^-1
+    #      v
+    #    a x 1
+    #      |
+    #      | id_a x coclev_b
+    #      v
+    # a x (b_v x b)
+    #      |
+    #      | α_( a, ( b_v, b ) )
+    #      v
+    # (a x b_v) x b
+    #      |
+    #      | B_( a, Codual(b) ) x id_b
+    #      v
+    # (b_v x a) x b
+    #      |
+    #      | Isomorphism x id_b
+    #      v
+    # Cohom(a,b) x b
     
     morphism := PreComposeList( cat, [
-                  LeftUnitorInverse( cat, object_1 ),
+                  RightUnitorInverse( cat, a ),
                   
                   TensorProductOnMorphisms( cat,
-                    CoclosedEvaluationForCoDual( cat, object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
-                  
-                  AssociatorLeftToRight( cat, object_2, CoDualOnObjects( cat, object_2 ), object_1 ),
+                    IdentityMorphism( cat, a ),
+                    CoclosedEvaluationForCoDual( cat, b ) ),
+
+                  AssociatorRightToLeft( cat, a, CoDualOnObjects( cat, b ), b ),
                   
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, object_2 ),
-                    Braiding( cat, CoDualOnObjects( cat, object_2 ), object_1 ) ),
+                    Braiding( cat, a, CoDualOnObjects( cat, b ) ),
+                    IdentityMorphism( cat, b ) ),
                   
-                  TensorProductOnMorphisms( cat, 
-                    IdentityMorphism( cat, object_2 ),
-                    IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) ) 
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromTensorProductToInternalCoHom( cat, b, a ),
+                    IdentityMorphism( cat, b ) )
                 ] );
                     
     return morphism;
@@ -93,21 +140,35 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoclosedEvaluationMorphismWithGivenRange,
                     
-  function( cat, object_1, object_2, object_2_tensored_internal_cohom )
+  function( cat, a, b, internal_cohom_tensored_b )
     local morphism;
+
+    #    a x 1
+    #      |
+    #      | id_a x coclev_b
+    #      v
+    # a x b_v x b
+    #      |
+    #      | B_( a, Codual(b) ) x id_b
+    #      v
+    # b_v x a x b
+    #      |
+    #      | Isomorphism x id_b
+    #      v
+    # Cohom(a,b) x b
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat,
-                    CoclosedEvaluationForCoDual( cat, object_2 ),
-                    IdentityMorphism( cat, object_1 ) ),
+                    IdentityMorphism( cat, a ),
+                    CoclosedEvaluationForCoDual( cat, b ) ),
                   
                   TensorProductOnMorphisms( cat,
-                    IdentityMorphism( cat, object_2 ),
-                    Braiding( cat, CoDualOnObjects( cat, object_2 ), object_1 ) ),
+                    Braiding( cat, a, CoDualOnObjects( cat, b ) ),
+                    IdentityMorphism( cat, b ) ),
                   
-                  TensorProductOnMorphisms( cat, 
-                    IdentityMorphism( cat, object_2 ),
-                    IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 ) ) 
+                  TensorProductOnMorphisms( cat,
+                    IsomorphismFromTensorProductToInternalCoHom( cat, b, a ),
+                    IdentityMorphism( cat, b ) )
                 ] );
                     
     return morphism;
@@ -118,33 +179,59 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory and IsStrictMon
 ##
 AddDerivationToCAP( CoclosedCoevaluationMorphismWithGivenSource,
                     
-  function( cat, object_1, object_2, internal_cohom )
-    local morphism, codual_1, id_2;
+  function( cat, a, b, internal_cohom )
+    local morphism, codual_b, id_a;
+
+    # Cohom(a x b, b)
+    #       |
+    #       | Isomorphism
+    #       v
+    #  b_v x (a x b)
+    #       |
+    #       | id_(b_v) x B_( a, b )
+    #       v
+    #  b_v x (b x a)
+    #       |
+    #       | α_( b_v, ( b, a ) )
+    #       v
+    #  (b_v x b) x a
+    #       |
+    #       | B_( b_v, b ) x id_a
+    #       v
+    # (b x b_v) x a
+    #       |
+    #       | coclcoev_b x id_a
+    #       v
+    #     1 x a
+    #       |
+    #       | λ_a
+    #       v
+    #       a
     
-    codual_1 := CoDualOnObjects( cat, object_1 );
+    codual_b := CoDualOnObjects( cat, b );
     
-    id_2 := IdentityMorphism( cat, object_2 );
+    id_a := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
                   IsomorphismFromInternalCoHomToTensorProduct( cat,
-                    TensorProductOnObjects( cat, object_1, object_2 ),
-                    object_1),
-                    
+                    TensorProductOnObjects( cat, a, b ),
+                    b),
+                  
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, object_1, object_2 ),
-                    IdentityMorphism( cat, codual_1 ) ),
-                    
-                  AssociatorLeftToRight( cat, object_2, object_1, codual_1 ),
-                    
+                    IdentityMorphism( cat, codual_b ),
+                    Braiding( cat, a, b ) ),
+                  
+                  AssociatorRightToLeft( cat, codual_b, b, a ),
+                  
                   TensorProductOnMorphisms( cat,
-                    id_2,
-                    Braiding( cat, object_1, codual_1 ) ),
-                    
+                    Braiding( cat, codual_b, b ),
+                    id_a ),
+                  
                   TensorProductOnMorphisms( cat,
-                    id_2,
-                    CoclosedCoevaluationForCoDual( cat, object_1 ) ),
-                    
-                  RightUnitor( cat, object_2 ) 
+                    CoclosedCoevaluationForCoDual( cat, b ),
+                    id_a ),
+                  
+                  LeftUnitor( cat, a )
                 ] );
                     
     return morphism;
@@ -155,29 +242,47 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoclosedCoevaluationMorphismWithGivenSource,
                     
-  function( cat, object_1, object_2, internal_cohom )
-    local morphism, codual_1, id_2;
+  function( cat, a, b, internal_cohom )
+    local morphism, codual_b, id_a;
+
+    # Cohom(a x b, b)
+    #       |
+    #       | Isomorphism
+    #       v
+    #  b_v x (a x b)
+    #       |
+    #       | id_(b_v) x B_( a, b )
+    #       v
+    #  b_v x (b x a)
+    #       |
+    #       | B_( b_v, b ) x id_a
+    #       v
+    # (b x b_v) x a
+    #       |
+    #       | coclcoev_b x id_a
+    #       v
+    #     1 x a
     
-    codual_1 := CoDualOnObjects( cat, object_1 );
+    codual_b := CoDualOnObjects( cat, b );
     
-    id_2 := IdentityMorphism( cat, object_2 );
+    id_a := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
                   IsomorphismFromInternalCoHomToTensorProduct( cat,
-                    TensorProductOnObjects( cat, object_1, object_2 ),
-                    object_1),
-                    
+                    TensorProductOnObjects( cat, a, b ),
+                    b),
+                  
                   TensorProductOnMorphisms( cat,
-                    Braiding( cat, object_1, object_2 ),
-                    IdentityMorphism( cat, codual_1 ) ),
-                    
+                    IdentityMorphism( cat, codual_b ),
+                    Braiding( cat, a, b ) ),
+                  
                   TensorProductOnMorphisms( cat,
-                    id_2,
-                    Braiding( cat, object_1, codual_1 ) ),
-                    
+                    Braiding( cat, codual_b, b ),
+                    id_a ),
+                  
                   TensorProductOnMorphisms( cat,
-                    id_2,
-                    CoclosedCoevaluationForCoDual( cat, object_1 ) ) 
+                    CoclosedCoevaluationForCoDual( cat, b ),
+                    id_a ),
                 ] );
                     
     return morphism;
@@ -188,9 +293,9 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory and IsStrictMon
 ##
 AddDerivationToCAP( MorphismFromInternalCoHomToTensorProductWithGivenObjects,
                   
-  function( cat, internal_cohom, object_1, object_2, tensor_object )
+  function( cat, internal_cohom, a, b, tensor_object )
     
-    return IsomorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 );
+    return IsomorphismFromInternalCoHomToTensorProduct( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromInternalCoHomToTensorProductWithGivenObjects using IsomorphismFromInternalCoHomToTensorProduct" );
@@ -199,9 +304,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromTensorProductToInternalCoHomWithGivenObjects,
                   
-  function( cat, tensor_object, object_1, object_2, internal_hom )
+  function( cat, tensor_object, a, b, internal_hom )
     
-    return IsomorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 );
+    return IsomorphismFromTensorProductToInternalCoHom( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "MorphismFromTensorProductToInternalCoHomWithGivenObjects using IsomorphismFromTensorProductToInternalCoHom" );
@@ -209,9 +314,9 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromInternalCoHomToTensorProduct,
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return MorphismFromInternalCoHomToTensorProduct( cat, object_1, object_2 );
+    return MorphismFromInternalCoHomToTensorProduct( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToTensorProduct using MorphismFromInternalCoHomToTensorProduct" );
@@ -219,23 +324,37 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromTensorProductToInternalCoHom,
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return MorphismFromTensorProductToInternalCoHom( cat, object_1, object_2 );
+    return MorphismFromTensorProductToInternalCoHom( cat, a, b );
     
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalCoHom using MorphismFromTensorProductToInternalCoHom" );
 
 AddDerivationToCAP( CoclosedCoevaluationForCoDualWithGivenTensorProduct,
                     
-  function( cat, tensor_object, object, unit )
+  function( cat, tensor_object, a, unit )
     local morphism;
+
+    # a x a_v
+    #    |
+    #    | B_( a, a_v )
+    #    v
+    # a_v x a
+    #    |
+    #    | Isomorphism
+    #    v
+    # Cohom(a,a)
+    #    |
+    #    | CoLambdaIntro( id_a )
+    #    v
+    #    1
     
-    morphism := IdentityMorphism( cat, object );
+    morphism := IdentityMorphism( cat, a );
     
     morphism := PreComposeList( cat, [
-                  Braiding( cat, CoDualOnObjects( cat, object ), object ),
-                  IsomorphismFromTensorProductToInternalCoHom( cat, object, object ),
+                  Braiding( cat, a, CoDualOnObjects( cat, a ) ),
+                  IsomorphismFromTensorProductToInternalCoHom( cat, a, a ),
                   CoLambdaIntroduction( cat, morphism ) 
                 ] );
                             
@@ -247,15 +366,31 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoTraceMap,
                     
-  function( cat, morphism )
-    local object;
+  function( cat, alpha )
+    local a;
+
+    # alpha: a -> a
+    #
+    #    1
+    #    |
+    #    | coclev_a
+    #    v
+    # a_v x a
+    #    |
+    #    | Isomorphism
+    #    v
+    # Cohom(a,a)
+    #    |
+    #    | CoLambdaIntro( alpha )
+    #    v
+    #    1
     
-    object := Source( morphism );
+    a := Source( alpha );
     
     return PreComposeList( cat, [
-             CoclosedEvaluationForCoDual( cat, object ) ,
-             IsomorphismFromTensorProductToInternalCoHom( cat, object, object ),
-             CoLambdaIntroduction( cat, morphism )
+             CoclosedEvaluationForCoDual( cat, a ) ,
+             IsomorphismFromTensorProductToInternalCoHom( cat, a, a ),
+             CoLambdaIntroduction( cat, alpha )
            ] );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
@@ -264,9 +399,9 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoRankMorphism,
                     
-  function( cat, object )
+  function( cat, a )
     
-    return CoTraceMap( cat, IdentityMorphism( cat, object ) );
+    return CoTraceMap( cat, IdentityMorphism( cat, a ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "Corank of an object as the cotrace of its identity" );
@@ -275,6 +410,8 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 AddDerivationToCAP( InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects,
                     
   function( cat, source, list, range )
+
+    # Inverse( Cohom( a x a', b x b') -> Cohom(a,b) x Cohom(a',b') )
     
     return InverseForMorphisms( cat, InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects( cat, source, list, range ) );
     
@@ -307,9 +444,9 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalCoHom,
                       IsomorphismFromTensorProductToInternalCoHom,
                       IsomorphismFromInternalCoHomToTensorProduct ],
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, CoDualOnObjects( cat, object_2 ) ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromTensorProductToInternalCoHom as the identity of (a tensored CoDual(b))" );
@@ -334,9 +471,9 @@ AddFinalDerivation( IsomorphismFromInternalCoHomToTensorProduct,
                       IsomorphismFromTensorProductToInternalCoHom,
                       IsomorphismFromInternalCoHomToTensorProduct ],
                     
-  function( cat, object_1, object_2 )
+  function( cat, a, b )
     
-    return IdentityMorphism( cat, TensorProductOnObjects( cat, object_1, CoDualOnObjects( cat, object_2 ) ) );
+    return IdentityMorphism( cat, TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) ) );
     
 end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToTensorProduct as the identity of (a tensored CoDual(b))" );

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDoc.gd
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDoc.gd
@@ -14,7 +14,7 @@
 
 #! A symmetric coclosed monoidal category $\mathbf{C}$ satisfying
 #! * the natural morphism
-#!  $\mathrm{\underline{coHom}}(a_1 \otimes a_2, b_1 \otimes b_2) \rightarrow \mathrm{\underline{coHom}}(a_1, b_1) \otimes \mathrm{\underline{coHom}}(a_2, b_2)$
+#!  $\mathrm{\underline{coHom}}(a \otimes a', b \otimes b') \rightarrow \mathrm{\underline{coHom}}(a, b) \otimes \mathrm{\underline{coHom}}(a', b')$
 #!  is an isomorphism,
 #! * the natural morphism
 #!  $\mathrm{\underline{coHom}}(1, \mathrm{\underline{coHom}}(1, a)) \rightarrow a$

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesMethodRecord.gi
@@ -1,6 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # MonoidalCategories: Monoidal and monoidal (co)closed categories
+# Pre processor functions for dual operations
 #
+
+BindGlobal( "DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismInverse",
+              { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[3] ) ] ]
+);
+
+BindGlobal( "DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects",
+              { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[3] ) ], Opposite( s ) ]
+);
+
+BindGlobal( "DualPreProcessorFuncMorphismFromTensorProductToInternalCoHomWithGivenObjects",
+              { cat, s, a, b, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( b ), Opposite( s ) ]
+);
+
 # Implementations
 #
 
@@ -12,12 +26,17 @@ CoclosedCoevaluationForCoDual := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, CoDualOnObjects( cat, a ), a )",
   output_range_getter_string := "TensorUnit( cat )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoevaluationForDual",
+),
 
 CoclosedCoevaluationForCoDualWithGivenTensorProduct := rec(
   filter_list := [ "category", "object", "object", "object" ],
   io_type := [ [ "s", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "CoevaluationForDualWithGivenTensorProduct",
+  dual_arguments_reversed := true,
+),
 
 MorphismToCoBidual := rec(
   filter_list := [ "category", "object" ],
@@ -25,12 +44,17 @@ MorphismToCoBidual := rec(
   output_source_getter_string := "a",
   output_range_getter_string := "CoDualOnObjects( cat, CoDualOnObjects( cat, a ) )",
   with_given_object_position := "Range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromBidual",
+),
 
 MorphismToCoBidualWithGivenCoBidual := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromBidualWithGivenBidual",
+  dual_arguments_reversed := false,
+),
 
 InternalCoHomTensorProductCompatibilityMorphismInverse := rec(
   filter_list := [ "category", "list_of_objects" ],
@@ -38,14 +62,22 @@ InternalCoHomTensorProductCompatibilityMorphismInverse := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, InternalCoHomOnObjects( cat, list[1], list[3] ), InternalCoHomOnObjects( cat, list[2], list[4] ) )",
   output_range_getter_string := "InternalCoHomOnObjects( cat, TensorProductOnObjects( cat, list[1], list[2] ), TensorProductOnObjects( cat, list[3], list[4] ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductInternalHomCompatibilityMorphismInverse",
+  dual_preprocessor_func := DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismInverse,
+  dual_arguments_reversed := false,
+),
 
 InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object" ],
   input_arguments_names := [ "cat", "source", "list", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncInternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 MorphismFromTensorProductToInternalCoHom := rec(
   filter_list := [ "category", "object", "object" ],
@@ -53,37 +85,50 @@ MorphismFromTensorProductToInternalCoHom := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, a, DualOnObjects( cat, b ) )",
   output_range_getter_string := "InternalCoHomOnObjects( cat, a, b )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromInternalHomToTensorProduct",
+  dual_arguments_reversed := false,
+),
 
 MorphismFromTensorProductToInternalCoHomWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "object", "object" ],
   io_type := [ [ "s", "a", "b", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "MorphismFromInternalHomToTensorProductWithGivenObjects",
+  dual_preprocessor_func := DualPreProcessorFuncMorphismFromTensorProductToInternalCoHomWithGivenObjects,
+  dual_arguments_reversed := false,
+),
 
 CoTraceMap := rec(
   filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "u", "u" ] ],
   return_type := "morphism",
+  dual_operation := "TraceMap",
 ),
 
 CoRankMorphism := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "u", "u" ] ],
   return_type := "morphism",
+  dual_operation := "RankMorphism",
 ),
 
 IsomorphismFromInternalCoHomToTensorProduct := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "i", "t" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromTensorProductToInternalHom",
+  dual_arguments_reversed := true,
 ),
 
 IsomorphismFromTensorProductToInternalCoHom := rec(
   filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "b" ], [ "t", "i" ] ],
   return_type := "morphism",
+  dual_operation := "IsomorphismFromInternalHomToTensorProduct",
+  dual_arguments_reversed := false,
 ),
-  
+
 ) );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( RIGID_SYMMETRIC_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );

--- a/MonoidalCategories/gap/SymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/SymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -7,11 +7,23 @@
 ##
 AddDerivationToCAP( TensorProductToInternalHomAdjunctionMap,
                     
-  function( cat, object_1, object_2, morphism )
-    
+  function( cat, a, b, f )
+
+    # f: a x b -> c
+    #
+    #      a
+    #      |
+    #      | coev_ab
+    #      v
+    # Hom(b,a x b)
+    #      |
+    #      | Hom(id_b, f)
+    #      v
+    #   Hom(b,c)
+
     return PreCompose( cat,
-             CoevaluationMorphism( cat, object_1, object_2 ),
-             InternalHomOnMorphisms( cat, IdentityMorphism( cat, object_2 ), morphism ) );
+             CoevaluationMorphism( cat, a, b ),
+             InternalHomOnMorphisms( cat, IdentityMorphism( cat, b ), f ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "TensorProductToInternalHomAdjunctionMap using CoevaluationMorphism and InternalHom" );
@@ -19,11 +31,23 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalHomToTensorProductAdjunctionMap,
                     
-  function( cat, object_1, object_2, morphism )
-    
+  function( cat, b, c, g )
+
+    # g: a -> Hom(b,c)
+    #
+    #    a x b
+    #      |
+    #      | g x id_b
+    #      v
+    # Hom(b,c) x b
+    #      |
+    #      | ev_bc
+    #      v
+    #      c
+
     return PreCompose( cat,
-             TensorProductOnMorphisms( cat, morphism, IdentityMorphism( cat, object_1 ) ),
-             EvaluationMorphism( cat, object_1, object_2 ) );
+             TensorProductOnMorphisms( cat, g, IdentityMorphism( cat, b ) ),
+             EvaluationMorphism( cat, b, c ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "InternalHomToTensorProductAdjunctionMap using TensorProductOnMorphisms and EvaluationMorphism" );
@@ -31,11 +55,15 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( UniversalPropertyOfDual,
                     
-  function( cat, object_1, object_2, test_morphism )
+  function( cat, t, a, alpha )
+
+    # alpha: t x a -> 1
+    #
+    # Adjoint( alpha ) = ( t -> Hom(a,1) ) -> a^v
     
     return PreCompose( cat,
-             TensorProductToInternalHomAdjunctionMap( cat, object_1, object_2, test_morphism ),
-             IsomorphismFromInternalHomToDual( cat, object_2 ) );
+             TensorProductToInternalHomAdjunctionMap( cat, t, a, alpha ),
+             IsomorphismFromInternalHomToDual( cat, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "UniversalPropertyOfDual using the tensor hom adjunction" );
@@ -43,13 +71,25 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismToBidualWithGivenBidual,
                   
-  function( cat, object, bidual )
-    local morphism;
+  function( cat, a, avv )
+    local alpha;
 
-    morphism := PreCompose( cat, Braiding( cat, object, DualOnObjects( cat, object ) ),
-                            EvaluationForDual( cat, object ) );
+    #    a x a^v
+    #      |
+    #      | B_(a,a^v)
+    #      v
+    #  a^v x a
+    #      |
+    #      | ev_a
+    #      v
+    #      1
+    #
+    # UniversalProperty( a x a^v -> 1 ) = ( a -> a^v^v)
+
+    alpha := PreCompose( cat, Braiding( cat, a, DualOnObjects( cat, a ) ),
+                            EvaluationForDual( cat, a ) );
     
-    return UniversalPropertyOfDual( cat, object, DualOnObjects( cat, object ), morphism );
+    return UniversalPropertyOfDual( cat, a, DualOnObjects( cat, a ), alpha );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "MorphismToBidualWithGivenBidual using the braiding and the universal property of the dual" );
@@ -57,23 +97,37 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismToBidualWithGivenBidual,
                     
-  function( cat, object, bidual )
-    local morphism, dual_object, tensor_unit;
+  function( cat, a, avv )
+    local morphism, av, tensor_unit;
+
+    #        a
+    #        |
+    #        | coev_(a,a^v)
+    #        v
+    #  Hom(av, a x a^v)
+    #        |
+    #        | Hom(id_av, B_(a,a^v))
+    #        v
+    # Hom(av, a^v x a)
+    #        |
+    #        | Hom(id_(a^v), ev_(a,1))
+    #        v
+    #    Hom(a^v,1)
     
-    dual_object := DualOnObjects( cat, object );
+    av := DualOnObjects( cat, a );
     
     tensor_unit := TensorUnit( cat );
-    
+
     morphism := PreComposeList( cat, [
-                  CoevaluationMorphism( cat, object, dual_object ),
+                  CoevaluationMorphism( cat, a, av ),
                   
                   InternalHomOnMorphisms( cat,
-                    IdentityMorphism( cat, dual_object ),
-                    Braiding( cat, object, dual_object ) ),
+                    IdentityMorphism( cat, av ),
+                    Braiding( cat, a, av ) ),
                   
                   InternalHomOnMorphisms( cat,
-                    IdentityMorphism( cat, dual_object ),
-                    EvaluationMorphism( cat, object, tensor_unit ) )
+                    IdentityMorphism( cat, av ),
+                    EvaluationMorphism( cat, a, tensor_unit ) )
                 ] );
     
     return morphism;
@@ -84,9 +138,11 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( DualOnObjects,
                   
-  function( cat, object )
+  function( cat, a )
+
+    # Source( a^v -> Hom(a,1) )
     
-    return Source( IsomorphismFromDualToInternalHom( cat, object ) );
+    return Source( IsomorphismFromDualToInternalHom( cat, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "DualOnObjects as the source of IsomorphismFromDualToInternalHom" );
@@ -94,9 +150,11 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( DualOnObjects,
                   
-  function( cat, object )
+  function( cat, a )
+
+    # Range( Hom(a,1) -> a^v )
     
-    return Range( IsomorphismFromInternalHomToDual( cat, object ) );
+    return Range( IsomorphismFromInternalHomToDual( cat, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "DualOnObjects as the range of IsomorphismFromInternalHomToDual" );
@@ -104,16 +162,30 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( DualOnMorphismsWithGivenDuals,
                   
-  function( cat, new_source, morphism, new_range )
+  function( cat, s, alpha, r )
+
+    # alpha: a->b
+    #
+    #   b^v
+    #    |
+    #    v
+    # Hom(b,1)
+    #    |
+    #    | Hom(alpha, id_1)
+    #    v
+    # Hom(a,1)
+    #    |
+    #    v
+    #   a^v
     
     return PreComposeList( cat, [
-             IsomorphismFromDualToInternalHom( cat, Range( morphism ) ),
+             IsomorphismFromDualToInternalHom( cat, Range( alpha ) ),
              
              InternalHomOnMorphisms( cat,
-               morphism,
+               alpha,
                IdentityMorphism( cat, TensorUnit( cat ) ) ),
                
-             IsomorphismFromInternalHomToDual( cat, Source( morphism ) )
+             IsomorphismFromInternalHomToDual( cat, Source( alpha ) )
            ] );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
@@ -122,10 +194,14 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( EvaluationForDualWithGivenTensorProduct,
                   
-  function( cat, tensor_object, object, unit )
+  function( cat, s, a, r )
+
+    # r := 1
+    #
+    # Adjoint( a^v -> Hom(a,1) ) = ( a^v x a -> 1 )
     
-    return InternalHomToTensorProductAdjunctionMap( cat, object, unit,
-                                                    IsomorphismFromDualToInternalHom( cat, object ) );
+    return InternalHomToTensorProductAdjunctionMap( cat, a, r,
+                                                    IsomorphismFromDualToInternalHom( cat, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "EvaluationForDualWithGivenTensorProduct using the tensor hom adjunction and IsomorphismFromDualToInternalHom" );
@@ -133,12 +209,24 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( LambdaIntroduction,
                   
-  function( cat, morphism )
+  function( cat, alpha )
     local result_morphism, source;
+
+    # 1 x a
+    #   |
+    #   | λ_a
+    #   v
+    #   a
+    #   |
+    #   | alpha
+    #   v
+    #   b
+    #
+    # Adjoint( 1 x a -> b) = ( 1 -> Hom(a,b) )
     
-    source := Source( morphism );
+    source := Source( alpha );
     
-    result_morphism := PreCompose( cat, LeftUnitor( cat, source ), morphism );
+    result_morphism := PreCompose( cat, LeftUnitor( cat, source ), alpha );
     
     return TensorProductToInternalHomAdjunctionMap( cat, TensorUnit( cat ), source, result_morphism );
     
@@ -148,15 +236,28 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( LambdaElimination,
                   
-  function( cat, object_1, object_2, morphism )
+  function( cat, a, b, alpha )
     local result_morphism;
+
+    # alpha: 1 -> Hom(a,b)
+    # Adjoint( alpha ) = ( 1 x a -> b)
+    #
+    #   a
+    #   |
+    #   | (λ_a)^-1
+    #   v
+    # 1 x a
+    #   |
+    #   | Adjoint( alpha)
+    #   v
+    #   b
     
-    result_morphism := InternalHomToTensorProductAdjunctionMap( cat, object_1, object_2, morphism );
+    result_morphism := InternalHomToTensorProductAdjunctionMap( cat, a, b, alpha );
     
-    return PreCompose( cat, LeftUnitorInverse( cat, object_1 ), result_morphism );
+    return PreCompose( cat, LeftUnitorInverse( cat, a ), result_morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
-      Description := "LambdaElimination using the tensor hom adjunction and left unitor" );
+      Description := "LambdaElimination using the tensor hom adjunction and left unitor inverse" );
 
 ##
 AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObjects,
@@ -164,6 +265,39 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObject
   function( cat, source, list, range )
     local a1, b1, a2, b2, morphism, int_hom_a1_b1, int_hom_a2_b2, id_a2, tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2;
     
+    # (Hom(a1,b1) x Hom(a2,b2)) x (a1 x a2)
+    #                  |
+    #                  | α_( Hom(a1,b1) x Hom(a2,b2), (a1, a2) )
+    #                  v
+    # ((Hom(a1,b1) x Hom(a2,b2)) x a1) x a2
+    #                  |
+    #                  | α_( ( Hom(a1,b1), Hom(a2,b2) ), a1 ) x id_a2
+    #                  v
+    # (Hom(a1,b1) x (Hom(a2,b2) x a1)) x a2
+    #                  |
+    #                  | ( id_Hom(a1,b1) x B_( Hom(a2,b2), a1 ) ) x id_a2
+    #                  v
+    # (Hom(a1,b1) x (a1 x Hom(a2,b2))) x a2
+    #                  |
+    #                  | α_( Hom(a1,b1), ( a1, Hom(a2,b2) ) ) x id_a2
+    #                  v
+    # ((Hom(a1,b1) x a1) x Hom(a2,b2)) x a2
+    #                  |
+    #                  | ( ev_(a1,b1) x id_Hom(a2,b2) ) x id_a2
+    #                  v
+    #       (b1 x Hom(a2,b2)) x a2
+    #                  |
+    #                  | α_( ( b1,Hom(a2,b2) ), a2 )
+    #                  v
+    #       b1 x (Hom(a2,b2) x a2)
+    #                  |
+    #                  | id_b1 x ev_(a2,b2)
+    #                  v
+    #               b1 x b2
+    #
+    #
+    # Adjoint[ (Hom(a1,b1) x Hom(a2,b2)) x (a1 x a2) -> b1 x b2 ] = [ Hom(a1,b1) x Hom(a2,b2) -> Hom(a1 x a2, b1 x b2) ]
+
     a1 := list[1];
     b1 := list[2];
     a2 := list[3];
@@ -177,7 +311,7 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObject
     
     tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2 := 
       TensorProductOnObjects( cat, int_hom_a1_b1, int_hom_a2_b2 );
-    
+
     morphism := PreComposeList( cat, [
                   AssociatorRightToLeft( cat,
                     tensor_product_on_objects_int_hom_a1_b1_int_hom_a2_b2,
@@ -216,30 +350,47 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismWithGivenObject
              morphism );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
-      Description := "TensorProductInternalHomCompatibilityMorphismWithGivenObjects using associator, braiding an the evaluation morphism" );
+      Description := "TensorProductInternalHomCompatibilityMorphismWithGivenObjects using associator, braiding and the evaluation morphism" );
 
 ##
 AddDerivationToCAP( TensorProductDualityCompatibilityMorphismWithGivenObjects,
                   
-  function( cat, new_source, object_1, object_2, new_range )
-    local morphism, unit, tensor_product_on_object_1_and_object_2;
+  function( cat, s, a, b, r )
+    local morphism, unit, tensor_product_on_a_and_b;
+
+    #      a^v x b^v
+    #          |
+    #          v
+    # Hom(a,1) x Hom(b,1)
+    #          |
+    #          | CompatMorphism(a,1,b,1)
+    #          V
+    #  Hom(a x b, 1 x 1)
+    #          |
+    #          | Hom(id_(a x b), λ_1)
+    #          V
+    #    Hom(a x b, 1)
+    #          |
+    #          V
+    #       (a x b)^v
+
     
     unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
+    tensor_product_on_a_and_b := TensorProductOnObjects( cat, a, b );
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat,
-                    IsomorphismFromDualToInternalHom( cat, object_1 ),
-                    IsomorphismFromDualToInternalHom( cat, object_2 ) ),
+                    IsomorphismFromDualToInternalHom( cat, a ),
+                    IsomorphismFromDualToInternalHom( cat, b ) ),
                   
-                  TensorProductInternalHomCompatibilityMorphism( cat, [ object_1, unit, object_2, unit ] ),
+                  TensorProductInternalHomCompatibilityMorphism( cat, [ a, unit, b, unit ] ),
                   
                   InternalHomOnMorphisms( cat,
-                    IdentityMorphism( cat, tensor_product_on_object_1_and_object_2 ),
+                    IdentityMorphism( cat, tensor_product_on_a_and_b ),
                     LeftUnitor( cat, unit ) ),
                   
-                  IsomorphismFromInternalHomToDual( cat, tensor_product_on_object_1_and_object_2 )
+                  IsomorphismFromInternalHomToDual( cat, tensor_product_on_a_and_b )
                 ] );
     
     return morphism;
@@ -250,16 +401,26 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
                   
-  function( cat, object, internal_hom )
+  function( cat, a, internal_hom )
     local unit;
+
+    #       a
+    #       |
+    #       | coev_(a,1)
+    #       v
+    # Hom(1, a x 1)
+    #       |
+    #       | Hom(id_1, ρ_a)
+    #       v
+    #   Hom(1, a)
     
     unit := TensorUnit( cat );
     
     return PreCompose( cat,
-             CoevaluationMorphism( cat, object, unit ),
+             CoevaluationMorphism( cat, a, unit ),
              InternalHomOnMorphisms( cat,
                IdentityMorphism( cat, unit ),
-               RightUnitor( cat, object ) ) );
+               RightUnitor( cat, a ) ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalHomWithGivenInternalHom using the coevaluation morphism" );
@@ -267,15 +428,19 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
                   
-  function( cat, object, internal_hom )
+  function( cat, a, internal_hom )
     local unit;
+
+    # ρ_a: a x 1 -> a
+    #
+    # Adjoint( ρ_a ) = ( a -> Hom(1,a) )
     
     unit := TensorUnit( cat );
     
     return TensorProductToInternalHomAdjunctionMap( cat,
-             object,
+             a,
              unit,
-             RightUnitor( cat, object ) );
+             RightUnitor( cat, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalHomWithGivenInternalHom as the adjoint of the right unitor" );
@@ -284,9 +449,11 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 # ##
 # AddDerivationToCAP( IsomorphismFromInternalHomToObjectWithGivenInternalHom,
 #                     
-#   function( cat, object, internal_hom )
+#   function( cat, a, internal_hom )
+#
+#     # Inverse( a -> Hom(1,a) )
 #     
-#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalHom( cat, object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalHom( cat, a ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 #       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom as the inverse of IsomorphismFromObjectToInternalHom" );
@@ -294,13 +461,23 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromInternalHomToObjectWithGivenInternalHom,
                   
-  function( cat, object, internal_hom )
+  function( cat, a, internal_hom )
     local unit;
+
+    #  Hom(1,a)
+    #      |
+    #      | ( ρ_Hom(1,a) )^-1
+    #      v
+    # Hom(1,a) x 1
+    #      |
+    #      | ev_(1,a)
+    #      v
+    #      a
     
     unit := TensorUnit( cat );
     
     return PreCompose( cat, RightUnitorInverse( cat, internal_hom ),
-                       EvaluationMorphism( cat, unit, object ) );
+                       EvaluationMorphism( cat, unit, a ) );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom using the evaluation morphism" );
@@ -310,6 +487,8 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 # AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
 #                     
 #   function( cat, object, internal_hom )
+#
+#     # Inverse( a -> Hom(1,a))
 #     
 #     return InverseForMorphisms( cat, IsomorphismFromInternalHomToObject( cat, object ) );
 #     
@@ -319,33 +498,39 @@ end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromTensorProductToInternalHomWithGivenObjects,
                     
-  function( cat, tensor_object, object_1, object_2, internal_hom )
+  function( cat, tensor_object, a, b, internal_hom )
     local unit;
-    
+
+    #      a^v x b
+    #          |
+    #          v
+    # Hom(a,1) x Hom(1,b)
+    #          |
+    #          | CompatMorphism
+    #          v
+    # Hom(a x 1, 1 x b)
+    #          |
+    #          | Hom(ρ_a, λ_b)
+    #          v
+    #       Hom(a,b)
+
     unit := TensorUnit( cat );
     
     return PreComposeList( cat, [
              TensorProductOnMorphisms( cat,
-               IsomorphismFromDualToInternalHom( cat, object_1 ),
-               IsomorphismFromObjectToInternalHom( cat, object_2 ) ),
+               IsomorphismFromDualToInternalHom( cat, a ),
+               IsomorphismFromObjectToInternalHom( cat, b ) ),
                 
              TensorProductInternalHomCompatibilityMorphism( cat,
-               [ object_1, unit, unit, object_2 ] ),
+               [ a, unit, unit, b ] ),
                 
              InternalHomOnMorphisms( cat,
-               RightUnitor( cat, object_1 ),
-               LeftUnitor( cat, object_2 ) ),
+               RightUnitor( cat, a ),
+               LeftUnitor( cat, b ) ),
            ] );
     
 end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
       Description := "MorphismFromTensorProductToInternalHomWithGivenObjects using TensorProductInternalHomCompatibilityMorphism" );
-
-##
-# AddDerivationToCAP( MorphismFromTensorProductToInternalHomWithGivenObjects,
-#                     
-#   function( )
-#   
-# end : CategoryFilter := IsSymmetricClosedMonoidalCategory 
 
 ##
 AddDerivationToCAP( EvaluationMorphismWithGivenSource,

--- a/MonoidalCategories/gap/SymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/SymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -7,11 +7,23 @@
 ##
 AddDerivationToCAP( TensorProductToInternalCoHomAdjunctionMap,
 
-  function( cat, object_1, object_2, morphism )
+  function( cat, c, b, g )
     
+    # g: a -> c x b
+    #
+    #    Cohom(a,b)
+    #        |
+    #        | Cohom(g, id_b)
+    #        v
+    # Cohom(c x b, b)
+    #        |
+    #        | coclcoev_cb
+    #        v
+    #        c
+
     return PreCompose( cat,
-             InternalCoHomOnMorphisms( cat, morphism, IdentityMorphism( cat, object_1 ) ),
-             CoclosedCoevaluationMorphism( cat, object_1, object_2 ) );
+             InternalCoHomOnMorphisms( cat, g, IdentityMorphism( cat, b ) ),
+             CoclosedCoevaluationMorphism( cat, c, b ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "TensorProductToInternalCoHomAdjunctionMap using CoclosedCoevaluationMorphism and InternalCoHom" );
@@ -19,11 +31,23 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( InternalCoHomToTensorProductAdjunctionMap,
 
-  function( cat, object_1, object_2, morphism )
+  function( cat, a, b, f )
+
+    # f: Cohom(a,b) -> c
+    #
+    #        a
+    #        |
+    #        | coclev_ab
+    #        v
+    # Cohom(a,b) x b
+    #        |
+    #        | f x id_b
+    #        v
+    #      c x b
     
     return PreCompose( cat,
-             CoclosedEvaluationMorphism( cat, object_1, object_2 ),
-             TensorProductOnMorphisms( cat, IdentityMorphism( cat, object_2 ), morphism ) );
+             CoclosedEvaluationMorphism( cat, a, b ),
+             TensorProductOnMorphisms( cat, f, IdentityMorphism( cat, b ) ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "InternalCoHomToTensorProductAdjunctionMap using TensorProductOnMorphisms and CoclosedEvaluationMorphism" );
@@ -31,11 +55,15 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( UniversalPropertyOfCoDual,
 
-  function( cat, object_1, object_2, test_morphism )
+  function( cat, t, a, alpha )
+
+    # alpha: 1 -----> t x a
+    #
+    # a_v -> ( Cohom(1,a) -> t ) = Adjoint( alpha )
     
     return PreCompose( cat,
-             IsomorphismFromCoDualToInternalCoHom( cat, object_2 ),
-             TensorProductToInternalCoHomAdjunctionMap( cat, object_1, object_2, test_morphism ) );
+             IsomorphismFromCoDualToInternalCoHom( cat, a ),
+             TensorProductToInternalCoHomAdjunctionMap( cat, t, a, alpha ) );
              
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "UniversalPropertyOfCoDual using the cohom tensor adjunction" );
@@ -43,14 +71,27 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
 
-  function( cat, cobidual, object )
-    local morphism;
+  function( cat, a, avv )
+    local alpha;
 
-    morphism := PreCompose( cat,
-                  CoclosedEvaluationForCoDual( cat, object ),
-                  Braiding( cat, object, CoDualOnObjects( cat, object ) ) );
+    #    1
+    #    |
+    #    | coclev_a
+    #    v
+    # a_v x a
+    #    |
+    #    | B_(a_v,a)
+    #    v
+    #  a x a_v
+    #
+    #
+    # UniversalPropertyOfCoDual( 1 -> a x a_v) = ( a_v_v -> a )
+
+    alpha := PreCompose( cat,
+                  CoclosedEvaluationForCoDual( cat, a ),
+                  Braiding( cat, CoDualOnObjects( cat, a ), a ) );
                   
-    return UniversalPropertyOfCoDual( cat, CoDualOnObjects( cat, object ), object, morphism );
+    return UniversalPropertyOfCoDual( cat, a, CoDualOnObjects( cat, a ), alpha );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "MorphismFromCoBidualWithGivenCoBidual using the braiding and the universal property of the codual" );
@@ -58,23 +99,37 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( MorphismFromCoBidualWithGivenCoBidual,
 
-  function( cat, cobidual, object )
-    local morphism, codual_object, tensor_unit;
+  function( cat, a, avv )
+    local morphism, av, tensor_unit;
+
+    #     Cohom(1, a_v)
+    #          |
+    #          | Cohom( coclev_(1,a), id_(a_v) )
+    #          v
+    # Cohom(a_v x a, a_v)
+    #          |
+    #          | Cohom( B_( a_v, a), id_(a_v) )
+    #          v
+    # Cohom(a x a_v, a_v)
+    #          |
+    #          | coclcoev_(a, a_v)
+    #          v
+    #          a
     
-    codual_object := CoDualOnObjects( cat, object );
+    av := CoDualOnObjects( cat, a );
     
     tensor_unit := TensorUnit( cat );
     
     morphism := PreComposeList( cat, [
                   InternalCoHomOnMorphisms( cat,
-                    CoclosedEvaluationMorphism( cat, tensor_unit, object ),
-                    IdentityMorphism( cat, codual_object ) ),
+                    CoclosedEvaluationMorphism( cat, tensor_unit, a ),
+                    IdentityMorphism( cat, av ) ),
                   
                   InternalCoHomOnMorphisms( cat,
-                    Braiding( cat, object, codual_object ),
-                    IdentityMorphism( cat, codual_object ) ),
+                    Braiding( cat, av, a ),
+                    IdentityMorphism( cat, av ) ),
                   
-                  CoclosedCoevaluationMorphism( cat, codual_object, object )
+                  CoclosedCoevaluationMorphism( cat, a, av )
                 ] );
     
     return morphism;
@@ -85,9 +140,11 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoDualOnObjects,
 
-  function( cat, object )
+  function( cat, a )
+
+    # Source( a_v -> Cohom(1,a) )
     
-    return Source( IsomorphismFromCoDualToInternalCoHom( cat, object ) );
+    return Source( IsomorphismFromCoDualToInternalCoHom( cat, a ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoDualOnObjects as the source of IsomorphismFromCoDualToInternalCoHom" );
@@ -95,9 +152,11 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoDualOnObjects,
 
-  function( cat, object )
+  function( cat, a )
+
+    # Range( Cohom(1,a) -> a_v )
     
-    return Range( IsomorphismFromInternalCoHomToCoDual( cat, object ) );
+    return Range( IsomorphismFromInternalCoHomToCoDual( cat, a ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoDualOnObjects as the range of IsomorphismFromInternalCoHomToCoDual" );
@@ -105,17 +164,31 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoDualOnMorphismsWithGivenCoDuals,
 
-  function( cat, new_source, morphism, new_range )
+  function( cat, s, alpha, r )
     local result_morphism;
+
+    # alpha: a->b
+    #
+    #    b_v
+    #     |
+    #     v
+    # Cohom(1,b)
+    #     |
+    #     | Cohom(id_1, alpha)
+    #     v
+    # Cohom(1,a)
+    #     |
+    #     v
+    #    a_v
     
     result_morphism := PreComposeList( cat, [
-                         IsomorphismFromCoDualToInternalCoHom( cat, Range( morphism ) ),
+                         IsomorphismFromCoDualToInternalCoHom( cat, Range( alpha ) ),
                          
                          InternalCoHomOnMorphisms( cat,
                            IdentityMorphism( cat, TensorUnit( cat ) ),
-                           morphism ),
+                           alpha ),
                            
-                         IsomorphismFromInternalCoHomToCoDual( cat, Source( morphism ) )
+                         IsomorphismFromInternalCoHomToCoDual( cat, Source( alpha ) )
                        ] );
                        
     return result_morphism;
@@ -126,12 +199,16 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoclosedEvaluationForCoDualWithGivenTensorProduct,
 
-  function( cat, unit, object, tensor_object )
+  function( cat, s, a, r )
+
+    # s := 1
+
+    # Adjoint( Cohom(1,a) -> a_v ) = ( 1 -> a_v x a )
 
     return InternalCoHomToTensorProductAdjunctionMap( cat,
-            unit,
-            object,
-            IsomorphismFromInternalCoHomToCoDual( cat, object ) );
+            s,
+            a,
+            IsomorphismFromInternalCoHomToCoDual( cat, a ) );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "CoclosedEvaluationForCoDualWithGivenTensorProduct using the cohom tensor adjunction and IsomorphismFromInternalCoHomToCoDual" );
@@ -139,91 +216,154 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoLambdaIntroduction,
 
-  function( cat, morphism )
+  function( cat, alpha )
     local result_morphism, range;
 
-    range := Range( morphism );
+    #            alpha    (λ_b)^-1
+    # Adjoint( a -----> b --------> 1 x b ) = ( Cohom(a,b) -> 1 )
 
-    result_morphism := PreCompose( cat, morphism, RightUnitorInverse( cat, range ) );
+    #   a
+    #   |
+    #   | alpha
+    #   v
+    #   b
+    #   |
+    #   | (λ_b)^-1
+    #   v
+    # 1 x b
+    #
+    # Adjoint( a -> 1 x b) = ( Cohom(a,b) -> 1 )
+
+    range := Range( alpha );
+
+    result_morphism := PreCompose( cat, alpha, LeftUnitorInverse( cat, range ) );
 
     return TensorProductToInternalCoHomAdjunctionMap( cat,
-             range,
              TensorUnit( cat ),
+             range,
              result_morphism );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
-      Description := "CoLambdaIntroduction using the cohom tensor adjunction and right unitor" );
+      Description := "CoLambdaIntroduction using the cohom tensor adjunction and the left unitor inverse" );
 
 ##
 AddDerivationToCAP( CoLambdaElimination,
 
-  function( cat, object_1, object_2, morphism )
+  function( cat, a, b, alpha )
     local result_morphism;
+
+    #                     alpha                       λ_b
+    # Adjoint( Cohom(a,b) -----> 1 ) = ( a -> 1 x b ) ---> b
+
+
+    # alpha: Cohom(a,b) -> 1
+    # Adjoint( alpha ) = ( a -> 1 x b)
+    #
+    #   a
+    #   |
+    #   | Adjoint( alpha )
+    #   v
+    # 1 x b
+    #   |
+    #   | λ_b
+    #   v
+    #   b
     
-    result_morphism := InternalCoHomToTensorProductAdjunctionMap( cat, object_1, object_2, morphism );
+    result_morphism := InternalCoHomToTensorProductAdjunctionMap( cat, a, b, alpha );
     
-    return PreCompose( cat, result_morphism, RightUnitor( cat, object_2 ) );
+    return PreCompose( cat, result_morphism, LeftUnitor( cat, b ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
-      Description := "CoLambdaElimination using the cohom tensor adjunction and right unitor" );
+      Description := "CoLambdaElimination using the cohom tensor adjunction and the left unitor" );
 
 ##
 AddDerivationToCAP( InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects,
 
   function( cat, source, list, range )
-    local a1, a2, b1, b2, morphism, tensor_product_b1_b2, int_cohom_a1_b1, int_cohom_a2_b2, id_int_cohom_a1_b1, id_int_cohom_a2_b2;
+    local a1, a2, b1, b2, morphism, int_cohom_a1_b1, int_cohom_a2_b2, id_b2, tensor_product_on_objects_int_cohom_a1_b1_int_cohom_a2_b2;
+
+    #                   a1 x a2
+    #                      |
+    #                      | id_a1 x coclev_(a2,b2)
+    #                      v
+    #          a1 x (Cohom(a2,b2) x b2)
+    #                      |
+    #                      | α_( a1, (Cohom(a2,b2), b2) )
+    #                      v
+    #          (a1 x Cohom(a2,b2)) x b2
+    #                      |
+    #                      | ( coclev_(a1,b1) x id_Cohom(a2,b2) ) x id_b2
+    #                      v
+    # ((Cohom(a1,b1) x b1) x Cohom(a2,b2)) x b2
+    #                      |
+    #                      | α_( (Cohom(a1,b1), a1), Cohom(a2,b2) ) ) x id_b2
+    #                      v
+    #  (Cohom(a1,b1) x (b1 x Cohom(a2,b2))) x b2
+    #                      |
+    #                      | ( id_Cohom(a1,b1) x B_( b1, Cohom(a2,b2) ) ) x id_b2
+    #                      v
+    #  (Cohom(a1,b1) x (Cohom(a2,b2) x b1)) x b2
+    #                      |
+    #                      | α_( Cohom(a1,b1), (Cohom(a2,b2), b1) ) x id_b2
+    #                      v
+    #  ((Cohom(a1,b1) x Cohom(a2,b2)) x b1) x b2
+    #                      |
+    #                      | α_( (Cohom(a1,b1) x Cohom(a2,b2), b1), b2 )
+    #                      v
+    #  (Cohom(a1,b1) x Cohom(a2,b2)) x (b1 x b2)
+    #
+    #
+    # Adjoint[ a1 x a2 -> (Cohom(a1,b1) x Cohom(a2,b2)) x (b1 x b2) ] = [ Cohom(a1 x a2, b1 x b2) -> Cohom(a1,b1) x Cohom(a2,b2) ]
     
     a1 := list[1];
     a2 := list[2];
     b1 := list[3];
     b2 := list[4];
     
-    tensor_product_b1_b2 := TensorProductOnObjects( cat, b1, b2 );
-    
     int_cohom_a1_b1 := InternalCoHomOnObjects( cat, a1, b1 );
     
     int_cohom_a2_b2 := InternalCoHomOnObjects( cat, a2, b2 );
+
+    id_b2 := IdentityMorphism( cat, b2 );
     
-    id_int_cohom_a1_b1 := IdentityMorphism( cat, int_cohom_a1_b1 );
-    
-    id_int_cohom_a2_b2 := IdentityMorphism( cat, int_cohom_a2_b2 );
+    tensor_product_on_objects_int_cohom_a1_b1_int_cohom_a2_b2 :=
+      TensorProductOnObjects( cat, int_cohom_a1_b1, int_cohom_a2_b2 );
     
     morphism := PreComposeList( cat, [
                   TensorProductOnMorphisms( cat,
                     IdentityMorphism( cat, a1 ),
                     CoclosedEvaluationMorphism( cat, a2, b2 ) ),
                   
-                  AssociatorRightToLeft( cat, a1, b2,  int_cohom_a2_b2),
+                  AssociatorRightToLeft( cat, a1, int_cohom_a2_b2, b2),
                   
                   TensorProductOnMorphisms( cat,
                     TensorProductOnMorphisms( cat,
                       CoclosedEvaluationMorphism( cat, a1, b1 ),
-                      IdentityMorphism( cat, b2 ) ),
-                     id_int_cohom_a2_b2),
+                      IdentityMorphism( cat, int_cohom_a2_b2)),
+                    id_b2 ),
                   
                   TensorProductOnMorphisms( cat,
-                    AssociatorLeftToRight( cat, b1, int_cohom_a1_b1, b2 ),
-                    id_int_cohom_a2_b2 ),
+                    AssociatorLeftToRight( cat, int_cohom_a1_b1, a1, int_cohom_a2_b2 ),
+                    id_b2 ),
                   
                   TensorProductOnMorphisms( cat,
                     TensorProductOnMorphisms( cat,
-                      IdentityMorphism( cat, b1 ),
-                      Braiding( cat, b2, int_cohom_a1_b1 ) ),
-                    id_int_cohom_a2_b2 ),
+                      IdentityMorphism( cat, int_cohom_a1_b1),
+                      Braiding( cat, b1, int_cohom_a2_b2 ) ),
+                    id_b2 ),
                   
                   TensorProductOnMorphisms( cat,
-                    AssociatorRightToLeft( cat, b1, b2, int_cohom_a1_b1 ),
-                    id_int_cohom_a2_b2 ),
+                    AssociatorRightToLeft( cat, int_cohom_a1_b1, int_cohom_a2_b2, b1 ),
+                    id_b2 ),
                   
                   AssociatorLeftToRight( cat,
-                    tensor_product_b1_b2,
-                    int_cohom_a1_b1,
-                    int_cohom_a2_b2 )
+                    tensor_product_on_objects_int_cohom_a1_b1_int_cohom_a2_b2,
+                    b1, b2 )
                 ] );
 
     return TensorProductToInternalCoHomAdjunctionMap( cat,
-             tensor_product_b1_b2,
-             TensorProductOnObjects( cat, int_cohom_a1_b1, int_cohom_a2_b2 ),
+             tensor_product_on_objects_int_cohom_a1_b1_int_cohom_a2_b2,
+             TensorProductOnObjects( cat, b1, b2 ),
              morphism );
 
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
@@ -232,25 +372,41 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
 
-  function( cat, new_source, object_1, object_2, new_range )
-    local morphism, unit, tensor_product_on_object_1_and_object_2;
+  function( cat, s, a, b, r )
+    local morphism, unit, tensor_product_on_a_and_b;
+
+    #         (a x b)_v
+    #            |
+    #            V
+    #      Cohom(1, a x b)
+    #            |
+    #            | Cohom((λ_1)^-1, id_(a x b))
+    #            V
+    #  Cohom(1 x 1, a x b)
+    #            |
+    #            | CompatMorphism(1,1,a,b)
+    #            V
+    # Cohom(1,a) x Cohom(1,b)
+    #            |
+    #            v
+    #        a_v x b_v
     
     unit := TensorUnit( cat );
     
-    tensor_product_on_object_1_and_object_2 := TensorProductOnObjects( cat, object_1, object_2 );
+    tensor_product_on_a_and_b := TensorProductOnObjects( cat, a, b );
     
     morphism := PreComposeList( cat, [
-                  IsomorphismFromCoDualToInternalCoHom( cat, tensor_product_on_object_1_and_object_2 ),
+                  IsomorphismFromCoDualToInternalCoHom( cat, tensor_product_on_a_and_b ),
                   
                   InternalCoHomOnMorphisms( cat,
                     LeftUnitorInverse( cat, unit ),
-                    IdentityMorphism( cat, tensor_product_on_object_1_and_object_2 ) ),
+                    IdentityMorphism( cat, tensor_product_on_a_and_b ) ),
                   
-                  InternalCoHomTensorProductCompatibilityMorphism( cat, [ unit, unit, object_1, object_2 ] ),
+                  InternalCoHomTensorProductCompatibilityMorphism( cat, [ unit, unit, a, b ] ),
                   
                   TensorProductOnMorphisms( cat,
-                    IsomorphismFromInternalCoHomToCoDual( cat, object_1 ),
-                    IsomorphismFromInternalCoHomToCoDual( cat, object_2 ) )
+                    IsomorphismFromInternalCoHomToCoDual( cat, a ),
+                    IsomorphismFromInternalCoHomToCoDual( cat, b ) )
                 ] );
 
     return morphism;
@@ -261,17 +417,27 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom,
                   
-  function( cat, object, internal_cohom )
+  function( cat, a, internal_cohom )
     local unit;
+
+    #     Cohom(a, 1)
+    #         |
+    #         | Cohom((ρ_a)^-1, id_1)
+    #         v
+    # Cohom(a x 1, 1)
+    #         |
+    #         | coclcoev_(a,1)
+    #         v
+    #         a
     
     unit := TensorUnit( cat );
     
     return PreCompose( cat,
              InternalCoHomOnMorphisms( cat,
-               LeftUnitorInverse( cat, object ),
+               RightUnitorInverse( cat, a ),
                IdentityMorphism( cat, unit ) ),
                
-             CoclosedCoevaluationMorphism( cat, unit, object ));
+             CoclosedCoevaluationMorphism( cat, a, unit ));
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom using the coclosed coevaluation morphism" );
@@ -279,74 +445,105 @@ end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
 ##
 AddDerivationToCAP( IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom,
                   
-  function( cat, object, internal_cohom )
+  function( cat, a, internal_cohom )
     local unit;
+
+    # (ρ_a)^-1: a -> a x 1
+    #
+    # Adjoint( (ρ_a)^-1 ) = ( Cohom(a,1) -> a )
     
     unit := TensorUnit( cat );
     
     return TensorProductToInternalCoHomAdjunctionMap( cat,
+             a,
              unit,
-             object,
-             LeftUnitorInverse( cat, object ) );
+             RightUnitorInverse( cat, a ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
-      Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom as the adjoint of the left inverse unitor" );
+      Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom as the adjoint of the right inverse unitor" );
 
-## TODO: modify for the coclosed case and enable
+## TODO: enable
 # ##
-# AddDerivationToCAP( IsomorphismFromInternalHomToObjectWithGivenInternalHom,
+# AddDerivationToCAP( IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom,
 #                     
-#   function( cat, object, internal_hom )
+#   function( cat, a, internal_cohom )
+#
+#     # Inverse( a -> Cohom(a,1) )
 #     
-#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalHom( cat, object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromObjectToInternalCoHom( cat, a ) );
 #     
-# end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
-#       Description := "IsomorphismFromInternalHomToObjectWithGivenInternalHom as the inverse of IsomorphismFromObjectToInternalHom" );
+# end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
+#       Description := "IsomorphismFromInternalCoHomToObjectWithGivenInternalCoHom as the inverse of IsomorphismFromObjectToInternalCoHom" );
 
 ##
 AddDerivationToCAP( IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom,
                   
-  function( cat, object, internal_cohom )
+  function( cat, a, internal_cohom )
     local unit;
+
+    #       a
+    #       |
+    #       | coclev_(a,1)
+    #       v
+    # Cohom(a,1) x 1
+    #       |
+    #       | ρ_Cohom(a,1)
+    #       v
+    #   Cohom(a,1)
     
     unit := TensorUnit( cat );
     
-    return PreCompose( cat, CoclosedEvaluationMorphism( cat, object, unit ),
-                       LeftUnitor( cat, internal_cohom ) );
+    return PreCompose( cat, CoclosedEvaluationMorphism( cat, a, unit ),
+                       RightUnitor( cat, internal_cohom ) );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,
       Description := "IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom using the coclosed evaluation morphism" );
 
-## TODO: modify for the coclosed case and enable
+## TODO: enable
 # ##
-# AddDerivationToCAP( IsomorphismFromObjectToInternalHomWithGivenInternalHom,
+# AddDerivationToCAP( IsomorphismFromObjectToInternalCoHomWithGivenInternalCoHom,
 #                     
-#   function( cat, object, internal_hom )
+#   function( cat, a, internal_cohom )
+#
+#     # Inverse( Cohom(a,1) -> a)
 #     
-#     return InverseForMorphisms( cat, IsomorphismFromInternalHomToObject( cat, object ) );
+#     return InverseForMorphisms( cat, IsomorphismFromInternalCoHomToObject( cat, a ) );
 #     
 # end : CategoryFilter := IsSymmetricClosedMonoidalCategory,
-#       Description := "IsomorphismFromObjectToInternalHom as the inverse of IsomorphismFromInternalHomToObject" );
+#       Description := "IsomorphismFromObjectToInternalCoHom as the inverse of IsomorphismFromInternalCoHomToObject" );
 
 ##
 AddDerivationToCAP( MorphismFromInternalCoHomToTensorProductWithGivenObjects,
                     
-  function( cat, internal_cohom, object_1, object_2, tensor_object )
+  function( cat, internal_cohom, a, b, tensor_object )
     local unit;
+
+    #       Cohom(a,b)
+    #            |
+    #            | Cohom( (λ_a)^-1, (ρ_b)^-1)
+    #            v
+    # Cohom(1 x a, b x 1)
+    #            |
+    #            | CompatMorphism
+    #            v
+    # Cohom(1,b) x Cohom(a,1)
+    #            |
+    #            v
+    #        b_v x a
     
     unit := TensorUnit( cat );
     
     return PreComposeList( cat, [
              InternalCoHomOnMorphisms( cat,
-               RightUnitorInverse( cat, object_1 ),
-               LeftUnitorInverse( cat, object_2 ) ),
+               LeftUnitorInverse( cat, a ),
+               RightUnitorInverse( cat, b ) ),
               
              InternalCoHomTensorProductCompatibilityMorphism( cat,
-               [ object_1, unit, unit, object_2 ] ),
+               [ unit, a, b, unit ] ),
               
              TensorProductOnMorphisms( cat,
-               IsomorphismFromInternalCoHomToObject( cat, object_1 ),
-               IsomorphismFromInternalCoHomToCoDual( cat, object_2 ) )
+               IsomorphismFromInternalCoHomToCoDual( cat, b ),
+               IsomorphismFromInternalCoHomToObject( cat, a ) )
            ] );
     
 end : CategoryFilter := IsSymmetricCoclosedMonoidalCategory,


### PR DESCRIPTION
- Changed the coclosed methods to be left coclosed (this is necessary for Opposite()).
- Inserted diagrams as comments for various derivations.