### PR TITLE
Various improvements

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.12-02",
+Version := "2021.12-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/LinearAlgebraForCAP.g
+++ b/CAP/examples/LinearAlgebraForCAP.g
@@ -16,10 +16,12 @@ mor := ZeroMorphism( ZeroObject( Wrapper ), ZeroObject( Wrapper ) );;
 2 * mor;;
 BasisOfExternalHom( Source( mor ), Range( mor ) );;
 CoefficientsOfMorphism( mor );;
-DistinguishedObjectOfHomomorphismStructure( Wrapper );;
-HomomorphismStructureOnObjects( Source( mor ), Source( mor ) );;
+distinguished_object := DistinguishedObjectOfHomomorphismStructure( Wrapper );;
+object := HomomorphismStructureOnObjects( Source( mor ), Source( mor ) );;
 HomomorphismStructureOnMorphisms( mor, mor );;
+HomomorphismStructureOnMorphismsWithGivenObjects( object, mor, mor, object );;
 iota := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( mor );;
+InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( distinguished_object, mor, object );;
 beta := InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( Source( mor ), Range( mor ), iota );;
 IsCongruentForMorphisms( mor, beta );
 #! true
@@ -27,10 +29,12 @@ IsCongruentForMorphisms( mor, beta );
 Wrapper2 := WrapperCategory( Qmat, rec( wrap_range_of_hom_structure := true ) );
 #! WrapperCategory( Category of matrices over Q )
 mor := ZeroMorphism( ZeroObject( Wrapper2 ), ZeroObject( Wrapper2 ) );;
-DistinguishedObjectOfHomomorphismStructure( Wrapper2 );;
-HomomorphismStructureOnObjects( Source( mor ), Source( mor ) );;
+distinguished_object := DistinguishedObjectOfHomomorphismStructure( Wrapper2 );;
+object := HomomorphismStructureOnObjects( Source( mor ), Source( mor ) );;
 HomomorphismStructureOnMorphisms( mor, mor );;
+HomomorphismStructureOnMorphismsWithGivenObjects( object, mor, mor, object );;
 iota := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( mor );;
+InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( distinguished_object, mor, object );;
 beta := InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( Source( mor ), Range( mor ), iota );;
 IsCongruentForMorphisms( mor, beta );
 #! true

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -993,7 +993,7 @@ DeclareAttribute( "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorph
 #! The output is the corresponding morphism
 #! $\nu( \alpha ): 1 \rightarrow r$ in $D$ of the homomorphism structure.
 #! @Returns a morphism in $\mathrm{Hom}_{D}(1, r)$
-#! @Arguments alpha
+#! @Arguments distinguished_object, alpha, r
 DeclareOperation( "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
                   [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ] );
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -971,7 +971,7 @@ InstallGlobalFunction( DerivationsOfMethodByCategory,
             if IsBound( category!.primitive_operations.( string ) ) and category!.primitive_operations.( string ) = true then
                 Print( "It was given as a primitive operation.\n\n" );
             else
-                Print( "It was installed as a final derivation or as a precompiled function.\n\n" );
+                Print( "It was installed as a final or precompiled derivation.\n\n" );
             fi;
         else
             Print( "It was derived by ", DerivationName( current_derivation ), " using \n" );

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -599,7 +599,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
         if set_primitive then
             AddPrimitiveOperation( category!.derivations_weight_list, function_name, weight );
             
-            if not ValueOption( "IsFinalDerivation" ) = true and not ValueOption( "IsPrecompiledFunction" ) = true then
+            if not ValueOption( "IsFinalDerivation" ) = true and not ValueOption( "IsPrecompiledDerivation" ) = true then
                 category!.primitive_operations.( function_name ) := true;
             fi;
             

--- a/CAP/gap/WrapperCategory.gi
+++ b/CAP/gap/WrapperCategory.gi
@@ -107,7 +107,7 @@ InstallMethod( WrapperCategory,
         [ IsCapCategory, IsRecord ],
         
   function( C, options )
-    local known_options_with_filters, filter, category_constructor_options, copy_value_or_default, D, HC, option_name;
+    local known_options_with_filters, filter, category_constructor_options, copy_value_or_default, list_of_operations_to_install, D, HC, option_name;
     
     ## check given options
     known_options_with_filters := rec(
@@ -201,13 +201,15 @@ InstallMethod( WrapperCategory,
     
     if IsBound( options.only_primitive_operations ) and options.only_primitive_operations then
         
-        category_constructor_options.list_of_operations_to_install := ListPrimitivelyInstalledOperationsOfCategory( C );
+        list_of_operations_to_install := ListPrimitivelyInstalledOperationsOfCategory( C );
         
     else
         
-        category_constructor_options.list_of_operations_to_install := ListInstalledOperationsOfCategory( C );
+        list_of_operations_to_install := ListInstalledOperationsOfCategory( C );
         
     fi;
+    
+    category_constructor_options.list_of_operations_to_install := list_of_operations_to_install;
     
     D := CategoryConstructor( category_constructor_options );
     
@@ -225,7 +227,7 @@ InstallMethod( WrapperCategory,
     
     SetUnderlyingCategory( D, C );
     
-    if CanCompute( C, "BasisOfExternalHom" ) then
+    if "BasisOfExternalHom" in list_of_operations_to_install then
         
         AddBasisOfExternalHom( D,
           function( cat, a, b )
@@ -237,7 +239,7 @@ InstallMethod( WrapperCategory,
         
     fi;
     
-    if CanCompute( C, "CoefficientsOfMorphismWithGivenBasisOfExternalHom" ) then
+    if "CoefficientsOfMorphismWithGivenBasisOfExternalHom" in list_of_operations_to_install then
         
         AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( D,
           function( cat, alpha, L )
@@ -269,7 +271,7 @@ InstallMethod( WrapperCategory,
                 
             fi;
             
-            if CanCompute( C, "DistinguishedObjectOfHomomorphismStructure" ) then
+            if "DistinguishedObjectOfHomomorphismStructure" in list_of_operations_to_install then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
                   function( cat )
                     
@@ -278,7 +280,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "HomomorphismStructureOnObjects" ) then
+            if "HomomorphismStructureOnObjects" in list_of_operations_to_install then
                 AddHomomorphismStructureOnObjects( D,
                   function( cat, a, b )
                     
@@ -287,7 +289,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "HomomorphismStructureOnMorphismsWithGivenObjects" ) then
+            if "HomomorphismStructureOnMorphismsWithGivenObjects" in list_of_operations_to_install then
                 AddHomomorphismStructureOnMorphismsWithGivenObjects( D,
                   function( cat, s, alpha, beta, r )
                     
@@ -296,7 +298,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects" ) then
+            if "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects" in list_of_operations_to_install then
                 AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( D,
                   function( cat, s, alpha, r )
                     
@@ -305,7 +307,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" ) then
+            if "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" in list_of_operations_to_install then
                 AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( D,
                   function( cat, a, b, iota )
                     
@@ -316,7 +318,7 @@ InstallMethod( WrapperCategory,
             
         else
             
-            if CanCompute( C, "DistinguishedObjectOfHomomorphismStructure" ) then
+            if "DistinguishedObjectOfHomomorphismStructure" in list_of_operations_to_install then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
                   function( cat )
                     
@@ -325,7 +327,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "HomomorphismStructureOnObjects" ) then
+            if "HomomorphismStructureOnObjects" in list_of_operations_to_install then
                 AddHomomorphismStructureOnObjects( D,
                   function( cat, a, b )
                     
@@ -334,7 +336,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "HomomorphismStructureOnMorphismsWithGivenObjects" ) then
+            if "HomomorphismStructureOnMorphismsWithGivenObjects" in list_of_operations_to_install then
                 AddHomomorphismStructureOnMorphismsWithGivenObjects( D,
                   function( cat, s, alpha, beta, r )
                     
@@ -343,7 +345,7 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" ) then
+            if "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" in list_of_operations_to_install then
                 AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( D,
                   function( cat, alpha )
                     
@@ -352,7 +354,16 @@ InstallMethod( WrapperCategory,
                 end );
             fi;
             
-            if CanCompute( C, "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" ) then
+            if "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects" in list_of_operations_to_install then
+                AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( D,
+                  function( cat, s, alpha, r )
+                    
+                    return InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( UnderlyingCategory( cat ), s, MorphismDatum( cat, alpha ), r );
+                    
+                end );
+            fi;
+            
+            if "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" in list_of_operations_to_install then
                 AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( D,
                   function( cat, a, b, iota )
                     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2021.12-02",
+Version := "2021.12-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -69,7 +69,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [
-      [ "CAP", ">= 2021.12-01" ],
+      [ "CAP", ">= 2021.12-03" ],
   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -246,7 +246,7 @@ BindGlobal( "CAP_JIT_INTERNAL_SAFE_OPERATIONS", [
 ] );
 
 InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_constructor, given_arguments, package_name, compiled_category_name )
-  local cat1, cat2, cat, obj, mor, operations, diff, output_string, package_info, parameters_string, current_string, object_name, example_input, without_given_name, without_given_rec, with_given_object_position, source, range, index, function_to_compile, compiled_tree, compiled_func, function_string, weight, filter_list, function_name, current_rec;
+  local cat1, cat2, cat, obj, mor, operations, diff, output_string, package_info, parameters_string, current_string, object_name, example_input, without_given_name, without_given_rec, with_given_object_position, source, range, index, function_to_compile, compiled_tree, compiled_func, function_string, weight, IsPrecompiledDerivation_string, filter_list, function_name, current_rec;
     
     if IsOperation( category_constructor ) or IsKernelFunction( category_constructor ) then
         
@@ -542,6 +542,16 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         Assert( 0, weight < infinity );
         
+        if IsBound( cat!.primitive_operations.(function_name) ) and cat!.primitive_operations.(function_name) = true then
+            
+            IsPrecompiledDerivation_string := "";
+            
+        else
+            
+            IsPrecompiledDerivation_string := " : IsPrecompiledDerivation := true";
+            
+        fi;
+        
         current_string := Concatenation(
             "    \n",
             "    ##\n",
@@ -551,7 +561,7 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
             function_string, "\n",
             "########\n",
             "        \n",
-            "    , ", String( weight ), " : IsPrecompiledFunction := true );\n"
+            "    , ", String( weight ), IsPrecompiledDerivation_string, " );\n"
         );
         output_string := Concatenation( output_string, current_string );
         

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.12-02",
+Version := "2021.12-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -88,7 +88,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.8",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2021.11-10" ],
+                           [ "CAP", ">= 2021.12-03" ],
                            [ "MatricesForHomalg", ">= 2021.07-01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "LinearAlgebraForCAP", ">= 2020.05.16" ],

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
@@ -296,11 +296,11 @@ CapJitAddLogicTemplate(
 # ConvertMatrixToRow( M )
 CapJitAddLogicTemplate(
     rec(
-        variable_names := [ "ring", "matrix" ],
-        variable_filters := [ "IsHomalgRing", "IsHomalgMatrix" ],
+        variable_names := [ "ring", "nr_rows", "matrix" ],
+        variable_filters := [ "IsHomalgRing", "IsInt", "IsHomalgMatrix" ],
         src_template := """
-            UnionOfColumns( ring, 1, List( [ 1 .. NrRows( matrix ) ], i ->
-                UnionOfColumns( ring, 1, List( [ 1 .. NrColumns( matrix ) ], j ->
+            UnionOfColumns( ring, nr_rows, List( [ 1 .. NrRows( matrix ) ], i ->
+                UnionOfColumns( ring, nr_rows, List( [ 1 .. NrColumns( matrix ) ], j ->
                     HomalgMatrix( [ matrix[i, j] ], 1, 1, ring )
                 ) )
             ) )

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -15,7 +15,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAdditiveInverseForMorphisms( cat,
@@ -27,7 +27,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddColift( cat,
@@ -39,7 +39,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismFromDirectSum( cat,
@@ -56,7 +56,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismIntoDirectSum( cat,
@@ -73,7 +73,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSum( cat,
@@ -87,7 +87,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumFunctorialWithGivenDirectSums( cat,
@@ -101,7 +101,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIdentityMorphism( cat,
@@ -113,7 +113,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInjectionOfBiasedWeakPushout( cat,
@@ -128,7 +128,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsColiftable( cat,
@@ -139,7 +139,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsCongruentForMorphisms( cat,
@@ -150,7 +150,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEqualForObjects( cat,
@@ -161,7 +161,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftable( cat,
@@ -172,7 +172,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,
@@ -197,7 +197,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForObjects( cat,
@@ -217,7 +217,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForMorphisms( cat,
@@ -228,7 +228,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForObjects( cat,
@@ -239,7 +239,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddLift( cat,
@@ -251,7 +251,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismConstructor( cat,
@@ -263,7 +263,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismDatum( cat,
@@ -286,7 +286,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectConstructor( cat,
@@ -298,7 +298,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectDatum( cat,
@@ -313,7 +313,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddPostCompose( cat,
@@ -325,7 +325,7 @@ function ( cat_1, beta_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionOfBiasedWeakFiberProduct( cat,
@@ -340,7 +340,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange( cat,
@@ -355,7 +355,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoFromInputObject( cat,
@@ -370,7 +370,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoToInputObject( cat,
@@ -385,7 +385,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource( cat,
@@ -400,7 +400,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange( cat,
@@ -416,7 +416,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputRange( cat,
@@ -431,7 +431,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputSource( cat,
@@ -446,7 +446,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputRange( cat,
@@ -461,7 +461,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputSource( cat,
@@ -476,7 +476,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoFromInputObject( cat,
@@ -491,7 +491,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoToInputObject( cat,
@@ -506,7 +506,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand( cat,
@@ -517,7 +517,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismFromInputRange( cat,
@@ -528,7 +528,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismToInputRange( cat,
@@ -539,7 +539,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
@@ -553,7 +553,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
@@ -565,7 +565,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
@@ -579,7 +579,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
@@ -591,7 +591,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakCokernelProjection( cat,
@@ -606,7 +606,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakKernelEmbedding( cat,
@@ -621,7 +621,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroMorphism( cat,
@@ -633,7 +633,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObject( cat,
@@ -645,7 +645,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
 end );
 

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -15,7 +15,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAdditiveInverseForMorphisms( cat,
@@ -27,7 +27,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraidingInverseWithGivenTensorProducts( cat,
@@ -47,7 +47,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraidingWithGivenTensorProducts( cat,
@@ -67,7 +67,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnMorphismsWithGivenCoDuals( cat,
@@ -79,7 +79,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnObjects( cat,
@@ -91,7 +91,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
@@ -113,7 +113,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
@@ -135,7 +135,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoevaluationForDualWithGivenTensorProduct( cat,
@@ -156,7 +156,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddColift( cat,
@@ -168,7 +168,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismFromDirectSum( cat,
@@ -185,7 +185,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismIntoDirectSum( cat,
@@ -202,7 +202,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSum( cat,
@@ -216,7 +216,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumFunctorialWithGivenDirectSums( cat,
@@ -230,7 +230,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDistinguishedObjectOfHomomorphismStructure( cat,
@@ -242,7 +242,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnMorphismsWithGivenDuals( cat,
@@ -254,7 +254,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnObjects( cat,
@@ -265,7 +265,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEvaluationForDualWithGivenTensorProduct( cat,
@@ -286,7 +286,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
@@ -298,7 +298,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnObjects( cat,
@@ -310,7 +310,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIdentityMorphism( cat,
@@ -322,7 +322,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInjectionOfBiasedWeakPushout( cat,
@@ -337,7 +337,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
@@ -353,7 +353,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
@@ -365,7 +365,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsColiftable( cat,
@@ -376,7 +376,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsCongruentForMorphisms( cat,
@@ -387,7 +387,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEqualForObjects( cat,
@@ -398,7 +398,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftable( cat,
@@ -409,7 +409,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,
@@ -434,7 +434,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForObjects( cat,
@@ -454,7 +454,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForMorphisms( cat,
@@ -465,7 +465,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForObjects( cat,
@@ -476,7 +476,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddLift( cat,
@@ -488,7 +488,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismConstructor( cat,
@@ -500,7 +500,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismDatum( cat,
@@ -523,7 +523,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismFromCoBidualWithGivenCoBidual( cat,
@@ -535,7 +535,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismToBidualWithGivenBidual( cat,
@@ -547,7 +547,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
@@ -559,7 +559,7 @@ function ( cat_1, r_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectConstructor( cat,
@@ -571,7 +571,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectDatum( cat,
@@ -586,7 +586,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddPostCompose( cat,
@@ -598,7 +598,7 @@ function ( cat_1, beta_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionOfBiasedWeakFiberProduct( cat,
@@ -613,7 +613,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange( cat,
@@ -628,7 +628,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoFromInputObject( cat,
@@ -643,7 +643,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoToInputObject( cat,
@@ -658,7 +658,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource( cat,
@@ -673,7 +673,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange( cat,
@@ -689,7 +689,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputRange( cat,
@@ -704,7 +704,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputSource( cat,
@@ -719,7 +719,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputRange( cat,
@@ -734,7 +734,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputSource( cat,
@@ -749,7 +749,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoFromInputObject( cat,
@@ -764,7 +764,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoToInputObject( cat,
@@ -779,7 +779,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand( cat,
@@ -790,7 +790,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismFromInputRange( cat,
@@ -801,7 +801,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismToInputRange( cat,
@@ -812,7 +812,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
@@ -824,7 +824,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnObjects( cat,
@@ -836,7 +836,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorUnit( cat,
@@ -848,7 +848,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
@@ -862,7 +862,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
@@ -874,7 +874,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
@@ -888,7 +888,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
@@ -900,7 +900,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakCokernelProjection( cat,
@@ -915,7 +915,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakKernelEmbedding( cat,
@@ -930,7 +930,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroMorphism( cat,
@@ -942,7 +942,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObject( cat,
@@ -954,7 +954,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
 end );
 

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -15,7 +15,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAdditiveInverseForMorphisms( cat,
@@ -27,7 +27,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBasisOfExternalHom( cat,
@@ -48,7 +48,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraidingInverseWithGivenTensorProducts( cat,
@@ -68,7 +68,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraidingWithGivenTensorProducts( cat,
@@ -88,7 +88,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnMorphismsWithGivenCoDuals( cat,
@@ -100,7 +100,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnObjects( cat,
@@ -112,7 +112,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
@@ -134,7 +134,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
@@ -156,7 +156,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
@@ -167,7 +167,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoevaluationForDualWithGivenTensorProduct( cat,
@@ -188,7 +188,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelObject( cat,
@@ -202,7 +202,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelProjection( cat,
@@ -217,7 +217,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddColift( cat,
@@ -229,7 +229,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismFromDirectSum( cat,
@@ -246,7 +246,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismIntoDirectSum( cat,
@@ -263,7 +263,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSum( cat,
@@ -277,7 +277,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumFunctorialWithGivenDirectSums( cat,
@@ -291,7 +291,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDistinguishedObjectOfHomomorphismStructure( cat,
@@ -303,7 +303,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnMorphismsWithGivenDuals( cat,
@@ -315,7 +315,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnObjects( cat,
@@ -326,7 +326,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEvaluationForDualWithGivenTensorProduct( cat,
@@ -347,7 +347,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
@@ -359,7 +359,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnObjects( cat,
@@ -371,7 +371,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIdentityMorphism( cat,
@@ -383,7 +383,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInjectionOfBiasedWeakPushout( cat,
@@ -398,7 +398,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
@@ -414,7 +414,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
@@ -426,7 +426,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsColiftable( cat,
@@ -437,7 +437,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsCongruentForMorphisms( cat,
@@ -448,7 +448,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEqualForObjects( cat,
@@ -459,7 +459,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftable( cat,
@@ -470,7 +470,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,
@@ -495,7 +495,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForObjects( cat,
@@ -515,7 +515,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForMorphisms( cat,
@@ -526,7 +526,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForObjects( cat,
@@ -537,7 +537,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelEmbedding( cat,
@@ -552,7 +552,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelObject( cat,
@@ -566,7 +566,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddLift( cat,
@@ -578,7 +578,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismConstructor( cat,
@@ -590,7 +590,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismDatum( cat,
@@ -613,7 +613,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismFromCoBidualWithGivenCoBidual( cat,
@@ -625,7 +625,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismToBidualWithGivenBidual( cat,
@@ -637,7 +637,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
@@ -649,7 +649,7 @@ function ( cat_1, r_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectConstructor( cat,
@@ -661,7 +661,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectDatum( cat,
@@ -676,7 +676,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddPostCompose( cat,
@@ -688,7 +688,7 @@ function ( cat_1, beta_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionOfBiasedWeakFiberProduct( cat,
@@ -703,7 +703,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange( cat,
@@ -718,7 +718,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoFromInputObject( cat,
@@ -733,7 +733,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifyRange_IsoToInputObject( cat,
@@ -748,7 +748,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource( cat,
@@ -763,7 +763,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange( cat,
@@ -779,7 +779,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputRange( cat,
@@ -794,7 +794,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoFromInputSource( cat,
@@ -809,7 +809,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputRange( cat,
@@ -824,7 +824,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySourceAndRange_IsoToInputSource( cat,
@@ -839,7 +839,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoFromInputObject( cat,
@@ -854,7 +854,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSimplifySource_IsoToInputObject( cat,
@@ -869,7 +869,7 @@ function ( cat_1, mor_1, n_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand( cat,
@@ -880,7 +880,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismFromInputRange( cat,
@@ -891,7 +891,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismToInputRange( cat,
@@ -902,7 +902,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
@@ -914,7 +914,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnObjects( cat,
@@ -926,7 +926,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorUnit( cat,
@@ -938,7 +938,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
@@ -952,7 +952,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
@@ -964,7 +964,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
@@ -978,7 +978,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
@@ -990,7 +990,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakCokernelProjection( cat,
@@ -1005,7 +1005,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddWeakKernelEmbedding( cat,
@@ -1020,7 +1020,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroMorphism( cat,
@@ -1032,7 +1032,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObject( cat,
@@ -1044,7 +1044,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
 end );
 

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -61,25 +61,22 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, range_1 )
-    local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
-    deduped_6_1 := UnderlyingMatrix( alpha_1 );
-    deduped_5_1 := UnderlyingRing( cat_1 );
-    deduped_4_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    hoisted_2_1 := ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 );
-    hoisted_3_1 := DiagMat( deduped_5_1, List( [ 1 .. NumberColumns( deduped_6_1 ) ], function ( logic_new_func_x_2 )
-              return hoisted_2_1;
+    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := UnderlyingMatrix( alpha_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
+    hoisted_1_1 := ColumnVectorOfGeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 );
+    hoisted_2_1 := DiagMat( deduped_4_1, List( [ 1 .. NumberColumns( deduped_5_1 ) ], function ( logic_new_func_x_2 )
+              return hoisted_1_1;
           end ) );
-    morphism_attr_1_1 := CoercedMatrix( deduped_5_1, UnderlyingRing( deduped_4_1 ), CoefficientsWithGivenMonomials( ConvertMatrixToRow( deduped_6_1 ), DiagMat( deduped_5_1, List( [ 1 .. NumberRows( deduped_6_1 ) ], function ( logic_new_func_x_2 )
-                  return hoisted_3_1;
-              end ) ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), deduped_4_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), deduped_4_1, RankOfObject, 1 ), ObjectifyObjectForCAPWithAttributes( rec(
-             ), deduped_4_1, RankOfObject, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
+           ), deduped_3_1, source_1, range_1, UnderlyingMatrix, CoercedMatrix( deduped_4_1, UnderlyingRing( deduped_3_1 ), CoefficientsWithGivenMonomials( ConvertMatrixToRow( deduped_5_1 ), DiagMat( deduped_4_1, List( [ 1 .. NumberRows( deduped_5_1 ) ], function ( logic_new_func_x_2 )
+                    return hoisted_2_1;
+                end ) ) ) ) );
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 100 : IsPrecompiledFunction := true );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -15,7 +15,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnObjects( cat,
@@ -27,7 +27,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
@@ -54,7 +54,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( cat,
@@ -76,7 +76,7 @@ function ( cat_1, source_1, alpha_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
@@ -114,7 +114,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
 end );
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -15,7 +15,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAdditiveInverseForMorphisms( cat,
@@ -27,7 +27,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAssociatorLeftToRight( cat,
@@ -43,7 +43,7 @@ function ( cat_1, a_1, b_1, c_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddAssociatorLeftToRightWithGivenTensorProducts( cat,
@@ -55,7 +55,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddAssociatorRightToLeft( cat,
@@ -71,7 +71,7 @@ function ( cat_1, a_1, b_1, c_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddAssociatorRightToLeftWithGivenTensorProducts( cat,
@@ -83,7 +83,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddAstrictionToCoimage( cat,
@@ -99,7 +99,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 704 : IsPrecompiledFunction := true );
+    , 704 : IsPrecompiledDerivation := true );
     
     ##
     AddAstrictionToCoimageWithGivenCoimage( cat,
@@ -115,7 +115,7 @@ function ( cat_1, alpha_1, C_1 )
 end
 ########
         
-    , 705 : IsPrecompiledFunction := true );
+    , 705 : IsPrecompiledDerivation := true );
     
     ##
     AddBasisOfExternalHom( cat,
@@ -136,7 +136,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraiding( cat,
@@ -161,7 +161,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddBraidingInverse( cat,
@@ -186,7 +186,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddBraidingInverseWithGivenTensorProducts( cat,
@@ -206,7 +206,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddBraidingWithGivenTensorProducts( cat,
@@ -226,7 +226,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoastrictionToImage( cat,
@@ -242,7 +242,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 704 : IsPrecompiledFunction := true );
+    , 704 : IsPrecompiledDerivation := true );
     
     ##
     AddCoastrictionToImageWithGivenImageObject( cat,
@@ -258,7 +258,7 @@ function ( cat_1, alpha_1, I_1 )
 end
 ########
         
-    , 705 : IsPrecompiledFunction := true );
+    , 705 : IsPrecompiledDerivation := true );
     
     ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
@@ -269,7 +269,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoevaluationForDual( cat,
@@ -296,7 +296,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 401 : IsPrecompiledFunction := true );
+    , 401 : IsPrecompiledDerivation := true );
     
     ##
     AddCoevaluationForDualWithGivenTensorProduct( cat,
@@ -317,7 +317,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoevaluationMorphism( cat,
@@ -357,7 +357,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 2811 : IsPrecompiledFunction := true );
+    , 2811 : IsPrecompiledDerivation := true );
     
     ##
     AddCoevaluationMorphismWithGivenRange( cat,
@@ -397,7 +397,7 @@ function ( cat_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 2408 : IsPrecompiledFunction := true );
+    , 2408 : IsPrecompiledDerivation := true );
     
     ##
     AddCoimage( cat,
@@ -411,7 +411,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddCoimageProjection( cat,
@@ -426,7 +426,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 602 : IsPrecompiledFunction := true );
+    , 602 : IsPrecompiledDerivation := true );
     
     ##
     AddCoimageProjectionWithGivenCoimage( cat,
@@ -441,7 +441,7 @@ function ( cat_1, alpha_1, C_1 )
 end
 ########
         
-    , 603 : IsPrecompiledFunction := true );
+    , 603 : IsPrecompiledDerivation := true );
     
     ##
     AddCokernelColift( cat,
@@ -456,7 +456,7 @@ function ( cat_1, alpha_1, T_1, tau_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddCokernelColiftWithGivenCokernelObject( cat,
@@ -471,7 +471,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 203 : IsPrecompiledFunction := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddCokernelObject( cat,
@@ -485,7 +485,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelObjectFunctorial( cat,
@@ -501,7 +501,7 @@ function ( cat_1, alpha_1, mu_1, alphap_1 )
 end
 ########
         
-    , 606 : IsPrecompiledFunction := true );
+    , 606 : IsPrecompiledDerivation := true );
     
     ##
     AddCokernelObjectFunctorialWithGivenCokernelObjects( cat,
@@ -517,7 +517,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
 end
 ########
         
-    , 405 : IsPrecompiledFunction := true );
+    , 405 : IsPrecompiledDerivation := true );
     
     ##
     AddCokernelProjection( cat,
@@ -532,7 +532,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelProjectionWithGivenCokernelObject( cat,
@@ -547,7 +547,7 @@ function ( cat_1, alpha_1, P_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddColift( cat,
@@ -559,7 +559,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddColiftAlongEpimorphism( cat,
@@ -571,7 +571,7 @@ function ( cat_1, epsilon_1, tau_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddComponentOfMorphismFromDirectSum( cat,
@@ -586,7 +586,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismIntoDirectSum( cat,
@@ -601,7 +601,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoproduct( cat,
@@ -615,7 +615,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddCoproductFunctorial( cat,
@@ -644,7 +644,7 @@ function ( cat_1, objects_1, L_1, objectsp_1 )
 end
 ########
         
-    , 2118 : IsPrecompiledFunction := true );
+    , 2118 : IsPrecompiledDerivation := true );
     
     ##
     AddCoproductFunctorialWithGivenCoproducts( cat,
@@ -670,7 +670,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 1713 : IsPrecompiledFunction := true );
+    , 1713 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectProduct( cat,
@@ -684,7 +684,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectProductFunctorial( cat,
@@ -713,7 +713,7 @@ function ( cat_1, objects_1, L_1, objectsp_1 )
 end
 ########
         
-    , 2118 : IsPrecompiledFunction := true );
+    , 2118 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectProductFunctorialWithGivenDirectProducts( cat,
@@ -739,7 +739,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 1713 : IsPrecompiledFunction := true );
+    , 1713 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectSum( cat,
@@ -753,7 +753,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumCodiagonalDifference( cat,
@@ -788,7 +788,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1706 : IsPrecompiledFunction := true );
+    , 1706 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectSumDiagonalDifference( cat,
@@ -823,7 +823,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1706 : IsPrecompiledFunction := true );
+    , 1706 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectSumFunctorial( cat,
@@ -841,7 +841,7 @@ function ( cat_1, objects_1, L_1, objectsp_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddDirectSumFunctorialWithGivenDirectSums( cat,
@@ -855,7 +855,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumProjectionInPushout( cat,
@@ -890,7 +890,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 3814 : IsPrecompiledFunction := true );
+    , 3814 : IsPrecompiledDerivation := true );
     
     ##
     AddDistinguishedObjectOfHomomorphismStructure( cat,
@@ -902,7 +902,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnMorphisms( cat,
@@ -914,7 +914,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddDualOnMorphismsWithGivenDuals( cat,
@@ -926,7 +926,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDualOnObjects( cat,
@@ -937,7 +937,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEpimorphismFromSomeProjectiveObject( cat,
@@ -949,7 +949,7 @@ function ( cat_1, A_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEpimorphismFromSomeProjectiveObjectWithGivenSomeProjectiveObject( cat,
@@ -961,7 +961,7 @@ function ( cat_1, A_1, P_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddEvaluationForDual( cat,
@@ -988,7 +988,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 401 : IsPrecompiledFunction := true );
+    , 401 : IsPrecompiledDerivation := true );
     
     ##
     AddEvaluationForDualWithGivenTensorProduct( cat,
@@ -1009,7 +1009,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEvaluationMorphism( cat,
@@ -1043,7 +1043,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 2610 : IsPrecompiledFunction := true );
+    , 2610 : IsPrecompiledDerivation := true );
     
     ##
     AddEvaluationMorphismWithGivenSource( cat,
@@ -1077,7 +1077,7 @@ function ( cat_1, a_1, b_1, s_1 )
 end
 ########
         
-    , 2207 : IsPrecompiledFunction := true );
+    , 2207 : IsPrecompiledDerivation := true );
     
     ##
     AddFiberProduct( cat,
@@ -1109,7 +1109,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 3815 : IsPrecompiledFunction := true );
+    , 3815 : IsPrecompiledDerivation := true );
     
     ##
     AddFiberProductEmbeddingInDirectSum( cat,
@@ -1144,7 +1144,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 3814 : IsPrecompiledFunction := true );
+    , 3814 : IsPrecompiledDerivation := true );
     
     ##
     AddFiberProductFunctorial( cat,
@@ -1202,7 +1202,7 @@ function ( cat_1, morphisms_1, L_1, morphismsp_1 )
 end
 ########
         
-    , 19782 : IsPrecompiledFunction := true );
+    , 19782 : IsPrecompiledDerivation := true );
     
     ##
     AddFiberProductFunctorialWithGivenFiberProducts( cat,
@@ -1258,7 +1258,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
 end
 ########
         
-    , 12151 : IsPrecompiledFunction := true );
+    , 12151 : IsPrecompiledDerivation := true );
     
     ##
     AddHomologyObject( cat,
@@ -1272,7 +1272,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 704 : IsPrecompiledFunction := true );
+    , 704 : IsPrecompiledDerivation := true );
     
     ##
     AddHomologyObjectFunctorialWithGivenHomologyObjects( cat,
@@ -1292,7 +1292,7 @@ function ( cat_1, H_1_1, L_1, H_2_1 )
 end
 ########
         
-    , 3815 : IsPrecompiledFunction := true );
+    , 3815 : IsPrecompiledDerivation := true );
     
     ##
     AddHomomorphismStructureOnMorphisms( cat,
@@ -1308,7 +1308,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
@@ -1320,7 +1320,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnObjects( cat,
@@ -1332,7 +1332,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIdentityMorphism( cat,
@@ -1344,7 +1344,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddImageEmbedding( cat,
@@ -1359,7 +1359,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 602 : IsPrecompiledFunction := true );
+    , 602 : IsPrecompiledDerivation := true );
     
     ##
     AddImageEmbeddingWithGivenImageObject( cat,
@@ -1374,7 +1374,7 @@ function ( cat_1, alpha_1, I_1 )
 end
 ########
         
-    , 603 : IsPrecompiledFunction := true );
+    , 603 : IsPrecompiledDerivation := true );
     
     ##
     AddImageObject( cat,
@@ -1388,7 +1388,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddInitialObject( cat,
@@ -1400,7 +1400,7 @@ function ( cat_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddInitialObjectFunctorial( cat,
@@ -1416,7 +1416,7 @@ function ( cat_1 )
 end
 ########
         
-    , 303 : IsPrecompiledFunction := true );
+    , 303 : IsPrecompiledDerivation := true );
     
     ##
     AddInitialObjectFunctorialWithGivenInitialObjects( cat,
@@ -1428,7 +1428,7 @@ function ( cat_1, P_1, Pp_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectionOfCofactorOfCoproduct( cat,
@@ -1450,7 +1450,7 @@ function ( cat_1, objects_1, k_1 )
 end
 ########
         
-    , 503 : IsPrecompiledFunction := true );
+    , 503 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectionOfCofactorOfCoproductWithGivenCoproduct( cat,
@@ -1472,7 +1472,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 504 : IsPrecompiledFunction := true );
+    , 504 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectionOfCofactorOfDirectSum( cat,
@@ -1494,7 +1494,7 @@ function ( cat_1, objects_1, k_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
@@ -1514,7 +1514,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInjectionOfCofactorOfPushout( cat,
@@ -1550,7 +1550,7 @@ function ( cat_1, morphisms_1, k_1 )
 end
 ########
         
-    , 3915 : IsPrecompiledFunction := true );
+    , 3915 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectionOfCofactorOfPushoutWithGivenPushout( cat,
@@ -1586,7 +1586,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
 end
 ########
         
-    , 3916 : IsPrecompiledFunction := true );
+    , 3916 : IsPrecompiledDerivation := true );
     
     ##
     AddInjectiveColift( cat,
@@ -1598,7 +1598,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddInternalHomOnMorphisms( cat,
@@ -1614,7 +1614,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 1810 : IsPrecompiledFunction := true );
+    , 1810 : IsPrecompiledDerivation := true );
     
     ##
     AddInternalHomOnMorphismsWithGivenInternalHoms( cat,
@@ -1630,7 +1630,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
 end
 ########
         
-    , 1205 : IsPrecompiledFunction := true );
+    , 1205 : IsPrecompiledDerivation := true );
     
     ##
     AddInternalHomOnObjects( cat,
@@ -1642,7 +1642,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddInternalHomToTensorProductAdjunctionMap( cat,
@@ -1676,7 +1676,7 @@ function ( cat_1, b_1, c_1, g_1 )
 end
 ########
         
-    , 3112 : IsPrecompiledFunction := true );
+    , 3112 : IsPrecompiledDerivation := true );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
@@ -1692,7 +1692,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( cat,
@@ -1708,7 +1708,7 @@ function ( cat_1, source_1, alpha_1, range_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
@@ -1720,7 +1720,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInverseForMorphisms( cat,
@@ -1734,7 +1734,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddInverseMorphismFromCoimageToImageWithGivenObjects( cat,
@@ -1752,7 +1752,7 @@ function ( cat_1, C_1, alpha_1, I_1 )
 end
 ########
         
-    , 2214 : IsPrecompiledFunction := true );
+    , 2214 : IsPrecompiledDerivation := true );
     
     ##
     AddIsAutomorphism( cat,
@@ -1766,7 +1766,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddIsCodominating( cat,
@@ -1777,7 +1777,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsColiftable( cat,
@@ -1788,7 +1788,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsColiftableAlongEpimorphism( cat,
@@ -1799,7 +1799,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsCongruentForMorphisms( cat,
@@ -1810,7 +1810,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsDominating( cat,
@@ -1821,7 +1821,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEndomorphism( cat,
@@ -1832,7 +1832,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEpimorphism( cat,
@@ -1843,7 +1843,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEqualAsFactorobjects( cat,
@@ -1857,7 +1857,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 603 : IsPrecompiledFunction := true );
+    , 603 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEqualAsSubobjects( cat,
@@ -1871,7 +1871,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 603 : IsPrecompiledFunction := true );
+    , 603 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEqualForMorphisms( cat,
@@ -1882,7 +1882,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEqualForMorphismsOnMor( cat,
@@ -1903,7 +1903,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddIsEqualForObjects( cat,
@@ -1914,7 +1914,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsIdempotent( cat,
@@ -1927,7 +1927,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsIdenticalToIdentityMorphism( cat,
@@ -1949,7 +1949,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 403 : IsPrecompiledFunction := true );
+    , 403 : IsPrecompiledDerivation := true );
     
     ##
     AddIsIdenticalToZeroMorphism( cat,
@@ -1972,7 +1972,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 403 : IsPrecompiledFunction := true );
+    , 403 : IsPrecompiledDerivation := true );
     
     ##
     AddIsInitial( cat,
@@ -1983,7 +1983,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsInjective( cat,
@@ -1994,7 +1994,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsIsomorphism( cat,
@@ -2007,7 +2007,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftable( cat,
@@ -2018,7 +2018,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftableAlongMonomorphism( cat,
@@ -2029,7 +2029,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsMonomorphism( cat,
@@ -2040,7 +2040,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsOne( cat,
@@ -2051,7 +2051,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsProjective( cat,
@@ -2062,7 +2062,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsSplitEpimorphism( cat,
@@ -2073,7 +2073,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsSplitMonomorphism( cat,
@@ -2084,7 +2084,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsTerminal( cat,
@@ -2095,7 +2095,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddIsWellDefinedForMorphisms( cat,
@@ -2117,7 +2117,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForObjects( cat,
@@ -2135,7 +2135,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForMorphisms( cat,
@@ -2146,7 +2146,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForObjects( cat,
@@ -2157,7 +2157,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsomorphismFromCoimageToCokernelOfKernel( cat,
@@ -2174,7 +2174,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromCokernelOfDiagonalDifferenceToPushout( cat,
@@ -2210,7 +2210,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1907 : IsPrecompiledFunction := true );
+    , 1907 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromCokernelOfKernelToCoimage( cat,
@@ -2227,7 +2227,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromCoproductToDirectSum( cat,
@@ -2245,7 +2245,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromDirectProductToDirectSum( cat,
@@ -2263,7 +2263,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromDirectSumToCoproduct( cat,
@@ -2281,7 +2281,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromDirectSumToDirectProduct( cat,
@@ -2299,7 +2299,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromDualToInternalHom( cat,
@@ -2311,7 +2311,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromFiberProductToKernelOfDiagonalDifference( cat,
@@ -2347,7 +2347,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1907 : IsPrecompiledFunction := true );
+    , 1907 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromHomologyObjectToItsConstructionAsAnImageObject( cat,
@@ -2364,7 +2364,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 703 : IsPrecompiledFunction := true );
+    , 703 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromImageObjectToKernelOfCokernel( cat,
@@ -2381,7 +2381,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInitialObjectToZeroObject( cat,
@@ -2397,7 +2397,7 @@ function ( cat_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalHomToDual( cat,
@@ -2409,7 +2409,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalHomToObject( cat,
@@ -2440,7 +2440,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 2914 : IsPrecompiledFunction := true );
+    , 2914 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalHomToObjectWithGivenInternalHom( cat,
@@ -2471,7 +2471,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 2913 : IsPrecompiledFunction := true );
+    , 2913 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalHomToTensorProduct( cat,
@@ -2487,7 +2487,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromItsConstructionAsAnImageObjectToHomologyObject( cat,
@@ -2505,7 +2505,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 906 : IsPrecompiledFunction := true );
+    , 906 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromKernelOfCokernelToImageObject( cat,
@@ -2522,7 +2522,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromKernelOfDiagonalDifferenceToFiberProduct( cat,
@@ -2558,7 +2558,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1907 : IsPrecompiledFunction := true );
+    , 1907 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromObjectToInternalHom( cat,
@@ -2596,7 +2596,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 5025 : IsPrecompiledFunction := true );
+    , 5025 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromObjectToInternalHomWithGivenInternalHom( cat,
@@ -2634,7 +2634,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 5024 : IsPrecompiledFunction := true );
+    , 5024 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromPushoutToCokernelOfDiagonalDifference( cat,
@@ -2670,7 +2670,7 @@ function ( cat_1, D_1 )
 end
 ########
         
-    , 1907 : IsPrecompiledFunction := true );
+    , 1907 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromTensorProductToInternalHom( cat,
@@ -2686,7 +2686,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromTerminalObjectToZeroObject( cat,
@@ -2702,7 +2702,7 @@ function ( cat_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromZeroObjectToInitialObject( cat,
@@ -2718,7 +2718,7 @@ function ( cat_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromZeroObjectToTerminalObject( cat,
@@ -2734,7 +2734,7 @@ function ( cat_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddKernelEmbedding( cat,
@@ -2749,7 +2749,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelEmbeddingWithGivenKernelObject( cat,
@@ -2764,7 +2764,7 @@ function ( cat_1, alpha_1, P_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddKernelLift( cat,
@@ -2779,7 +2779,7 @@ function ( cat_1, alpha_1, T_1, tau_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddKernelLiftWithGivenKernelObject( cat,
@@ -2794,7 +2794,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 203 : IsPrecompiledFunction := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddKernelObject( cat,
@@ -2808,7 +2808,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelObjectFunctorial( cat,
@@ -2824,7 +2824,7 @@ function ( cat_1, alpha_1, mu_1, alphap_1 )
 end
 ########
         
-    , 606 : IsPrecompiledFunction := true );
+    , 606 : IsPrecompiledDerivation := true );
     
     ##
     AddKernelObjectFunctorialWithGivenKernelObjects( cat,
@@ -2840,7 +2840,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
 end
 ########
         
-    , 405 : IsPrecompiledFunction := true );
+    , 405 : IsPrecompiledDerivation := true );
     
     ##
     AddLambdaElimination( cat,
@@ -2873,7 +2873,7 @@ function ( cat_1, a_1, b_1, alpha_1 )
 end
 ########
         
-    , 3315 : IsPrecompiledFunction := true );
+    , 3315 : IsPrecompiledDerivation := true );
     
     ##
     AddLambdaIntroduction( cat,
@@ -2911,7 +2911,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 5125 : IsPrecompiledFunction := true );
+    , 5125 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftDistributivityExpanding( cat,
@@ -2942,7 +2942,7 @@ function ( cat_1, a_1, L_1 )
 end
 ########
         
-    , 1707 : IsPrecompiledFunction := true );
+    , 1707 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftDistributivityExpandingWithGivenObjects( cat,
@@ -2969,7 +2969,7 @@ function ( cat_1, s_1, a_1, L_1, r_1 )
 end
 ########
         
-    , 1506 : IsPrecompiledFunction := true );
+    , 1506 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftDistributivityFactoring( cat,
@@ -3000,7 +3000,7 @@ function ( cat_1, a_1, L_1 )
 end
 ########
         
-    , 1707 : IsPrecompiledFunction := true );
+    , 1707 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftDistributivityFactoringWithGivenObjects( cat,
@@ -3027,7 +3027,7 @@ function ( cat_1, s_1, a_1, L_1, r_1 )
 end
 ########
         
-    , 1506 : IsPrecompiledFunction := true );
+    , 1506 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftUnitor( cat,
@@ -3039,7 +3039,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftUnitorInverse( cat,
@@ -3051,7 +3051,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftUnitorInverseWithGivenTensorProduct( cat,
@@ -3063,7 +3063,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddLeftUnitorWithGivenTensorProduct( cat,
@@ -3075,7 +3075,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddLift( cat,
@@ -3087,7 +3087,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddLiftAlongMonomorphism( cat,
@@ -3099,7 +3099,7 @@ function ( cat_1, iota_1, tau_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddMereExistenceOfSolutionOfLinearSystemInAbCategory( cat,
@@ -3126,7 +3126,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddMonoidalPostComposeMorphism( cat,
@@ -3197,7 +3197,7 @@ function ( cat_1, a_1, b_1, c_1 )
 end
 ########
         
-    , 12155 : IsPrecompiledFunction := true );
+    , 12155 : IsPrecompiledDerivation := true );
     
     ##
     AddMonoidalPostComposeMorphismWithGivenObjects( cat,
@@ -3268,7 +3268,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
 end
 ########
         
-    , 11148 : IsPrecompiledFunction := true );
+    , 11148 : IsPrecompiledDerivation := true );
     
     ##
     AddMonoidalPreComposeMorphism( cat,
@@ -3351,7 +3351,7 @@ function ( cat_1, a_1, b_1, c_1 )
 end
 ########
         
-    , 12958 : IsPrecompiledFunction := true );
+    , 12958 : IsPrecompiledDerivation := true );
     
     ##
     AddMonoidalPreComposeMorphismWithGivenObjects( cat,
@@ -3434,7 +3434,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
 end
 ########
         
-    , 11951 : IsPrecompiledFunction := true );
+    , 11951 : IsPrecompiledDerivation := true );
     
     ##
     AddMonomorphismIntoSomeInjectiveObject( cat,
@@ -3446,7 +3446,7 @@ function ( cat_1, A_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMonomorphismIntoSomeInjectiveObjectWithGivenSomeInjectiveObject( cat,
@@ -3458,7 +3458,7 @@ function ( cat_1, A_1, I_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismBetweenDirectSums( cat,
@@ -3482,7 +3482,7 @@ function ( cat_1, source_diagram_1, mat_1, range_diagram_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismBetweenDirectSumsWithGivenDirectSums( cat,
@@ -3501,7 +3501,7 @@ function ( cat_1, S_1, source_diagram_1, mat_1, range_diagram_1, T_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismConstructor( cat,
@@ -3513,7 +3513,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismDatum( cat,
@@ -3524,7 +3524,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismFromBidual( cat,
@@ -3538,7 +3538,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 504 : IsPrecompiledFunction := true );
+    , 504 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromBidualWithGivenBidual( cat,
@@ -3552,7 +3552,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 303 : IsPrecompiledFunction := true );
+    , 303 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromCoimageToImageWithGivenObjects( cat,
@@ -3569,7 +3569,7 @@ function ( cat_1, C_1, alpha_1, I_1 )
 end
 ########
         
-    , 2011 : IsPrecompiledFunction := true );
+    , 2011 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromFiberProductToSink( cat,
@@ -3605,7 +3605,7 @@ function ( cat_1, morphisms_1 )
 end
 ########
         
-    , 4016 : IsPrecompiledFunction := true );
+    , 4016 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromFiberProductToSinkWithGivenFiberProduct( cat,
@@ -3641,7 +3641,7 @@ function ( cat_1, morphisms_1, P_1 )
 end
 ########
         
-    , 4017 : IsPrecompiledFunction := true );
+    , 4017 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromInternalHomToTensorProduct( cat,
@@ -3657,7 +3657,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 805 : IsPrecompiledFunction := true );
+    , 805 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromInternalHomToTensorProductWithGivenObjects( cat,
@@ -3673,7 +3673,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromKernelObjectToSink( cat,
@@ -3690,7 +3690,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromKernelObjectToSinkWithGivenKernelObject( cat,
@@ -3707,7 +3707,7 @@ function ( cat_1, alpha_1, P_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromSourceToCokernelObject( cat,
@@ -3724,7 +3724,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromSourceToCokernelObjectWithGivenCokernelObject( cat,
@@ -3741,7 +3741,7 @@ function ( cat_1, alpha_1, P_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromSourceToPushout( cat,
@@ -3777,7 +3777,7 @@ function ( cat_1, morphisms_1 )
 end
 ########
         
-    , 4016 : IsPrecompiledFunction := true );
+    , 4016 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromSourceToPushoutWithGivenPushout( cat,
@@ -3813,7 +3813,7 @@ function ( cat_1, morphisms_1, P_1 )
 end
 ########
         
-    , 4017 : IsPrecompiledFunction := true );
+    , 4017 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromTensorProductToInternalHom( cat,
@@ -3829,7 +3829,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 805 : IsPrecompiledFunction := true );
+    , 805 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismFromTensorProductToInternalHomWithGivenObjects( cat,
@@ -3845,7 +3845,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 302 : IsPrecompiledFunction := true );
+    , 302 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismToBidual( cat,
@@ -3857,7 +3857,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddMorphismToBidualWithGivenBidual( cat,
@@ -3869,7 +3869,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
@@ -3881,7 +3881,7 @@ function ( cat_1, r_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectConstructor( cat,
@@ -3893,7 +3893,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectDatum( cat,
@@ -3904,7 +3904,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddPostCompose( cat,
@@ -3916,7 +3916,7 @@ function ( cat_1, beta_1, alpha_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddPreCompose( cat,
@@ -3928,7 +3928,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionInFactorOfDirectProduct( cat,
@@ -3950,7 +3950,7 @@ function ( cat_1, objects_1, k_1 )
 end
 ########
         
-    , 503 : IsPrecompiledFunction := true );
+    , 503 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectionInFactorOfDirectProductWithGivenDirectProduct( cat,
@@ -3972,7 +3972,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 504 : IsPrecompiledFunction := true );
+    , 504 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectionInFactorOfDirectSum( cat,
@@ -3994,7 +3994,7 @@ function ( cat_1, objects_1, k_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
@@ -4014,7 +4014,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionInFactorOfFiberProduct( cat,
@@ -4050,7 +4050,7 @@ function ( cat_1, morphisms_1, k_1 )
 end
 ########
         
-    , 3915 : IsPrecompiledFunction := true );
+    , 3915 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectionInFactorOfFiberProductWithGivenFiberProduct( cat,
@@ -4086,7 +4086,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
 end
 ########
         
-    , 3916 : IsPrecompiledFunction := true );
+    , 3916 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectiveLift( cat,
@@ -4098,7 +4098,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddPushout( cat,
@@ -4130,7 +4130,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 3815 : IsPrecompiledFunction := true );
+    , 3815 : IsPrecompiledDerivation := true );
     
     ##
     AddPushoutFunctorial( cat,
@@ -4188,7 +4188,7 @@ function ( cat_1, morphisms_1, L_1, morphismsp_1 )
 end
 ########
         
-    , 19782 : IsPrecompiledFunction := true );
+    , 19782 : IsPrecompiledDerivation := true );
     
     ##
     AddPushoutFunctorialWithGivenPushouts( cat,
@@ -4244,7 +4244,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
 end
 ########
         
-    , 12151 : IsPrecompiledFunction := true );
+    , 12151 : IsPrecompiledDerivation := true );
     
     ##
     AddRankMorphism( cat,
@@ -4290,7 +4290,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 5929 : IsPrecompiledFunction := true );
+    , 5929 : IsPrecompiledDerivation := true );
     
     ##
     AddRightDistributivityExpanding( cat,
@@ -4321,7 +4321,7 @@ function ( cat_1, L_1, a_1 )
 end
 ########
         
-    , 1707 : IsPrecompiledFunction := true );
+    , 1707 : IsPrecompiledDerivation := true );
     
     ##
     AddRightDistributivityExpandingWithGivenObjects( cat,
@@ -4348,7 +4348,7 @@ function ( cat_1, s_1, L_1, a_1, r_1 )
 end
 ########
         
-    , 1506 : IsPrecompiledFunction := true );
+    , 1506 : IsPrecompiledDerivation := true );
     
     ##
     AddRightDistributivityFactoring( cat,
@@ -4379,7 +4379,7 @@ function ( cat_1, L_1, a_1 )
 end
 ########
         
-    , 1707 : IsPrecompiledFunction := true );
+    , 1707 : IsPrecompiledDerivation := true );
     
     ##
     AddRightDistributivityFactoringWithGivenObjects( cat,
@@ -4406,7 +4406,7 @@ function ( cat_1, s_1, L_1, a_1, r_1 )
 end
 ########
         
-    , 1506 : IsPrecompiledFunction := true );
+    , 1506 : IsPrecompiledDerivation := true );
     
     ##
     AddRightUnitor( cat,
@@ -4418,7 +4418,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddRightUnitorInverse( cat,
@@ -4430,7 +4430,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddRightUnitorInverseWithGivenTensorProduct( cat,
@@ -4442,7 +4442,7 @@ function ( cat_1, a_1, r_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddRightUnitorWithGivenTensorProduct( cat,
@@ -4454,7 +4454,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddSolveLinearSystemInAbCategory( cat,
@@ -4493,7 +4493,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 401 : IsPrecompiledFunction := true );
+    , 401 : IsPrecompiledDerivation := true );
     
     ##
     AddSomeInjectiveObject( cat,
@@ -4504,7 +4504,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeProjectiveObject( cat,
@@ -4515,7 +4515,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand( cat,
@@ -4532,7 +4532,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismFromInputRange( cat,
@@ -4547,7 +4547,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeReductionBySplitEpiSummand_MorphismToInputRange( cat,
@@ -4563,7 +4563,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSubtractionForMorphisms( cat,
@@ -4575,7 +4575,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductDualityCompatibilityMorphism( cat,
@@ -4654,7 +4654,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 15766 : IsPrecompiledFunction := true );
+    , 15766 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductDualityCompatibilityMorphismWithGivenObjects( cat,
@@ -4733,7 +4733,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 15265 : IsPrecompiledFunction := true );
+    , 15265 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductInternalHomCompatibilityMorphism( cat,
@@ -4816,7 +4816,7 @@ function ( cat_1, list_1 )
 end
 ########
         
-    , 14160 : IsPrecompiledFunction := true );
+    , 14160 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductInternalHomCompatibilityMorphismInverse( cat,
@@ -4900,7 +4900,7 @@ function ( cat_1, list_1 )
 end
 ########
         
-    , 14363 : IsPrecompiledFunction := true );
+    , 14363 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects( cat,
@@ -4984,7 +4984,7 @@ function ( cat_1, source_1, list_1, range_1 )
 end
 ########
         
-    , 13156 : IsPrecompiledFunction := true );
+    , 13156 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductInternalHomCompatibilityMorphismWithGivenObjects( cat,
@@ -5067,7 +5067,7 @@ function ( cat_1, source_1, list_1, range_1 )
 end
 ########
         
-    , 12953 : IsPrecompiledFunction := true );
+    , 12953 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductOnMorphisms( cat,
@@ -5083,7 +5083,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 301 : IsPrecompiledFunction := true );
+    , 301 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
@@ -5095,7 +5095,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnObjects( cat,
@@ -5107,7 +5107,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductToInternalHomAdjunctionMap( cat,
@@ -5147,7 +5147,7 @@ function ( cat_1, a_1, b_1, f_1 )
 end
 ########
         
-    , 4822 : IsPrecompiledFunction := true );
+    , 4822 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorUnit( cat,
@@ -5159,7 +5159,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTerminalObject( cat,
@@ -5171,7 +5171,7 @@ function ( cat_1 )
 end
 ########
         
-    , 202 : IsPrecompiledFunction := true );
+    , 202 : IsPrecompiledDerivation := true );
     
     ##
     AddTerminalObjectFunctorial( cat,
@@ -5187,7 +5187,7 @@ function ( cat_1 )
 end
 ########
         
-    , 303 : IsPrecompiledFunction := true );
+    , 303 : IsPrecompiledDerivation := true );
     
     ##
     AddTerminalObjectFunctorialWithGivenTerminalObjects( cat,
@@ -5199,7 +5199,7 @@ function ( cat_1, P_1, Pp_1 )
 end
 ########
         
-    , 102 : IsPrecompiledFunction := true );
+    , 102 : IsPrecompiledDerivation := true );
     
     ##
     AddTraceMap( cat,
@@ -5245,7 +5245,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 5828 : IsPrecompiledFunction := true );
+    , 5828 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromCoproduct( cat,
@@ -5262,7 +5262,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
 end
 ########
         
-    , 503 : IsPrecompiledFunction := true );
+    , 503 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromCoproductWithGivenCoproduct( cat,
@@ -5279,7 +5279,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 504 : IsPrecompiledFunction := true );
+    , 504 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromDirectSum( cat,
@@ -5296,7 +5296,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
@@ -5310,7 +5310,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromImage( cat,
@@ -5326,7 +5326,7 @@ function ( cat_1, alpha_1, tau_1 )
 end
 ########
         
-    , 704 : IsPrecompiledFunction := true );
+    , 704 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromImageWithGivenImageObject( cat,
@@ -5342,7 +5342,7 @@ function ( cat_1, alpha_1, tau_1, I_1 )
 end
 ########
         
-    , 705 : IsPrecompiledFunction := true );
+    , 705 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromInitialObject( cat,
@@ -5357,7 +5357,7 @@ function ( cat_1, T_1 )
 end
 ########
         
-    , 303 : IsPrecompiledFunction := true );
+    , 303 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromInitialObjectWithGivenInitialObject( cat,
@@ -5369,7 +5369,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromPushout( cat,
@@ -5405,7 +5405,7 @@ function ( cat_1, morphisms_1, T_1, tau_1 )
 end
 ########
         
-    , 4117 : IsPrecompiledFunction := true );
+    , 4117 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromPushoutWithGivenPushout( cat,
@@ -5441,7 +5441,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 4118 : IsPrecompiledFunction := true );
+    , 4118 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromZeroObject( cat,
@@ -5456,7 +5456,7 @@ function ( cat_1, T_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
@@ -5468,7 +5468,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoCoimage( cat,
@@ -5484,7 +5484,7 @@ function ( cat_1, alpha_1, tau_1 )
 end
 ########
         
-    , 704 : IsPrecompiledFunction := true );
+    , 704 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoCoimageWithGivenCoimage( cat,
@@ -5500,7 +5500,7 @@ function ( cat_1, alpha_1, tau_1, C_1 )
 end
 ########
         
-    , 705 : IsPrecompiledFunction := true );
+    , 705 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoDirectProduct( cat,
@@ -5517,7 +5517,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
 end
 ########
         
-    , 503 : IsPrecompiledFunction := true );
+    , 503 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoDirectProductWithGivenDirectProduct( cat,
@@ -5534,7 +5534,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 504 : IsPrecompiledFunction := true );
+    , 504 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoDirectSum( cat,
@@ -5551,7 +5551,7 @@ function ( cat_1, objects_1, T_1, tau_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
@@ -5565,7 +5565,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoFiberProduct( cat,
@@ -5601,7 +5601,7 @@ function ( cat_1, morphisms_1, T_1, tau_1 )
 end
 ########
         
-    , 4117 : IsPrecompiledFunction := true );
+    , 4117 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoFiberProductWithGivenFiberProduct( cat,
@@ -5637,7 +5637,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 4118 : IsPrecompiledFunction := true );
+    , 4118 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoTerminalObject( cat,
@@ -5652,7 +5652,7 @@ function ( cat_1, T_1 )
 end
 ########
         
-    , 303 : IsPrecompiledFunction := true );
+    , 303 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoTerminalObjectWithGivenTerminalObject( cat,
@@ -5664,7 +5664,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoZeroObject( cat,
@@ -5679,7 +5679,7 @@ function ( cat_1, T_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
@@ -5691,7 +5691,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalPropertyOfDual( cat,
@@ -5730,7 +5730,7 @@ function ( cat_1, t_1, a_1, alpha_1 )
 end
 ########
         
-    , 5124 : IsPrecompiledFunction := true );
+    , 5124 : IsPrecompiledDerivation := true );
     
     ##
     AddZeroMorphism( cat,
@@ -5742,7 +5742,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObject( cat,
@@ -5754,7 +5754,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObjectFunctorial( cat,
@@ -5770,7 +5770,7 @@ function ( cat_1 )
 end
 ########
         
-    , 201 : IsPrecompiledFunction := true );
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddZeroObjectFunctorialWithGivenZeroObjects( cat,
@@ -5782,7 +5782,7 @@ function ( cat_1, P_1, Pp_1 )
 end
 ########
         
-    , 101 : IsPrecompiledFunction := true );
+    , 101 : IsPrecompiledDerivation := true );
     
 end );
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -19,7 +19,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddAdditiveInverseForMorphisms( cat,
@@ -34,7 +34,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBasisOfExternalHom( cat,
@@ -66,7 +66,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddBraidingInverseWithGivenTensorProducts( cat,
@@ -89,7 +89,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnMorphismsWithGivenCoDuals( cat,
@@ -102,7 +102,7 @@ function ( cat_1, s_1, alpha_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoDualOnObjects( cat,
@@ -114,7 +114,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedCoevaluationForCoDualWithGivenTensorProduct( cat,
@@ -141,7 +141,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoclosedEvaluationForCoDualWithGivenTensorProduct( cat,
@@ -168,7 +168,7 @@ function ( cat_1, s_1, a_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
@@ -179,7 +179,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelObject( cat,
@@ -194,7 +194,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddCokernelProjection( cat,
@@ -215,7 +215,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddColift( cat,
@@ -231,7 +231,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismFromDirectSum( cat,
@@ -252,7 +252,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddComponentOfMorphismIntoDirectSum( cat,
@@ -273,7 +273,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSum( cat,
@@ -288,7 +288,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDirectSumFunctorialWithGivenDirectSums( cat,
@@ -305,7 +305,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddDistinguishedObjectOfHomomorphismStructure( cat,
@@ -317,7 +317,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddEpimorphismFromSomeProjectiveObject( cat,
@@ -334,7 +334,7 @@ function ( cat_1, A_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
@@ -346,7 +346,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddHomomorphismStructureOnObjects( cat,
@@ -358,7 +358,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIdentityMorphism( cat,
@@ -374,7 +374,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
@@ -400,7 +400,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
@@ -417,7 +417,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
@@ -435,7 +435,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsColiftable( cat,
@@ -446,7 +446,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsCongruentForMorphisms( cat,
@@ -457,7 +457,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEpimorphism( cat,
@@ -470,7 +470,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsEqualForObjects( cat,
@@ -481,7 +481,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsInjective( cat,
@@ -492,7 +492,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsIsomorphism( cat,
@@ -506,7 +506,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsLiftable( cat,
@@ -517,7 +517,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsMonomorphism( cat,
@@ -530,7 +530,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsProjective( cat,
@@ -541,7 +541,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,
@@ -565,7 +565,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsWellDefinedForObjects( cat,
@@ -585,7 +585,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForMorphisms( cat,
@@ -596,7 +596,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddIsZeroForObjects( cat,
@@ -607,7 +607,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelEmbedding( cat,
@@ -628,7 +628,7 @@ function ( cat_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddKernelObject( cat,
@@ -643,7 +643,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddLift( cat,
@@ -659,7 +659,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMonomorphismIntoSomeInjectiveObject( cat,
@@ -676,7 +676,7 @@ function ( cat_1, A_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismBetweenDirectSumsWithGivenDirectSums( cat,
@@ -699,7 +699,7 @@ function ( cat_1, S_1, source_diagram_1, mat_1, range_diagram_1, T_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismConstructor( cat,
@@ -711,7 +711,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismDatum( cat,
@@ -722,7 +722,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMorphismFromCoBidualWithGivenCoBidual( cat,
@@ -738,7 +738,7 @@ function ( cat_1, a_1, s_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddMultiplyWithElementOfCommutativeRingForMorphisms( cat,
@@ -753,7 +753,7 @@ function ( cat_1, r_1, a_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectConstructor( cat,
@@ -765,7 +765,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddObjectDatum( cat,
@@ -776,7 +776,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddPostCompose( cat,
@@ -792,7 +792,7 @@ function ( cat_1, beta_1, alpha_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
@@ -818,7 +818,7 @@ function ( cat_1, objects_1, k_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeInjectiveObject( cat,
@@ -830,7 +830,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddSomeProjectiveObject( cat,
@@ -842,7 +842,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
@@ -855,7 +855,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorProductOnObjects( cat,
@@ -868,7 +868,7 @@ function ( cat_1, arg2_1, arg3_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddTensorUnit( cat,
@@ -881,7 +881,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
@@ -899,7 +899,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
@@ -915,7 +915,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
@@ -933,7 +933,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
@@ -949,7 +949,7 @@ function ( cat_1, T_1, P_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroMorphism( cat,
@@ -966,7 +966,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
     ##
     AddZeroObject( cat,
@@ -979,7 +979,7 @@ function ( cat_1 )
 end
 ########
         
-    , 100 : IsPrecompiledFunction := true );
+    , 100 );
     
 end );
 


### PR DESCRIPTION
* Respect "only_primitive_operations" for manually added functions in WrapperCategory
* Fix typo in the documentation of InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects
* Better distinguish between precompiled primitive operations and precompiled derivations