### PR TITLE
Remove additional filters from filter lists of IsEqualAsSub/Factorobjects and Is(Co)Dominating

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2021.12-09",
+Version := "2022.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1141,19 +1141,19 @@ UniversalMorphismFromCoproductWithGivenCoproduct := rec(
   return_type := "morphism" ),
 
 IsEqualAsSubobjects := rec(
-  filter_list := [ "category", [ "morphism", IsSubobject ], [ "morphism", IsSubobject ] ],
+  filter_list := [ "category", "morphism", "morphism" ],
   well_defined_todo := false,
   return_type := "bool",
   dual_operation := "IsEqualAsFactorobjects" ),
 
 IsEqualAsFactorobjects := rec(
-  filter_list := [ "category", [ "morphism", IsFactorobject ], [ "morphism", IsFactorobject ] ],
+  filter_list := [ "category", "morphism", "morphism" ],
   well_defined_todo := false,
   return_type := "bool",
   dual_operation := "IsEqualAsSubobjects" ),
 
 IsDominating := rec(
-  filter_list := [ "category", [ "morphism", IsSubobject ], [ "morphism", IsSubobject ] ],
+  filter_list := [ "category", "morphism", "morphism" ],
   well_defined_todo := false,
   dual_operation := "IsCodominating",
   
@@ -1177,7 +1177,7 @@ IsDominating := rec(
   return_type := "bool" ),
 
 IsCodominating := rec(
-  filter_list := [ "category", [ "morphism", IsFactorobject ], [ "morphism", IsFactorobject ] ],
+  filter_list := [ "category", "morphism", "morphism" ],
   well_defined_todo := false,
   dual_operation := "IsDominating",
   


### PR DESCRIPTION
I'm not sure why those were added in the first place. If the reason was type checking: this is not done anywhere else, for example `LiftAlongMonomorphism` does not check that it gets a monomorphism.

I want to get rid of this special case (and in a follow up remove CAP's support for this) because it complicates any code handling `filter_list`s.

@sebastianpos Couly you quickly check if you see any problems with this?