### PR TITLE
Various fixes and improvements

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.12-08",
+Version := "2021.12-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -940,8 +940,8 @@ InstallGlobalFunction( DerivationsOfMethodByCategory,
   
   function( category, name )
     local string, weight_list, current_weight, current_derivation,
-          possible_derivations, category_filter, used_ops_with_multiples, i,
-          currently_installed_funcs;
+          currently_installed_funcs, to_delete, used_ops_with_multiples,
+          possible_derivations, category_filter, i;
     
     if IsFunction( name ) then
         string := NameFunction( name );
@@ -968,47 +968,75 @@ InstallGlobalFunction( DerivationsOfMethodByCategory,
         Print( Name( category ), " can already compute ", string, " with weight " , String( current_weight ), ".\n" );
         
         if current_derivation = fail then
+            
             if IsBound( category!.primitive_operations.( string ) ) and category!.primitive_operations.( string ) = true then
-                Print( "It was given as a primitive operation.\n\n" );
+                
+                Print( "It was given as a primitive operation.\n" );
+                
             else
-                Print( "It was installed as a final or precompiled derivation.\n\n" );
+                
+                Print( "It was installed as a final or precompiled derivation.\n" );
+                
             fi;
+            
+            currently_installed_funcs := category!.added_functions.( string );
+            
+            # delete overwritten funcs
+            to_delete := [ ];
+            
+            for i in [ 1 .. Length( currently_installed_funcs ) ] do
+                
+                if ForAny( [ (i+1) .. Length( currently_installed_funcs ) ], j -> currently_installed_funcs[i][2] = currently_installed_funcs[j][2] ) then
+                    
+                    Add( to_delete, i );
+                    
+                fi;
+                
+            od;
+            
+            currently_installed_funcs := currently_installed_funcs{Difference( [ 1 .. Length( currently_installed_funcs ) ], to_delete )};
+            
         else
+            
             Print( "It was derived by ", DerivationName( current_derivation ), " using \n" );
+            
             used_ops_with_multiples := UsedOperationsWithMultiples( current_derivation );
+            
             for i in used_ops_with_multiples do
                 
                 Print( "* ", i[ 1 ], " (", i[ 2 ], "x)" );
                 Print( " installed with weight ", String( CurrentOperationWeight( weight_list, i[ 1 ] ) ) );
                 Print( "\n" );
-              
+                
             od;
             
             currently_installed_funcs := DerivationFunctionsWithExtraFilters( current_derivation );
             
-            Print( "\nThe following function" );
-            
-            if Length( currently_installed_funcs ) > 1 then
-                Print( "s were" );
-            else
-                Print( " was" );
-            fi;
-            
-            Print( " installed for this operation:\n\n" );
-            
-            for i in currently_installed_funcs do
-                
-                Print( "Filters: " );
-                Print( String( i[ 2 ] ) );
-                Print( "\n\n" );
-                Display( i[ 1 ] );
-                Print( "\n" );
-                
-            od;
-            
-            Print( "#######\n\n" );
-            
         fi;
+        
+        Print( "\nThe following function" );
+        
+        if Length( currently_installed_funcs ) > 1 then
+            Print( "s were" );
+        else
+            Print( " was" );
+        fi;
+        
+        Print( " installed for this operation:\n\n" );
+        
+        for i in currently_installed_funcs do
+            
+            Print( "Filters: " );
+            Print( String( i[ 2 ] ) );
+            Print( "\n\n" );
+            Display( i[ 1 ] );
+            Print( "\n" );
+            Print( "Source: ", FilenameFunc( i[ 1 ] ), ":", StartlineFunc( i[ 1 ] ), "\n" );
+            Print( "\n" );
+            
+        od;
+        
+        Print( "#######\n\n" );
         
     else
         

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2021.12-05",
+Version := "2021.12-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/EXPR_CASE.g
+++ b/CompilerForCAP/examples/EXPR_CASE.g
@@ -91,7 +91,9 @@ coded_func2();
 # we have to work hard to not write semicolons so AutoDoc
 # does not begin a new statement
 func3 := EvalString( ReplacedString( """function( x )
-  local inner_func@
+  local my_func, inner_func@
+    
+    my_func := MY_ID_FUNC( x -> x )@
     
     inner_func := function( )
       local y@
@@ -103,17 +105,21 @@ func3 := EvalString( ReplacedString( """function( x )
         fi@
     end@
     
-    return MY_ID_FUNC( inner_func( ) )@
+    return my_func( inner_func( ) )@
     
 end""", "@", ";" ) );;
 
-compiled_func3 := CapJitCompiledFunction( func3, [ true ] );;
+compiled_func3 := CapJitCompiledFunction( func3, [ ] );;
 Display( compiled_func3 );
 #! function ( x_1 )
+#!     local deduped_1_1;
+#!     deduped_1_1 := MY_ID_FUNC( function ( x_2 )
+#!             return x_2;
+#!         end );
 #!     if x_1 then
-#!         return MY_ID_FUNC( 1 );
+#!         return deduped_1_1( 1 );
 #!     else
-#!         return MY_ID_FUNC( 2 );
+#!         return deduped_1_1( 2 );
 #!     fi;
 #!     return;
 #! end

--- a/CompilerForCAP/examples/Logic.g
+++ b/CompilerForCAP/examples/Logic.g
@@ -41,4 +41,14 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #!     return [ 1, 2, 3, 4 ];
 #! end
 
+func := function ( my_func )
+  return CallFuncList( my_func, [ 1, 2 ] ); end;;
+
+tree := ENHANCED_SYNTAX_TREE( func );;
+tree := CapJitAppliedLogic( tree, [ ] );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+#! function ( my_func_1 )
+#!     return my_func_1( 1, 2 );
+#! end
+
 #! @EndExample

--- a/CompilerForCAP/examples/Logic.g
+++ b/CompilerForCAP/examples/Logic.g
@@ -21,4 +21,24 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #!             end( 2 ) ];
 #! end
 
+func := function ( )
+  return Concatenation( [ 1, 2 ], [ 3, 4 ] ); end;;
+
+tree := ENHANCED_SYNTAX_TREE( func );;
+tree := CapJitAppliedLogic( tree, [ ] );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+#! function (  )
+#!     return [ 1, 2, 3, 4 ];
+#! end
+
+func := function ( )
+  return Concatenation( [ [ 1, 2 ], [ 3, 4 ] ] ); end;;
+
+tree := ENHANCED_SYNTAX_TREE( func );;
+tree := CapJitAppliedLogic( tree, [ ] );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+#! function (  )
+#!     return [ 1, 2, 3, 4 ];
+#! end
+
 #! @EndExample

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -78,17 +78,27 @@ CapJitAddLogicFunction( function ( tree, jit_args )
             
             args := tree.args;
             
-            if ForAll( args, a -> a.type = "EXPR_LIST" ) then
+            # Concatenation with a single argument has different semantics
+            if args.length = 1 and args.1.type = "EXPR_LIST" and ForAll( args.1.list, a -> a.type = "EXPR_LIST" ) then
                 
                 return rec(
                     type := "EXPR_LIST",
-                    list := ConcatenationForSyntaxTreeLists( List( args, a -> a.list ) ),
+                    list := ConcatenationForSyntaxTreeLists( AsListMut( List( args.1.list, a -> a.list ) ) ),
                 );
                 
             fi;
-
-        fi;
             
+            if args.length > 1 and ForAll( args, a -> a.type = "EXPR_LIST" ) then
+                
+                return rec(
+                    type := "EXPR_LIST",
+                    list := ConcatenationForSyntaxTreeLists( AsListMut( List( args, a -> a.list ) ) ),
+                );
+                
+            fi;
+            
+        fi;
+        
         return tree;
         
     end;

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -291,7 +291,7 @@ CapJitAddLogicFunction( function ( tree, jit_args )
                     condition := branch.condition,
                     value := rec(
                         type := "EXPR_FUNCCALL",
-                        funcref := tree.funcref,
+                        funcref := CapJitCopyWithNewFunctionIDs( tree.funcref ),
                         args := AsSyntaxTreeList( [
                             branch.value
                         ] ),

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -546,11 +546,14 @@ end );
 InstallGlobalFunction( ConcatenationForSyntaxTreeLists, function ( arg... )
   local tree, index, i, j;
     
-    if Length( arg ) = 1 and IsList( arg[1] ) then
+    if Length( arg ) = 1 then
         
         arg := arg[1];
         
     fi;
+    
+    Assert( 0, IsList( arg ) );
+    Assert( 0, ForAll( arg, a -> a.type = "SYNTAX_TREE_LIST" ) );
     
     tree := rec(
         type := "SYNTAX_TREE_LIST",

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.12-07",
+Version := "2021.12-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -811,6 +811,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         if homomorphism_structure_derivation_case <> "none" then
             
             ##
+            # this is expensive, so we assume a weight of 400 which will be used below
             InstallMethodWithCacheFromObject( HomomorphismStructureOnObjectsForAdelmanCategoryGeneralizedEmbedding, 
                                               [ IsAdelmanCategoryObject and ObjectFilter( category ), IsAdelmanCategoryObject and ObjectFilter( category ) ],
                 function( object_A, object_B )
@@ -872,7 +873,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 
                 return UnderlyingHonestObject( Source( HomomorphismStructureOnObjectsForAdelmanCategoryGeneralizedEmbedding( object_A, object_B ) ) );
                 
-            end );
+            end, 100 + 400 );
             
             ##
             AddHomomorphismStructureOnMorphisms( category,
@@ -894,7 +895,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 
                 return HonestRepresentative( composition );
                 
-            end );
+            end, 100 + 2 * 400 );
             
              ##
             AddDistinguishedObjectOfHomomorphismStructure( category,
@@ -929,7 +930,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 
                 return PreCompose( LiftAlongMonomorphism( arrow, interpret ), reversed );
                 
-            end );
+            end, 100 + 400 );
             
             ##
             AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( category,
@@ -952,7 +953,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 
                 return AdelmanCategoryMorphism( object_A, interpret, object_B );
                 
-            end );
+            end, 100 + 400 );
             
         fi;
         

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -43,6 +43,12 @@ InstallMethod( AdelmanCategory,
     
     adelman_category!.category_as_first_argument := true;
     
+    adelman_category!.compiler_hints := rec(
+        category_attribute_names := [
+            "UnderlyingCategory",
+        ],
+    );
+    
     SetFilterObj( adelman_category, IsAdelmanCategory );
     
     ## this is the purpose of the Adelman category
@@ -80,15 +86,22 @@ InstallMethod( AdelmanCategoryObject,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
 
   function( relation_morphism, corelation_morphism )
-    local category;
+    
+    return AdelmanCategoryObject( AdelmanCategory( CapCategory( relation_morphism ) ), relation_morphism, corelation_morphism );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( AdelmanCategoryObject,
+                                     [ IsAdelmanCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ],
+                                     
+  function( category, relation_morphism, corelation_morphism )
     
     if not IsEqualForObjects( Range( relation_morphism ), Source( corelation_morphism ) ) then
     
         Error ( "the range of the relation morphism has to be equal to the source of the corelation morphism" );
     
     fi;
-    
-    category := AdelmanCategory( CapCategory( relation_morphism ) );
     
     return ObjectifyObjectForCAPWithAttributes( rec( ), category,
                                                 RelationMorphism, relation_morphism,
@@ -116,7 +129,17 @@ InstallMethod( AdelmanCategoryMorphism,
                [ IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ],
                
   function( source, morphism_datum, range )
-    local adelman_category_morphism, category;
+    
+    return AdelmanCategoryMorphism( CapCategory( source ), source, morphism_datum, range );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( AdelmanCategoryMorphism,
+                                     [ IsAdelmanCategory, IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ],
+                                     
+  function( category, source, morphism_datum, range )
+    local adelman_category_morphism;
     
     if not IsIdenticalObj( CapCategory( morphism_datum ), UnderlyingCategory( CapCategory( source ) ) ) then
         
@@ -136,16 +159,12 @@ InstallMethod( AdelmanCategoryMorphism,
         
     fi;
     
-    category :=  CapCategory( source );
-    
     adelman_category_morphism := ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes(
                              rec( ), category,
                              source,
                              range,
                              MorphismDatum, morphism_datum
     );
-    
-    Add( category, adelman_category_morphism );
     
     return adelman_category_morphism;
     
@@ -215,6 +234,16 @@ InstallMethod( MereExistenceOfWitnessPairForBeingCongruentToZero,
                [ IsAdelmanCategoryMorphism ],
                
   function( morphism )
+    
+    return MereExistenceOfWitnessPairForBeingCongruentToZero( CapCategory( morphism ), morphism );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( MereExistenceOfWitnessPairForBeingCongruentToZero,
+                                     [ IsAdelmanCategory, IsAdelmanCategoryMorphism ],
+                                     
+  function( cat, morphism )
     local datum, left_coeffs, right_coeffs;
     
     datum := MorphismDatum( morphism );
@@ -333,7 +362,15 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddIsCongruentForMorphisms( category,
       function( cat, morphism_1, morphism_2 )
         
-        return MereExistenceOfWitnessPairForBeingCongruentToZero( SubtractionForMorphisms( morphism_1, morphism_2 ) );
+        return MereExistenceOfWitnessPairForBeingCongruentToZero( cat, SubtractionForMorphisms( cat, morphism_1, morphism_2 ) );
+        
+    end );
+    
+    ##
+    AddIsZeroForMorphisms( category,
+      function( cat, morphism )
+        
+        return MereExistenceOfWitnessPairForBeingCongruentToZero( cat, morphism );
         
     end );
     
@@ -343,7 +380,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       
       function( cat, object )
         
-        return AdelmanCategoryMorphism( object, IdentityMorphism( Range( RelationMorphism( object ) ) ), object );
+        return AdelmanCategoryMorphism( cat, object, IdentityMorphism( Range( RelationMorphism( object ) ) ), object );
         
     end );
     
@@ -355,7 +392,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         
         composition := PreCompose( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) );
         
-        return AdelmanCategoryMorphism( Source( morphism_1 ), composition, Range( morphism_2 ) );
+        return AdelmanCategoryMorphism( cat, Source( morphism_1 ), composition, Range( morphism_2 ) );
         
     end );
 
@@ -364,7 +401,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, morphism_1, morphism_2 )
         local subtraction;
         
-        subtraction := AdelmanCategoryMorphism(
+        subtraction := AdelmanCategoryMorphism( cat,
                             Source( morphism_1 ),
                             SubtractionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
                             Range( morphism_1 )
@@ -379,7 +416,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, morphism_1, morphism_2 )
         local addition;
         
-        addition := AdelmanCategoryMorphism(
+        addition := AdelmanCategoryMorphism( cat,
                             Source( morphism_1 ),
                             AdditionForMorphisms( MorphismDatum( morphism_1 ), MorphismDatum( morphism_2 ) ),
                             Range( morphism_1 )
@@ -394,7 +431,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, morphism )
         local additive_inverse;
         
-        additive_inverse := AdelmanCategoryMorphism(
+        additive_inverse := AdelmanCategoryMorphism( cat,
                               Source( morphism ),
                               AdditiveInverseForMorphisms( MorphismDatum( morphism ) ),
                               Range( morphism )
@@ -409,7 +446,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, source, range )
         local zero_morphism;
         
-        zero_morphism := AdelmanCategoryMorphism(
+        zero_morphism := AdelmanCategoryMorphism( cat,
                            source,
                            ZeroMorphism( Range( RelationMorphism( source ) ), Range( RelationMorphism( range ) ) ),
                            range
@@ -432,7 +469,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, sink, zero_object )
         local universal_morphism;
         
-        universal_morphism := AdelmanCategoryMorphism(
+        universal_morphism := AdelmanCategoryMorphism( cat,
                                 sink,
                                 UniversalMorphismIntoZeroObject( Range( RelationMorphism( sink ) ) ),
                                 zero_object
@@ -447,7 +484,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
       function( cat, source, zero_object )
         local universal_morphism;
         
-        universal_morphism := AdelmanCategoryMorphism(
+        universal_morphism := AdelmanCategoryMorphism( cat,
                                 zero_object,
                                 UniversalMorphismFromZeroObject( Range( RelationMorphism( source ) ) ),
                                 source
@@ -461,7 +498,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddDirectSum( category,
       function( cat, object_list )
         
-        return AdelmanCategoryObject( DirectSumFunctorial( List( object_list, RelationMorphism ) ),
+        return AdelmanCategoryObject( cat, DirectSumFunctorial( List( object_list, RelationMorphism ) ),
                                       DirectSumFunctorial( List( object_list, CorelationMorphism ) ) );
         
     end );
@@ -470,7 +507,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddDirectSumFunctorialWithGivenDirectSums( category,
       function( cat, direct_sum_source, source_diagram, diagram, range_diagram, direct_sum_range )
         
-        return AdelmanCategoryMorphism( direct_sum_source,
+        return AdelmanCategoryMorphism( cat, direct_sum_source,
                                         DirectSumFunctorial( List( diagram, MorphismDatum ) ),
                                         direct_sum_range );
         
@@ -480,7 +517,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddProjectionInFactorOfDirectSumWithGivenDirectSum( category,
       function( cat, object_list, projection_number, direct_sum_object )
         
-        return AdelmanCategoryMorphism( direct_sum_object,
+        return AdelmanCategoryMorphism( cat, direct_sum_object,
                                         ProjectionInFactorOfDirectSum( List( object_list, obj -> Range( RelationMorphism( obj ) ) ), projection_number ),
                                         object_list[projection_number]
                                       );
@@ -491,7 +528,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddUniversalMorphismIntoDirectSumWithGivenDirectSum( category,
       function( cat, diagram, test_object, source, direct_sum_object )
         
-        return AdelmanCategoryMorphism( Source( source[1] ),
+        return AdelmanCategoryMorphism( cat, Source( source[1] ),
                                         UniversalMorphismIntoDirectSum( List( diagram, obj -> Range( RelationMorphism( obj ) ) ),
                                                                         List( source, mor -> MorphismDatum( mor ) ) ),
                                         direct_sum_object
@@ -503,7 +540,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( category,
       function( cat, object_list, injection_number, direct_sum_object )
         
-        return AdelmanCategoryMorphism( object_list[injection_number],
+        return AdelmanCategoryMorphism( cat, object_list[injection_number],
                                         InjectionOfCofactorOfDirectSum( List( object_list, obj -> Range( RelationMorphism( obj ) ) ), injection_number ),
                                         direct_sum_object
                                       );
@@ -514,7 +551,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
     AddUniversalMorphismFromDirectSumWithGivenDirectSum( category,
       function( cat, diagram, test_object, sink, direct_sum_object )
         
-        return AdelmanCategoryMorphism( direct_sum_object,
+        return AdelmanCategoryMorphism( cat, direct_sum_object,
                                         UniversalMorphismFromDirectSum( List( diagram, obj -> Range( RelationMorphism( obj ) ) ),
                                                                         List( sink, mor -> MorphismDatum( mor ) ) ),
                                         Range( sink[1] )
@@ -547,12 +584,12 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         alpha := MorphismDatum( morphism );
         
         cokernel_object :=
-            AdelmanCategoryObject(
+            AdelmanCategoryObject( cat,
                 MorphismBetweenDirectSums( [ [ b, ZeroMorphism( Bp, App ) ], [ alpha, ap ] ] ),
                 DirectSumFunctorial( [ bp, IdentityMorphism( App ) ] )
             );
         
-        return AdelmanCategoryMorphism( 
+        return AdelmanCategoryMorphism( cat,
             Range( morphism ),
             InjectionOfCofactorOfDirectSum( [ B, App ], 1 ),
             cokernel_object
@@ -573,7 +610,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 [ MorphismDatum( test_morphism ), -witness_pair[2] ]
             );
         
-        return AdelmanCategoryMorphism( cokernel_object,
+        return AdelmanCategoryMorphism( cat, cokernel_object,
                                         datum,
                                         Range( test_morphism ) );
         
@@ -619,7 +656,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         
         sigma1 := ComponentOfMorphismFromDirectSum( sigma12, [ App, B ], 1 );
         
-        return AdelmanCategoryMorphism( range_alpha,
+        return AdelmanCategoryMorphism( cat, range_alpha,
                                         PreCompose( sigma8, datum_tau ) + PreCompose( [ b2, sigma6, sigma1 ] ) + PreCompose( [ b2, sigma5, sigma2 ] ),
                                         Range( tau ) );
         
@@ -650,12 +687,12 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         A := Source( alpha );
         
         kernel_object :=
-            AdelmanCategoryObject(
+            AdelmanCategoryObject( cat,
                 DirectSumFunctorial( [ a, IdentityMorphism( Bp ) ] ),
                 MorphismBetweenDirectSums( [ [ ap, alpha ], [ ZeroMorphism( Bp, App ), b ] ] )
             );
         
-        return AdelmanCategoryMorphism( 
+        return AdelmanCategoryMorphism( cat,
             kernel_object,
             ProjectionInFactorOfDirectSum( [ A, Bp ], 1 ),
             Source( morphism )
@@ -676,7 +713,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 [ MorphismDatum( test_morphism ), -witness_pair[1] ]
             );
         
-        return AdelmanCategoryMorphism( Source( test_morphism ),
+        return AdelmanCategoryMorphism( cat, Source( test_morphism ),
                                         datum,
                                         kernel_object );
         
@@ -691,9 +728,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         
         A := Source( rel );
         
-        proj := AdelmanCategoryObject( MorphismFromZeroObject( A ), rel );
+        proj := AdelmanCategoryObject( cat, MorphismFromZeroObject( A ), rel );
         
-        return AdelmanCategoryMorphism(
+        return AdelmanCategoryMorphism( cat,
             proj,
             IdentityMorphism( A ),
             obj
@@ -710,9 +747,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
         
         B := Range( rel );
         
-        inj := AdelmanCategoryObject( rel, MorphismIntoZeroObject( B ) );
+        inj := AdelmanCategoryObject( cat, rel, MorphismIntoZeroObject( B ) );
         
-        return AdelmanCategoryMorphism(
+        return AdelmanCategoryMorphism( cat,
             obj,
             IdentityMorphism( B ),
             inj
@@ -724,7 +761,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                f -> CanCompute( underlying_category, f ) ) then
         
         AddMultiplyWithElementOfCommutativeRingForMorphisms( category,
-          { cat, r, alpha } -> AdelmanCategoryMorphism(
+          { cat, r, alpha } -> AdelmanCategoryMorphism( cat,
                               Source( alpha ),
                               MultiplyWithElementOfCommutativeRingForMorphisms( r, MorphismDatum( alpha ) ),
                               Range( alpha )
@@ -812,10 +849,10 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
             
             ##
             # this is expensive, so we assume a weight of 400 which will be used below
-            InstallMethodWithCacheFromObject( HomomorphismStructureOnObjectsForAdelmanCategoryGeneralizedEmbedding, 
+            InstallMethodWithCacheFromObject( HomomorphismStructureOnObjectsForAdelmanCategoryGeneralizedEmbedding,
                                               [ IsAdelmanCategoryObject and ObjectFilter( category ), IsAdelmanCategoryObject and ObjectFilter( category ) ],
                 function( object_A, object_B )
-                  local A, Ap, App, B, Bp, Bpp, a, b, ap, bp, 
+                  local A, Ap, App, B, Bp, Bpp, a, b, ap, bp,
                         H_A_b, H_ap_B, H_A_bp, H_a_B, H_ap_Bpp, H_Ap_b, rel, corel, ker, coker, im;
                   
                   a := RelationMorphism( object_A );
@@ -951,7 +988,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY,
                 
                 interpret := interpret_morphism_from_distinguished_object_to_homomorphism_structure_as_homomorphism( A, B, lift );
                 
-                return AdelmanCategoryMorphism( object_A, interpret, object_B );
+                return AdelmanCategoryMorphism( cat, object_A, interpret, object_B );
                 
             end, 100 + 400 );
             

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
@@ -48,7 +48,7 @@ InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
             )
         );
         
-        homalg_matrix := HomalgMatrix( matrix_entries, RankOfObject( source ), RankOfObject( range ), UnderlyingRing( cat ) );
+        homalg_matrix := HomalgMatrixListList( matrix_entries, RankOfObject( source ), RankOfObject( range ), UnderlyingRing( cat ) );
         
         return CategoryOfRowsMorphism( cat, source, homalg_matrix, range );
         
@@ -154,6 +154,27 @@ InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
         SetIsAbelianCategory( wrapper, true );
         
     fi;
+
+    # some manually precompiled functions
+    
+    ##
+    AddZeroMorphism( wrapper,
+      function( cat, source, range )
+        
+        return CategoryOfRowsMorphism( cat, source, HomalgMatrixListList( NullMatImmutable( RankOfObject( source ), RankOfObject( range ) ), RankOfObject( source ), RankOfObject( range ), homalg_ring ), range );
+        
+    end );
+    
+    ##
+    AddDirectSum( wrapper,
+      function( cat, object_list )
+        local rank;
+        
+        rank := Sum( List( object_list, object -> RankOfObject( object ) ) );
+        
+        return CategoryOfRowsObject( cat, rank );
+        
+    end );
     
     Finalize( wrapper );
     

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -104,7 +104,7 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
                 end );
         end );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, arg2_1, arg3_1, UnderlyingMatrix, HomalgMatrix( List( deduped_8_1, function ( logic_new_func_x_2 )
+           ), cat_1, arg2_1, arg3_1, UnderlyingMatrix, HomalgMatrixListList( List( deduped_8_1, function ( logic_new_func_x_2 )
                 local hoisted_1_2;
                 hoisted_1_2 := hoisted_5_1[logic_new_func_x_2];
                 return List( hoisted_4_1, function ( logic_new_func_x_3 )


### PR DESCRIPTION
* `DerivationsOfMethodByCategory` can now print primitively added functions and prints the path to the source file (including the line number) in the output (for both primitively added functions and derivations).
* Should fix https://github.com/homalg-project/FinSetsForCAP/issues/81.
* Fixes a performance regression in AdelmanCategory introduced by the new derivations of `Is(Co)Dominating` (94cb007).


See commit messages for further changes.