### PR TITLE
Fix the method records of the compatibility morphisms

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2021.12-10",
+Version := "2021.12-11",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesMethodRecord.gi
@@ -196,7 +196,7 @@ TensorProductInternalHomCompatibilityMorphism := rec(
   with_given_object_position := "both",
   return_type := "morphism",
   dual_operation := "InternalCoHomTensorProductCompatibilityMorphism",
-  dual_preprocessor_func := { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ] ],
+  dual_preprocessor_func := { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ] ],
   dual_arguments_reversed := false,
 ),
 
@@ -208,7 +208,7 @@ TensorProductInternalHomCompatibilityMorphismWithGivenObjects := rec(
   return_type := "morphism",
   dual_operation := "InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects",
   dual_preprocessor_func :=
-    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ], Opposite( s ) ],
+    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ], Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 

--- a/MonoidalCategories/gap/CoclosedMonoidalCategories.autogen.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategories.autogen.gd
@@ -659,7 +659,7 @@ DeclareOperation( "AddTensorProductToInternalCoHomAdjunctionMap",
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
 #! to the category for the basic operation `UniversalPropertyOfCoDual`.
-#! $F: ( a, t, alpha ) \mapsto \mathtt{UniversalPropertyOfCoDual}(a, t, alpha)$.
+#! $F: ( t, a, alpha ) \mapsto \mathtt{UniversalPropertyOfCoDual}(t, a, alpha)$.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddUniversalPropertyOfCoDual",

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesMethodRecord.gi
@@ -196,7 +196,7 @@ InternalCoHomTensorProductCompatibilityMorphism := rec(
   with_given_object_position := "both",
   return_type := "morphism",
   dual_operation := "TensorProductInternalHomCompatibilityMorphism",
-  dual_preprocessor_func := { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ] ],
+  dual_preprocessor_func := { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ] ],
   dual_arguments_reversed := false,
 ),
 
@@ -208,7 +208,7 @@ InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects := rec(
   return_type := "morphism",
   dual_operation := "TensorProductInternalHomCompatibilityMorphismWithGivenObjects",
   dual_preprocessor_func :=
-    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ], Opposite( s ) ],
+    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ], Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 
@@ -267,7 +267,7 @@ IsomorphismFromInternalCoHomToCoDual := rec(
 
 UniversalPropertyOfCoDual := rec(
   filter_list := [ "category", "object", "object", "morphism" ],
-  io_type := [ [ "a", "t", "alpha" ], [ "d", "t" ] ],
+  io_type := [ [ "t", "a", "alpha" ], [ "d", "t" ] ],
   return_type := "morphism",
   dual_operation := "UniversalPropertyOfDual",
   dual_arguments_reversed := false,

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesMethodRecord.gi
@@ -51,7 +51,7 @@ TensorProductInternalHomCompatibilityMorphismInverse := rec(
   return_type := "morphism",
   dual_operation := "InternalCoHomTensorProductCompatibilityMorphismInverse",
   dual_preprocessor_func :=
-    { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[2] ) ] ],
+    { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ] ],
   dual_arguments_reversed := false,
 ),
 
@@ -63,7 +63,7 @@ TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects := rec(
   return_type := "morphism",
   dual_operation := "InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects",
   dual_preprocessor_func :=
-    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[2] ) ], Opposite( s ) ],
+    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[4] ), Opposite( list[1] ), Opposite( list[3] ) ], Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesMethodRecord.gi
@@ -50,7 +50,8 @@ InternalCoHomTensorProductCompatibilityMorphismInverse := rec(
   with_given_object_position := "both",
   return_type := "morphism",
   dual_operation := "TensorProductInternalHomCompatibilityMorphismInverse",
-  dual_preprocessor_func := { cat, list } -> [ Opposite( cat ), [ Opposite( list[2] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[3] ) ] ],
+  dual_preprocessor_func :=
+    { cat, list } -> [ Opposite( cat ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ] ],
   dual_arguments_reversed := false,
 ),
 
@@ -62,7 +63,7 @@ InternalCoHomTensorProductCompatibilityMorphismInverseWithGivenObjects := rec(
   return_type := "morphism",
   dual_operation := "TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects",
   dual_preprocessor_func :=
-    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[2] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[3] ) ], Opposite( s ) ],
+    { cat, s, list, r } -> [ Opposite( cat ), Opposite( r ), [ Opposite( list[3] ), Opposite( list[1] ), Opposite( list[4] ), Opposite( list[2] ) ], Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 
@@ -122,15 +123,15 @@ IsomorphismFromTensorProductToInternalCoHom := rec(
 BindGlobal( "RIGID_SYMMETRIC_CLOSED_AND_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD", rec( ) );
 
 Perform( RecNames( RIGID_SYMMETRIC_CLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD ), function ( name )
-    
+
     RIGID_SYMMETRIC_CLOSED_AND_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD.(name) := RIGID_SYMMETRIC_CLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD.(name);
-    
+
 end );
 
 Perform( RecNames( RIGID_SYMMETRIC_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD ), function ( name )
-    
+
     RIGID_SYMMETRIC_CLOSED_AND_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD.(name) := RIGID_SYMMETRIC_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD.(name);
-    
+
 end );
 
 CAP_INTERNAL_ENHANCE_NAME_RECORD( RIGID_SYMMETRIC_CLOSED_AND_COCLOSED_MONOIDAL_CATEGORIES_METHOD_NAME_RECORD );


### PR DESCRIPTION
The closed and coclosed `dual_preprocessor_func`'s were swapped and the `io_type` of `UniversalPropertyOfCoDual` was wrong.