### PR TITLE
Miscellaneous changes

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.01-01",
+Version := "2022.01-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -123,8 +123,6 @@ The record can have the following components, most of which can be set in the me
 
 * filter_list: A list containing the basic filters for the methods installed by the add methods. Possible entries are filters, or
                the strings listed below, which will be replaced by appropriate filters at the time the add method is called.
-               Additionally, an entry can be a list with two entries. In this case, the first entry must be one of the strings listed below and
-               the second entry must be a filter. After the first entry is replaced by the appropriate filter, both entries are joined via `and` to form a single filter.
                The first entry of `filter_list` must be the string `category`. If the category can be inferred from the remaining arguments, a convenience method without the category
                as the first argument is installed automatically. Additionally, the category is not passed to primitively added functions, except if
                `category!.category_as_first_argument` is set to `true` (this will probably change to be the default in the future).

--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -131,6 +131,8 @@ The record can have the following components, most of which can be set in the me
                * <C>object</C>,
                * <C>morphism</C>,
                * <C>twocell</C>,
+               * <C>object_in_range_category_of_homomorphism_structure</C>,
+               * <C>morphism_in_range_category_of_homomorphism_structure</C>,
                * <C>other_category</C>,
                * <C>other_cell</C>,
                * <C>other_object</C>,

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -308,6 +308,14 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 input_sanity_check_functions[i] := function( arg, i )
                     CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( arg, category, function( ) return input_human_readable_identifier_getter( i ); end );
                 end;
+            elif filter = "object_in_range_category_of_homomorphism_structure" then
+                input_sanity_check_functions[i] := function( arg, i )
+                    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( arg, RangeCategoryOfHomomorphismStructure( category ), function( ) return input_human_readable_identifier_getter( i ); end );
+                end;
+            elif filter = "morphism_in_range_category_of_homomorphism_structure" then
+                input_sanity_check_functions[i] := function( arg, i )
+                    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( arg, RangeCategoryOfHomomorphismStructure( category ), function( ) return input_human_readable_identifier_getter( i ); end );
+                end;
             elif filter = "other_cell" then
                 input_sanity_check_functions[i] := function( arg, i )
                     CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY( arg, false, function( ) return input_human_readable_identifier_getter( i ); end );
@@ -376,6 +384,14 @@ InstallGlobalFunction( CapInternalInstallAdd,
         elif record.return_type = "twocell" then
             output_sanity_check_function := function( result )
                 CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
+            end;
+        elif record.return_type = "object_in_range_category_of_homomorphism_structure" then
+            output_sanity_check_function := function( result )
+                CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( result, RangeCategoryOfHomomorphismStructure( category ), output_human_readable_identifier_getter );
+            end;
+        elif record.return_type = "morphism_in_range_category_of_homomorphism_structure" then
+            output_sanity_check_function := function( result )
+                CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( result, RangeCategoryOfHomomorphismStructure( category ), output_human_readable_identifier_getter );
             end;
         elif record.return_type = "bool" then
             output_sanity_check_function := function( result )

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -106,7 +106,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
         
         DeclareOperation( install_name, replaced_filter_list );
         
-        if filter_list[2] in [ "object", "morphism", "twocell" ] or ( IsList( filter_list[2] ) and filter_list[2][1] in [ "object", "morphism", "twocell" ] ) then
+        if filter_list[2] in [ "object", "morphism", "twocell" ] then
             
             get_convenience_function := oper -> { arg } -> CallFuncList( oper, Concatenation( [ CapCategory( arg[1] ) ], arg ) );
             
@@ -283,13 +283,9 @@ InstallGlobalFunction( CapInternalInstallAdd,
         
         input_sanity_check_functions := [];
         for i in [ 1 .. Length( record.filter_list ) ] do
+            
             filter := record.filter_list[ i ];
 
-            # in the special case of multiple filters, we currently only test for the first one
-            if not IsString( filter ) and IsList( filter ) then
-                filter := filter[1];
-            fi;
-            
             if IsFilter( filter ) then
                 # the only check would be that the input lies in the filter, which is already checked by the method selection
                 input_sanity_check_functions[i] := ReturnTrue;

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -4296,7 +4296,7 @@ end );
 
 InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
   function( record )
-    local recnames, current_recname, current_rec, io_type, number_of_arguments, flattened_filter_list, functorial, func_string,
+    local recnames, current_recname, current_rec, io_type, number_of_arguments, functorial, func_string,
           installation_name, output_list, input_list, argument_names, return_list, current_output, input_position, list_position,
           without_given_name, with_given_names, with_given_name, without_given_rec, with_given_object_position, object_name,
           object_filter_list, with_given_object_filter, given_source_argument_name, given_range_argument_name, with_given_rec, i;
@@ -4377,33 +4377,13 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
             Error( "the dual preprocessor function of <current_rec> has the wrong number of arguments" );
         fi;
         
-        if not ForAll( current_rec.filter_list, x -> IsFilter( x ) or IsString( x ) or (IsList( x ) and Length( x ) = 2 and IsString( x[1] ) and IsFilter( x[2] )) ) then
+        if not ForAll( current_rec.filter_list, x -> IsString( x ) or IsFilter( x ) ) then
             Error( "the filter list of <current_rec> does not fulfill the requirements" );
         fi;
         
         if not IsBound( current_rec.install_convenience_without_category ) then
             
-            # we cannot use `Flat` for lists of strings :-(
-            flattened_filter_list := Concatenation( List( current_rec.filter_list,
-              function( x )
-                
-                if IsString( x ) or IsFilter( x ) then
-                    
-                    return [ x ];
-                    
-                elif IsList( x ) then
-                    
-                    return x;
-                    
-                else
-                    
-                    Error( "entries of filter_list must be strings, filters or lists" );
-                    
-                fi;
-                
-            end ) );
-            
-            if not IsEmpty( Intersection( [ "object", "morphism", "twocell", "list_of_objects", "list_of_morphisms" ], Filtered( flattened_filter_list, IsString ) ) ) then
+            if ForAny( [ "object", "morphism", "twocell", "list_of_objects", "list_of_morphisms" ], filter -> filter in current_rec.filter_list ) then
                 
                 current_rec.install_convenience_without_category := true;
                 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -11,6 +11,8 @@ InstallValue( CAP_INTERNAL_VALID_RETURN_TYPES,
         "morphism",
         "morphism_or_fail",
         "twocell",
+        "object_in_range_category_of_homomorphism_structure",
+        "morphism_in_range_category_of_homomorphism_structure",
         "bool",
         "other_object",
         "other_morphism",
@@ -2998,7 +3000,7 @@ IsHomSetInhabited := rec(
 
 HomomorphismStructureOnObjects := rec(
   filter_list := [ "category", "object", "object" ],
-  return_type := "other_object",
+  return_type := "object_in_range_category_of_homomorphism_structure",
   dual_operation := "HomomorphismStructureOnObjects",
   dual_arguments_reversed := true,
   dual_postprocessor_func := IdFunc
@@ -3010,7 +3012,7 @@ HomomorphismStructureOnMorphisms := rec(
   output_source_getter_string := "HomomorphismStructureOnObjects( cat, Range( alpha ), Source( beta ) )",
   output_range_getter_string := "HomomorphismStructureOnObjects( cat, Source( alpha ), Range( beta ) )",
   with_given_object_position := "both",
-  return_type := "other_morphism",
+  return_type := "morphism_in_range_category_of_homomorphism_structure",
   dual_operation := "HomomorphismStructureOnMorphisms",
   dual_preprocessor_func := function( cat, alpha, beta )
     return [ OppositeCategory( cat ), Opposite( beta ), Opposite( alpha ) ];
@@ -3019,11 +3021,11 @@ HomomorphismStructureOnMorphisms := rec(
 ),
 
 HomomorphismStructureOnMorphismsWithGivenObjects := rec(
-  filter_list := [ "category", "other_object", "morphism", "morphism", "other_object" ],
+  filter_list := [ "category", "object_in_range_category_of_homomorphism_structure", "morphism", "morphism", "object_in_range_category_of_homomorphism_structure" ],
   input_arguments_names := [ "cat", "source", "alpha", "beta", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "other_morphism",
+  return_type := "morphism_in_range_category_of_homomorphism_structure",
   dual_operation := "HomomorphismStructureOnMorphismsWithGivenObjects",
   dual_preprocessor_func := function( cat, source, alpha, beta, range )
     return [ OppositeCategory( cat ), source, Opposite( beta ), Opposite( alpha ), range ];
@@ -3033,7 +3035,7 @@ HomomorphismStructureOnMorphismsWithGivenObjects := rec(
 
 DistinguishedObjectOfHomomorphismStructure := rec(
   filter_list := [ "category" ],
-  return_type := "other_object",
+  return_type := "object_in_range_category_of_homomorphism_structure",
   dual_operation := "DistinguishedObjectOfHomomorphismStructure",
   dual_postprocessor_func := IdFunc ),
 
@@ -3043,17 +3045,17 @@ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure := rec
   output_source_getter_string := "DistinguishedObjectOfHomomorphismStructure( cat )",
   output_range_getter_string := "HomomorphismStructureOnObjects( cat, Source( alpha ), Range( alpha ) )",
   with_given_object_position := "both",
-  return_type := "other_morphism",
+  return_type := "morphism_in_range_category_of_homomorphism_structure",
   dual_operation := "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure",
   dual_postprocessor_func := IdFunc
 ),
 
 InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects := rec(
-  filter_list := [ "category", "other_object", "morphism", "other_object" ],
+  filter_list := [ "category", "object_in_range_category_of_homomorphism_structure", "morphism", "object_in_range_category_of_homomorphism_structure" ],
   input_arguments_names := [ "cat", "source", "alpha", "range" ],
   output_source_getter_string := "source",
   output_range_getter_string := "range",
-  return_type := "other_morphism",
+  return_type := "morphism_in_range_category_of_homomorphism_structure",
   dual_operation := "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
   dual_preprocessor_func := function( cat, distinguished_object, alpha, hom_source_range )
     return [ OppositeCategory( cat ), distinguished_object, Opposite( alpha ), hom_source_range ];
@@ -3062,7 +3064,7 @@ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGiv
 ),
 
 InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism := rec(
-  filter_list := [ "category", "object", "object", "other_morphism" ],
+  filter_list := [ "category", "object", "object", "morphism_in_range_category_of_homomorphism_structure" ],
   return_type := "morphism",
   dual_operation := "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
   dual_preprocessor_func := function( cat, A, B, morphism )
@@ -4723,9 +4725,9 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
                 
             fi;
             
-            if not without_given_rec.return_type in [ "morphism", "other_morphism" ] then
+            if not without_given_rec.return_type in [ "morphism", "morphism_in_range_category_of_homomorphism_structure", "other_morphism" ] then
                 
-                Error( "This is a WithoutGiven record, but return_type is neither \"morphism\" nor \"other_morphism\". This is not supported." );
+                Error( "This is a WithoutGiven record, but return_type is neither \"morphism\" nor \"morphism_in_range_category_of_homomorphism_structure\" nor \"other_morphism\". This is not supported." );
                 
             fi;
             
@@ -4733,6 +4735,10 @@ InstallGlobalFunction( CAP_INTERNAL_ENHANCE_NAME_RECORD,
             if without_given_rec.return_type = "morphism" then
                 
                 with_given_object_filter := "object";
+                
+            elif without_given_rec.return_type = "morphism_in_range_category_of_homomorphism_structure" then
+                
+                with_given_object_filter := "object_in_range_category_of_homomorphism_structure";
                 
             elif without_given_rec.return_type = "other_morphism" then
                 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -185,13 +185,6 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                 filter := filter_list[i];
                 argument_name := input_arguments_names[i];
                 
-                # we only take the first filter in a filter list into account
-                if not IsString( filter ) and IsList( filter ) then
-                    
-                    filter := filter[1];
-                    
-                fi;
-                
                 if filter = "object" then
                     
                     return Concatenation( "ObjectDatum( cat, ", argument_name, " )" );

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -90,6 +90,26 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
     
     only_primitive_operations := ValueOption( "only_primitive_operations" ) = true;
     
+    ## Take care of attributes
+    ## TODO: if there are more instances, set markers in the MethodRecord
+    list_of_attributes := [ "RangeCategoryOfHomomorphismStructure", "CommutativeRingOfLinearCategory" ];
+    
+    for attr in list_of_attributes do
+        
+        tester := ValueGlobal( Concatenation( "Has", attr ) );
+        
+        if not tester( opposite_category ) and tester( category ) then
+            
+            setter := ValueGlobal( Concatenation( "Set", attr ) );
+            
+            getter := ValueGlobal( attr );
+            
+            setter( opposite_category, getter( category ) );
+            
+        fi;
+        
+    od;
+    
     recnames := RecNames( CAP_INTERNAL_METHOD_NAME_RECORD );
     
     for current_recname in recnames do
@@ -318,26 +338,6 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
         current_add := ValueGlobal( Concatenation( "Add", current_recname ) );
         
         current_add( opposite_category, func, weight );
-        
-    od;
-    
-    ## Take care of attributes
-    ## TODO: if there are more instances, set markers in the MethodRecord
-    list_of_attributes := [ "RangeCategoryOfHomomorphismStructure", "CommutativeRingOfLinearCategory" ];
-    
-    for attr in list_of_attributes do
-        
-        tester := ValueGlobal( Concatenation( "Has", attr ) );
-        
-        if not tester( opposite_category ) and tester( category ) then
-            
-            setter := ValueGlobal( Concatenation( "Set", attr ) );
-            
-            getter := ValueGlobal( attr );
-            
-            setter( opposite_category, getter( category ) );
-            
-        fi;
         
     od;
     

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -138,6 +138,14 @@ BindGlobal( "CAP_INTERNAL_INSTALL_PRODUCT_ADDS_FROM_CATEGORY",
         
         current_entry := CAP_INTERNAL_METHOD_NAME_RECORD.( current_recname );
         
+        if not ForAll( current_entry.filter_list, filter -> filter in [ "category", "cell", "object", "morphism", "twocell", IsInt, "list_of_objects", "list_of_morphisms", "list_of_twocells" ] ) then
+            continue;
+        fi;
+        
+        if not current_entry.return_type in [ "object", "morphism", "twocell", "bool" ] then
+            continue;
+        fi;
+        
         if IsBound( current_entry.no_install ) and current_entry.no_install = true then
             continue;
         fi;

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -422,6 +422,32 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   else
                       list[ i ] := IsCapCategoryTwoCell;
                   fi;
+              elif current_entry = "object_in_range_category_of_homomorphism_structure" then
+                  
+                  if category <> false and not HasRangeCategoryOfHomomorphismStructure( category ) then
+                      
+                      Display( Concatenation( "WARNING: You are calling an Add function for a CAP operation for \"", Name( category ), "\" which is part of a homomorphism structure but the category has no RangeCategoryOfHomomorphismStructure (yet)" ) );
+                      
+                  fi;
+                  
+                  if category <> false and HasRangeCategoryOfHomomorphismStructure( category ) then
+                      list[ i ] := ObjectFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryObject;
+                  else
+                      list[ i ] := IsCapCategoryObject;
+                  fi;
+              elif current_entry = "morphism_in_range_category_of_homomorphism_structure" then
+                  
+                  if category <> false and not HasRangeCategoryOfHomomorphismStructure( category ) then
+                      
+                      Display( Concatenation( "WARNING: You are calling an Add function for a CAP operation for \"", Name( category ), "\" which is part of a homomorphism structure but the category has no RangeCategoryOfHomomorphismStructure (yet)" ) );
+                      
+                  fi;
+                  
+                  if category <> false and HasRangeCategoryOfHomomorphismStructure( category ) then
+                      list[ i ] := MorphismFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryMorphism;
+                  else
+                      list[ i ] := IsCapCategoryMorphism;
+                  fi;
               elif current_entry = "other_category" then
                   list[ i ] := IsCapCategory;
               elif current_entry = "other_cell" then

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -442,13 +442,10 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   Error( "filter type is not recognized, see the documentation for allowed values" );
               fi;
               
-          elif IsList( current_entry ) then
-              current_entry := CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS( current_entry, category );
-              current_filter := current_entry[ 1 ];
-              for j in current_entry{[ 2 .. Length( current_entry ) ]} do
-                  current_filter := current_filter and j;
-              od;
-              list[ i ] := current_filter;
+          else
+              
+              Error( "the entries of filter lists must be strings or filters" );
+              
           fi;
           
       od;

--- a/CAP/gap/WrapperCategory.gi
+++ b/CAP/gap/WrapperCategory.gi
@@ -271,6 +271,8 @@ InstallMethod( WrapperCategory,
                 
             fi;
             
+            SetRangeCategoryOfHomomorphismStructure( D, HC );
+            
             if "DistinguishedObjectOfHomomorphismStructure" in list_of_operations_to_install then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
                   function( cat )
@@ -317,6 +319,8 @@ InstallMethod( WrapperCategory,
             fi;
             
         else
+            
+            SetRangeCategoryOfHomomorphismStructure( D, HC );
             
             if "DistinguishedObjectOfHomomorphismStructure" in list_of_operations_to_install then
                 AddDistinguishedObjectOfHomomorphismStructure( D,
@@ -373,8 +377,6 @@ InstallMethod( WrapperCategory,
             fi;
             
         fi;
-        
-        SetRangeCategoryOfHomomorphismStructure( D, HC );
         
     fi;
     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2021.12-06",
+Version := "2022.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/CapJitInlinedBindings.g
+++ b/CompilerForCAP/examples/CapJitInlinedBindings.g
@@ -18,9 +18,6 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function (  )
 #!     local val1_1, val2_1;
 #!     return 1;
-#!     val2_1 := 1;
-#!     val1_1 := 1;
-#!     return;
 #! end
 
 tree2 := CapJitInlinedBindings( tree );;
@@ -28,9 +25,6 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 #! function (  )
 #!     local val1_1, val2_1;
 #!     return 1;
-#!     val2_1 := 1;
-#!     val1_1 := 1;
-#!     return;
 #! end
 
 tree = tree2;
@@ -49,9 +43,6 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function (  )
 #!     local f1_1, f2_1;
 #!     return IdFunc;
-#!     f2_1 := IdFunc;
-#!     f1_1 := IdFunc;
-#!     return;
 #! end
 
 tree2 := CapJitInlinedBindingsToVariableReferences( tree );;
@@ -59,9 +50,6 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 #! function (  )
 #!     local f1_1, f2_1;
 #!     return IdFunc;
-#!     f2_1 := IdFunc;
-#!     f1_1 := IdFunc;
-#!     return;
 #! end
 
 tree = tree2;

--- a/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
+++ b/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
@@ -1,0 +1,66 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "CompilerForCAP", false );
+#! true
+
+# check that CapJitResolvedGlobalVariables is idempotent
+
+MY_GLOBAL_FUNCTION_1 := function ( x )
+    #% CAP_JIT_RESOLVE_FUNCTION
+    return x; end;;
+
+MY_GLOBAL_FUNCTION_2 := function ( x )
+    #% CAP_JIT_RESOLVE_FUNCTION
+    return MY_GLOBAL_FUNCTION_1( x ); end;;
+
+MY_CAP_CATEGORY_1 := CreateCapCategory( );;
+MY_CAP_CATEGORY_2 := CreateCapCategory( );;
+SetUnderlyingCategory( MY_CAP_CATEGORY_1, MY_CAP_CATEGORY_2 );
+
+DeclareAttribute( "MyAttribute", IsCapCategory );
+
+SetMyAttribute( MY_CAP_CATEGORY_2, MY_GLOBAL_FUNCTION_2 );
+
+func := function ( )
+  return MY_GLOBAL_FUNCTION_2( MyAttribute(
+        UnderlyingCategory( MY_CAP_CATEGORY_1 )
+    ) ); end;;
+
+tree := ENHANCED_SYNTAX_TREE( func );;
+
+tree := CapJitResolvedGlobalVariables( tree );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+#! function (  )
+#!     return function ( x_2 )
+#!             return function ( x_3 )
+#!                     return x_3;
+#!                 end( x_2 );
+#!         end( function ( x_2 )
+#!             return function ( x_3 )
+#!                     return x_3;
+#!                 end( x_2 );
+#!         end );
+#! end
+
+tree2 := CapJitResolvedGlobalVariables( tree );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
+#! function (  )
+#!     return function ( x_2 )
+#!             return function ( x_3 )
+#!                     return x_3;
+#!                 end( x_2 );
+#!         end( function ( x_2 )
+#!             return function ( x_3 )
+#!                     return x_3;
+#!                 end( x_2 );
+#!         end );
+#! end
+
+tree = tree2;
+#! true
+
+#! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -158,7 +158,6 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         CapJitInlinedFunctionCalls,
         CapJitDroppedUnusedBindings,
         CapJitInlinedBindings,
-        CapJitDroppedUnusedBindings,
     ];
     
     orig_tree := rec( );

--- a/CompilerForCAP/gap/InlineBindings.gd
+++ b/CompilerForCAP/gap/InlineBindings.gd
@@ -11,6 +11,7 @@
 #!   Example: transforms `function() local x; x := 1; return x^2; end` into `function() return 1^2; end()`.
 #!   Details: Replaces references to local variables of a function by the value of the corresponding binding of the function.
 #!   If the option `inline_var_refs_only` is set to `true`, this is only done if the value is a reference to a (local or global) variable.
+#!   Also drops the inlined bindings.
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitInlinedBindings" );

--- a/CompilerForCAP/gap/InlineFunctionCalls.gi
+++ b/CompilerForCAP/gap/InlineFunctionCalls.gi
@@ -35,6 +35,11 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID, function ( tree,
             # copy new_nams so the pointer does not leak
             tree.nams := StructuralCopy( new_nams );
             
+            # check that tree.bindings.names and the record entries are in sync
+            # otherwise we might "lose" bindings unexpectedly
+            Assert( 0, IsSortedList( tree.bindings.names ) );
+            Assert( 0, SortedList( Filtered( RecNames( tree.bindings ), name -> StartsWith( name, "BINDING_" ) ) ) = List( tree.bindings.names, name -> Concatenation( "BINDING_", name ) ) );
+            
             new_bindings := rec(
                 type := "FVAR_BINDING_SEQ",
                 names := [ ],

--- a/CompilerForCAP/gap/IterateOverTree.gi
+++ b/CompilerForCAP/gap/IterateOverTree.gi
@@ -149,9 +149,17 @@ InstallGlobalFunction( CapJitIterateOverTree, function ( tree, pre_func, result_
         
         keys := List( [ 1 .. tree.length ], i -> String( i ) );
         
+        # check that tree.length and the record entries are in sync
+        # keys are sorted as integers but not lexicographically
+        Assert( 0, SortedList( Filtered( RecNames( tree ), name -> IsDigitChar( First( name ) ) ) ) = SortedList( keys ) );
+        
     elif type = "FVAR_BINDING_SEQ" then
         
         keys := List( tree.names, name -> Concatenation( "BINDING_", name ) );
+        
+        # check that tree.names and the record entries are in sync
+        Assert( 0, IsSortedList( tree.names ) );
+        Assert( 0, SortedList( Filtered( RecNames( tree ), name -> StartsWith( name, "BINDING_" ) ) ) = keys );
         
     elif IsBound( CAP_JIT_INTERNAL_ITERATION_KEYS.(type) ) then
         

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -50,9 +50,9 @@ CapJitAddLogicFunction( function ( tree, jit_args )
     pre_func := function ( tree, additional_arguments )
       local args;
         
-        if tree.type = "EXPR_ELM_LIST" and tree.list.type = "EXPR_LIST" and tree.pos.type = "EXPR_INT" then
+        if CapJitIsCallToGlobalFunction( tree, "[]" ) and tree.args.1.type = "EXPR_LIST" and tree.args.2.type = "EXPR_INT" then
             
-            return tree.list.list.(tree.pos.value);
+            return tree.args.1.list.(tree.args.2.value);
             
         fi;
         

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -64,6 +64,16 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
                     # normalize to the "official" name
                     name := NameFunction( value );
                     
+                    # in GAP 4.11, "MatElm" points to "[,]", in GAP 4.12 it's the other way round
+                    if name = "[,]" then
+                        
+                        # this code is only executed with GAP 4.11, but coverage information is only uploaded for GAP master
+                        Assert( 0, IsIdenticalObj( \[\,\], MatElm ) );
+                        
+                        name := "MatElm";
+                        
+                    fi;
+                    
                     if name <> tree.gvar and IsBoundGlobal( name ) and IsIdenticalObj( value, ValueGlobal( name ) ) then
                         
                         tree := ShallowCopy( tree );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -12,13 +12,22 @@ BindGlobal( "CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES", [
 ] );
 
 InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
-  local pre_func;
+  local result_func;
     
     Info( InfoCapJit, 1, "####" );
     Info( InfoCapJit, 1, "Resolving global variables." );
     
-    pre_func := function ( tree, additional_arguments )
-      local value, resolved_tree, name, attr, cat, global_variable_name;
+    # we have to use result_func instead of pre_func to correctly resolve `Attribute( UnderlyingCategory( cat ) )`
+    result_func := function ( tree, result, keys, additional_arguments )
+      local key, value, resolved_tree, name, attr, cat, global_variable_name;
+        
+        tree := ShallowCopy( tree );
+        
+        for key in keys do
+            
+            tree.(key) := result.(key);
+            
+        od;
         
         if not (IsBound( tree.CAP_JIT_NOT_RESOLVABLE ) and tree.CAP_JIT_NOT_RESOLVABLE) then
             
@@ -55,7 +64,7 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
                                 
                             fi;
                             
-                            return resolved_tree;
+                            return CapJitResolvedGlobalVariables( resolved_tree );
                             
                         fi;
                         
@@ -102,6 +111,6 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
         
     end;
     
-    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, ReturnTrue, true );
+    return CapJitIterateOverTree( tree, ReturnFirst, result_func, ReturnTrue, true );
     
 end );

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -39,15 +39,15 @@ InstallGlobalFunction( CapJitResultFuncCombineChildren, function ( tree, result,
     elif IsRecord( result ) then
         
         tree := ShallowCopy( tree );
-
+        
         for key in keys do
             
             tree.(key) := result.(key);
-
+            
         od;
         
         return tree;
-
+        
     else
         
         # COVERAGE_IGNORE_NEXT_LINE

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2021.12-08",
+Version := "2022.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -329,23 +329,23 @@ function ( cat_1, a_1, b_1 )
     deduped_9_1 := Dimension( a_1 );
     deduped_8_1 := Dimension( b_1 );
     deduped_7_1 := deduped_8_1 * deduped_9_1;
-    deduped_6_1 := deduped_8_1 * deduped_8_1;
-    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_4_1 := deduped_8_1 * deduped_8_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_8_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                   if (deduped_8_1 = 0) then
-                      return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
+                      return HomalgZeroMatrix( 1, deduped_4_1, deduped_10_1 );
                   else
-                      return ConvertMatrixToRow( deduped_4_1 );
+                      return ConvertMatrixToRow( deduped_5_1 );
                   fi;
                   return;
-              end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+              end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( deduped_5_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                       local deduped_1_2;
                       deduped_1_2 := (i_2 - 1);
                       return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
@@ -369,23 +369,23 @@ function ( cat_1, a_1, b_1, r_1 )
     deduped_9_1 := Dimension( a_1 );
     deduped_8_1 := Dimension( b_1 );
     deduped_7_1 := deduped_8_1 * deduped_9_1;
-    deduped_6_1 := deduped_8_1 * deduped_8_1;
-    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_4_1 := deduped_8_1 * deduped_8_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_8_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                   if (deduped_8_1 = 0) then
-                      return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
+                      return HomalgZeroMatrix( 1, deduped_4_1, deduped_10_1 );
                   else
-                      return ConvertMatrixToRow( deduped_4_1 );
+                      return ConvertMatrixToRow( deduped_5_1 );
                   fi;
                   return;
-              end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+              end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( deduped_5_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                       local deduped_1_2;
                       deduped_1_2 := (i_2 - 1);
                       return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
@@ -1020,19 +1020,19 @@ function ( cat_1, a_1, b_1 )
     deduped_8_1 := UnderlyingRing( cat_1 );
     deduped_7_1 := Dimension( a_1 );
     deduped_6_1 := Dimension( b_1 );
-    deduped_5_1 := deduped_7_1 * deduped_6_1;
-    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    deduped_4_1 := deduped_7_1 * deduped_6_1;
     hoisted_3_1 := deduped_7_1;
     hoisted_2_1 := deduped_6_1;
-    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_4_1, deduped_8_1 ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
+                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_8_1 ), deduped_5_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
                 if (deduped_7_1 = 0) then
                     return HomalgZeroMatrix( (deduped_7_1 * deduped_7_1), 1, deduped_8_1 );
                 else
-                    return ConvertMatrixToColumn( deduped_4_1 );
+                    return ConvertMatrixToColumn( deduped_5_1 );
                 fi;
                 return;
             end(  ) );
@@ -1054,19 +1054,19 @@ function ( cat_1, a_1, b_1, s_1 )
     deduped_8_1 := UnderlyingRing( cat_1 );
     deduped_7_1 := Dimension( a_1 );
     deduped_6_1 := Dimension( b_1 );
-    deduped_5_1 := deduped_7_1 * deduped_6_1;
-    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_7_1, deduped_8_1 );
+    deduped_4_1 := deduped_7_1 * deduped_6_1;
     hoisted_3_1 := deduped_7_1;
     hoisted_2_1 := deduped_6_1;
-    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_4_1, deduped_8_1 ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
+                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_8_1 ), deduped_5_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_6_1, deduped_8_1 ), function (  )
                 if (deduped_7_1 = 0) then
                     return HomalgZeroMatrix( (deduped_7_1 * deduped_7_1), 1, deduped_8_1 );
                 else
-                    return ConvertMatrixToColumn( deduped_4_1 );
+                    return ConvertMatrixToColumn( deduped_5_1 );
                 fi;
                 return;
             end(  ) );
@@ -1436,16 +1436,16 @@ end
 ########
 function ( cat_1, objects_1, k_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfColumns( HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ) );
+            end ), deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, deduped_4_1, ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
@@ -1458,16 +1458,16 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfColumns( HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ) );
+            end ), deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, deduped_4_1, ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
@@ -1480,16 +1480,16 @@ end
 ########
 function ( cat_1, objects_1, k_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfColumns( HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( deduped_2_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_3_1 ) );
+            end ), deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, deduped_4_1, ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, deduped_3_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
@@ -1502,15 +1502,15 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     local deduped_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := objects_1[k_1];
-    deduped_2_1 := UnderlyingRing( cat_1 );
-    deduped_1_1 := Dimension( deduped_3_1 );
+    deduped_3_1 := UnderlyingRing( cat_1 );
+    deduped_2_1 := objects_1[k_1];
+    deduped_1_1 := Dimension( deduped_2_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, deduped_3_1, P_1, UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( deduped_1_1, Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
+           ), cat_1, deduped_2_1, P_1, UnderlyingMatrix, UnionOfColumns( HomalgZeroMatrix( deduped_1_1, Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                   return Dimension( c_2 );
-              end ), deduped_2_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ), HomalgZeroMatrix( deduped_1_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+              end ), deduped_3_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_3_1 ), HomalgZeroMatrix( deduped_1_1, Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                   return Dimension( c_2 );
-              end ), deduped_2_1 ) ) );
+              end ), deduped_3_1 ) ) );
 end
 ########
         
@@ -2419,18 +2419,18 @@ function ( cat_1, a_1 )
     local morphism_attr_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
     deduped_6_1 := UnderlyingRing( cat_1 );
     deduped_5_1 := Dimension( a_1 );
-    deduped_4_1 := 1 * deduped_5_1;
-    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_6_1 );
+    deduped_4_1 := HomalgIdentityMatrix( 1, deduped_6_1 );
+    deduped_3_1 := 1 * deduped_5_1;
     hoisted_2_1 := deduped_5_1;
-    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_4_1, deduped_6_1 ), deduped_3_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
+    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_3_1, deduped_6_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * 1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_6_1 ), deduped_3_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_6_1 ), function (  )
+                    end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, deduped_6_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_6_1 ), function (  )
                 if (1 = 0) then
                     return HomalgZeroMatrix( (1 * 1), 1, deduped_6_1 );
                 else
-                    return ConvertMatrixToColumn( deduped_3_1 );
+                    return ConvertMatrixToColumn( deduped_4_1 );
                 fi;
                 return;
             end(  ) );
@@ -2450,18 +2450,18 @@ function ( cat_1, a_1, s_1 )
     local morphism_attr_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
     deduped_6_1 := UnderlyingRing( cat_1 );
     deduped_5_1 := Dimension( a_1 );
-    deduped_4_1 := 1 * deduped_5_1;
-    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_6_1 );
+    deduped_4_1 := HomalgIdentityMatrix( 1, deduped_6_1 );
+    deduped_3_1 := 1 * deduped_5_1;
     hoisted_2_1 := deduped_5_1;
-    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_4_1, deduped_6_1 ), deduped_3_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
+    morphism_attr_1_1 := KroneckerMat( HomalgIdentityMatrix( deduped_3_1, deduped_6_1 ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * 1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_6_1 ), deduped_3_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_6_1 ), function (  )
+                    end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, deduped_6_1 ), deduped_4_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_5_1, deduped_6_1 ), function (  )
                 if (1 = 0) then
                     return HomalgZeroMatrix( (1 * 1), 1, deduped_6_1 );
                 else
-                    return ConvertMatrixToColumn( deduped_3_1 );
+                    return ConvertMatrixToColumn( deduped_4_1 );
                 fi;
                 return;
             end(  ) );
@@ -2566,29 +2566,29 @@ end
 ########
 function ( cat_1, a_1 )
     local morphism_attr_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
-    deduped_8_1 := 1 * 1;
-    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := UnderlyingRing( cat_1 );
+    deduped_7_1 := 1 * 1;
     deduped_6_1 := Dimension( a_1 );
     deduped_5_1 := 1 * deduped_6_1;
-    deduped_4_1 := HomalgIdentityMatrix( deduped_6_1, deduped_7_1 );
-    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_7_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_6_1, deduped_8_1 );
+    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_8_1 );
     hoisted_2_1 := deduped_6_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                     if (1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_8_1, deduped_7_1 );
+                        return HomalgZeroMatrix( 1, deduped_7_1, deduped_8_1 );
                     else
                         return ConvertMatrixToRow( deduped_3_1 );
                     fi;
                     return;
-                end(  ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                end(  ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, 1 ) * 1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_7_1 ), deduped_4_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+                      end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * 1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_7_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), deduped_4_1 );
+                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), deduped_4_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -2604,29 +2604,29 @@ end
 ########
 function ( cat_1, a_1, r_1 )
     local morphism_attr_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1;
-    deduped_8_1 := 1 * 1;
-    deduped_7_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := UnderlyingRing( cat_1 );
+    deduped_7_1 := 1 * 1;
     deduped_6_1 := Dimension( a_1 );
     deduped_5_1 := 1 * deduped_6_1;
-    deduped_4_1 := HomalgIdentityMatrix( deduped_6_1, deduped_7_1 );
-    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_7_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_6_1, deduped_8_1 );
+    deduped_3_1 := HomalgIdentityMatrix( 1, deduped_8_1 );
     hoisted_2_1 := deduped_6_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                     if (1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_8_1, deduped_7_1 );
+                        return HomalgZeroMatrix( 1, deduped_7_1, deduped_8_1 );
                     else
                         return ConvertMatrixToRow( deduped_3_1 );
                     fi;
                     return;
-                end(  ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                end(  ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, 1 ) * 1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_7_1 ), deduped_4_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+                      end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_8_1 ), deduped_4_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_2_1 ) * 1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_7_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), deduped_4_1 );
+                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), deduped_4_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -2885,25 +2885,25 @@ function ( cat_1, alpha_1 )
     deduped_7_1 := HomalgIdentityMatrix( 1, deduped_8_1 );
     deduped_6_1 := Dimension( Source( alpha_1 ) );
     deduped_5_1 := deduped_6_1 * 1;
-    deduped_4_1 := deduped_6_1 * deduped_6_1;
-    deduped_3_1 := HomalgIdentityMatrix( deduped_6_1, deduped_8_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_6_1, deduped_8_1 );
+    deduped_3_1 := deduped_6_1 * deduped_6_1;
     hoisted_2_1 := deduped_6_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                     if (deduped_6_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_4_1, deduped_8_1 );
+                        return HomalgZeroMatrix( 1, deduped_3_1, deduped_8_1 );
                     else
-                        return ConvertMatrixToRow( deduped_3_1 );
+                        return ConvertMatrixToRow( deduped_4_1 );
                     fi;
                     return;
-                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
+                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_8_1 ), deduped_7_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+                      end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, deduped_8_1 ), deduped_7_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, 1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), UnderlyingMatrix( alpha_1 ) );
+                    end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_8_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -3138,55 +3138,55 @@ function ( cat_1, a_1, b_1, c_1 )
     deduped_18_1 := Dimension( c_1 );
     deduped_17_1 := Dimension( b_1 );
     deduped_16_1 := Dimension( a_1 );
-    deduped_15_1 := deduped_16_1 * deduped_16_1;
-    deduped_14_1 := deduped_16_1 * deduped_17_1;
-    deduped_13_1 := deduped_17_1 * deduped_18_1;
-    deduped_12_1 := deduped_16_1 = 0;
-    deduped_11_1 := deduped_13_1 * deduped_14_1;
-    deduped_10_1 := HomalgIdentityMatrix( deduped_17_1, deduped_19_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_16_1, deduped_19_1 );
-    deduped_8_1 := deduped_16_1 * deduped_11_1;
-    deduped_7_1 := HomalgIdentityMatrix( deduped_13_1, deduped_19_1 );
-    deduped_6_1 := HomalgIdentityMatrix( deduped_11_1, deduped_19_1 );
+    deduped_15_1 := deduped_16_1 = 0;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_17_1, deduped_19_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_16_1, deduped_19_1 );
+    deduped_12_1 := deduped_16_1 * deduped_16_1;
+    deduped_11_1 := deduped_16_1 * deduped_17_1;
+    deduped_10_1 := deduped_17_1 * deduped_18_1;
+    deduped_9_1 := HomalgIdentityMatrix( deduped_10_1, deduped_19_1 );
+    deduped_8_1 := deduped_10_1 * deduped_11_1;
+    deduped_7_1 := deduped_16_1 * deduped_8_1;
+    deduped_6_1 := HomalgIdentityMatrix( deduped_8_1, deduped_19_1 );
     hoisted_5_1 := deduped_18_1;
     hoisted_4_1 := deduped_17_1;
-    hoisted_3_1 := deduped_11_1;
+    hoisted_3_1 := deduped_8_1;
     hoisted_2_1 := deduped_16_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if deduped_12_1 then
-                        return HomalgZeroMatrix( 1, deduped_15_1, deduped_19_1 );
+                    if deduped_15_1 then
+                        return HomalgZeroMatrix( 1, deduped_12_1, deduped_19_1 );
                     else
-                        return ConvertMatrixToRow( deduped_9_1 );
+                        return ConvertMatrixToRow( deduped_13_1 );
                     fi;
                     return;
-                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_12_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_19_1 ), deduped_6_1 ) * KroneckerMat( deduped_9_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                      end ) ), deduped_12_1 ), deduped_12_1, deduped_12_1, deduped_19_1 ), deduped_6_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_19_1 ) ) * KroneckerMat( TransposedMatrix( deduped_9_1 ), (KroneckerMat( deduped_7_1, KroneckerMat( HomalgIdentityMatrix( deduped_14_1, deduped_19_1 ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_19_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( deduped_9_1, KroneckerMat( HomalgIdentityMatrix( deduped_11_1, deduped_19_1 ), deduped_13_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                            end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_19_1 ), deduped_9_1 ) * KroneckerMat( deduped_10_1, function (  )
-                        if deduped_12_1 then
-                            return HomalgZeroMatrix( deduped_15_1, 1, deduped_19_1 );
+                            end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_19_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, function (  )
+                        if deduped_15_1 then
+                            return HomalgZeroMatrix( deduped_12_1, 1, deduped_19_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_9_1 );
+                            return ConvertMatrixToColumn( deduped_13_1 );
                         fi;
                         return;
-                    end(  ) ) ) * (KroneckerMat( deduped_7_1, deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
+                    end(  ) ) ) * (KroneckerMat( deduped_9_1, deduped_14_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                          end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_19_1 ), deduped_10_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_19_1 ), function (  )
+                          end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_19_1 ), deduped_14_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_19_1 ), function (  )
                       if (deduped_17_1 = 0) then
                           return HomalgZeroMatrix( (deduped_17_1 * deduped_17_1), 1, deduped_19_1 );
                       else
-                          return ConvertMatrixToColumn( deduped_10_1 );
+                          return ConvertMatrixToColumn( deduped_14_1 );
                       fi;
                       return;
                   end(  ) ))) );
@@ -3209,55 +3209,55 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
     deduped_18_1 := Dimension( c_1 );
     deduped_17_1 := Dimension( b_1 );
     deduped_16_1 := Dimension( a_1 );
-    deduped_15_1 := deduped_16_1 * deduped_16_1;
-    deduped_14_1 := deduped_16_1 * deduped_17_1;
-    deduped_13_1 := deduped_17_1 * deduped_18_1;
-    deduped_12_1 := deduped_16_1 = 0;
-    deduped_11_1 := deduped_13_1 * deduped_14_1;
-    deduped_10_1 := HomalgIdentityMatrix( deduped_17_1, deduped_19_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_16_1, deduped_19_1 );
-    deduped_8_1 := deduped_16_1 * deduped_11_1;
-    deduped_7_1 := HomalgIdentityMatrix( deduped_13_1, deduped_19_1 );
-    deduped_6_1 := HomalgIdentityMatrix( deduped_11_1, deduped_19_1 );
+    deduped_15_1 := deduped_16_1 = 0;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_17_1, deduped_19_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_16_1, deduped_19_1 );
+    deduped_12_1 := deduped_16_1 * deduped_16_1;
+    deduped_11_1 := deduped_16_1 * deduped_17_1;
+    deduped_10_1 := deduped_17_1 * deduped_18_1;
+    deduped_9_1 := HomalgIdentityMatrix( deduped_10_1, deduped_19_1 );
+    deduped_8_1 := deduped_10_1 * deduped_11_1;
+    deduped_7_1 := deduped_16_1 * deduped_8_1;
+    deduped_6_1 := HomalgIdentityMatrix( deduped_8_1, deduped_19_1 );
     hoisted_5_1 := deduped_18_1;
     hoisted_4_1 := deduped_17_1;
-    hoisted_3_1 := deduped_11_1;
+    hoisted_3_1 := deduped_8_1;
     hoisted_2_1 := deduped_16_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if deduped_12_1 then
-                        return HomalgZeroMatrix( 1, deduped_15_1, deduped_19_1 );
+                    if deduped_15_1 then
+                        return HomalgZeroMatrix( 1, deduped_12_1, deduped_19_1 );
                     else
-                        return ConvertMatrixToRow( deduped_9_1 );
+                        return ConvertMatrixToRow( deduped_13_1 );
                     fi;
                     return;
-                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_12_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_19_1 ), deduped_6_1 ) * KroneckerMat( deduped_9_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
+                      end ) ), deduped_12_1 ), deduped_12_1, deduped_12_1, deduped_19_1 ), deduped_6_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_19_1 ) ) * KroneckerMat( TransposedMatrix( deduped_9_1 ), (KroneckerMat( deduped_7_1, KroneckerMat( HomalgIdentityMatrix( deduped_14_1, deduped_19_1 ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_19_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( deduped_9_1, KroneckerMat( HomalgIdentityMatrix( deduped_11_1, deduped_19_1 ), deduped_13_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                            end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_19_1 ), deduped_9_1 ) * KroneckerMat( deduped_10_1, function (  )
-                        if deduped_12_1 then
-                            return HomalgZeroMatrix( deduped_15_1, 1, deduped_19_1 );
+                            end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_19_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, function (  )
+                        if deduped_15_1 then
+                            return HomalgZeroMatrix( deduped_12_1, 1, deduped_19_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_9_1 );
+                            return ConvertMatrixToColumn( deduped_13_1 );
                         fi;
                         return;
-                    end(  ) ) ) * (KroneckerMat( deduped_7_1, deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
+                    end(  ) ) ) * (KroneckerMat( deduped_9_1, deduped_14_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                          end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_19_1 ), deduped_10_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_19_1 ), function (  )
+                          end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_19_1 ), deduped_14_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_19_1 ), function (  )
                       if (deduped_17_1 = 0) then
                           return HomalgZeroMatrix( (deduped_17_1 * deduped_17_1), 1, deduped_19_1 );
                       else
-                          return ConvertMatrixToColumn( deduped_10_1 );
+                          return ConvertMatrixToColumn( deduped_14_1 );
                       fi;
                       return;
                   end(  ) ))) );
@@ -3280,67 +3280,67 @@ function ( cat_1, a_1, b_1, c_1 )
     deduped_22_1 := Dimension( c_1 );
     deduped_21_1 := Dimension( b_1 );
     deduped_20_1 := Dimension( a_1 );
-    deduped_19_1 := deduped_20_1 * deduped_20_1;
-    deduped_18_1 := deduped_21_1 * deduped_22_1;
-    deduped_17_1 := deduped_20_1 * deduped_21_1;
-    deduped_16_1 := deduped_20_1 = 0;
-    deduped_15_1 := deduped_21_1 * deduped_18_1;
-    deduped_14_1 := deduped_18_1 * deduped_20_1;
-    deduped_13_1 := deduped_17_1 * deduped_18_1;
-    deduped_12_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
-    deduped_10_1 := deduped_20_1 * deduped_13_1;
-    deduped_9_1 := HomalgIdentityMatrix( deduped_18_1, deduped_23_1 );
-    deduped_8_1 := HomalgIdentityMatrix( deduped_17_1, deduped_23_1 );
-    deduped_7_1 := HomalgIdentityMatrix( deduped_13_1, deduped_23_1 );
+    deduped_19_1 := deduped_20_1 = 0;
+    deduped_18_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
+    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
+    deduped_16_1 := deduped_20_1 * deduped_20_1;
+    deduped_15_1 := deduped_21_1 * deduped_22_1;
+    deduped_14_1 := deduped_20_1 * deduped_21_1;
+    deduped_13_1 := deduped_21_1 * deduped_15_1;
+    deduped_12_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_11_1 := deduped_15_1 * deduped_20_1;
+    deduped_10_1 := HomalgIdentityMatrix( deduped_14_1, deduped_23_1 );
+    deduped_9_1 := deduped_14_1 * deduped_15_1;
+    deduped_8_1 := deduped_20_1 * deduped_9_1;
+    deduped_7_1 := HomalgIdentityMatrix( deduped_9_1, deduped_23_1 );
     hoisted_6_1 := deduped_22_1;
     hoisted_5_1 := deduped_21_1;
-    hoisted_4_1 := deduped_18_1;
-    hoisted_3_1 := deduped_13_1;
+    hoisted_4_1 := deduped_15_1;
+    hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_20_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if deduped_16_1 then
-                        return HomalgZeroMatrix( 1, deduped_19_1, deduped_23_1 );
+                    if deduped_19_1 then
+                        return HomalgZeroMatrix( 1, deduped_16_1, deduped_23_1 );
                     else
-                        return ConvertMatrixToRow( deduped_11_1 );
+                        return ConvertMatrixToRow( deduped_17_1 );
                     fi;
                     return;
-                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
+                      end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_17_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( deduped_8_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                    end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_17_1 ), (KroneckerMat( deduped_10_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                          end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_23_1 ) ) * KroneckerMat( (KroneckerMat( deduped_8_1, deduped_11_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                          end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_23_1 ) ) * KroneckerMat( (KroneckerMat( deduped_10_1, deduped_17_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                                end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ), deduped_11_1 ) * KroneckerMat( deduped_12_1, function (  )
-                            if deduped_16_1 then
-                                return HomalgZeroMatrix( deduped_19_1, 1, deduped_23_1 );
+                                end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_23_1 ), deduped_17_1 ) * KroneckerMat( deduped_18_1, function (  )
+                            if deduped_19_1 then
+                                return HomalgZeroMatrix( deduped_16_1, 1, deduped_23_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_11_1 );
+                                return ConvertMatrixToColumn( deduped_17_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_9_1 ) * HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                        end(  ) )), deduped_12_1 ) * HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_23_1 ) * (KroneckerMat( deduped_9_1, deduped_12_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+                      end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_23_1 ) * (KroneckerMat( deduped_12_1, deduped_18_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                          end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_23_1 ), deduped_12_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_22_1, deduped_23_1 ), function (  )
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_23_1 ), deduped_18_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_22_1, deduped_23_1 ), function (  )
                       if (deduped_21_1 = 0) then
                           return HomalgZeroMatrix( (deduped_21_1 * deduped_21_1), 1, deduped_23_1 );
                       else
-                          return ConvertMatrixToColumn( deduped_12_1 );
+                          return ConvertMatrixToColumn( deduped_18_1 );
                       fi;
                       return;
                   end(  ) ))) );
@@ -3363,67 +3363,67 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
     deduped_22_1 := Dimension( c_1 );
     deduped_21_1 := Dimension( b_1 );
     deduped_20_1 := Dimension( a_1 );
-    deduped_19_1 := deduped_20_1 * deduped_20_1;
-    deduped_18_1 := deduped_21_1 * deduped_22_1;
-    deduped_17_1 := deduped_20_1 * deduped_21_1;
-    deduped_16_1 := deduped_20_1 = 0;
-    deduped_15_1 := deduped_21_1 * deduped_18_1;
-    deduped_14_1 := deduped_18_1 * deduped_20_1;
-    deduped_13_1 := deduped_17_1 * deduped_18_1;
-    deduped_12_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
-    deduped_10_1 := deduped_20_1 * deduped_13_1;
-    deduped_9_1 := HomalgIdentityMatrix( deduped_18_1, deduped_23_1 );
-    deduped_8_1 := HomalgIdentityMatrix( deduped_17_1, deduped_23_1 );
-    deduped_7_1 := HomalgIdentityMatrix( deduped_13_1, deduped_23_1 );
+    deduped_19_1 := deduped_20_1 = 0;
+    deduped_18_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
+    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
+    deduped_16_1 := deduped_20_1 * deduped_20_1;
+    deduped_15_1 := deduped_21_1 * deduped_22_1;
+    deduped_14_1 := deduped_20_1 * deduped_21_1;
+    deduped_13_1 := deduped_21_1 * deduped_15_1;
+    deduped_12_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_11_1 := deduped_15_1 * deduped_20_1;
+    deduped_10_1 := HomalgIdentityMatrix( deduped_14_1, deduped_23_1 );
+    deduped_9_1 := deduped_14_1 * deduped_15_1;
+    deduped_8_1 := deduped_20_1 * deduped_9_1;
+    deduped_7_1 := HomalgIdentityMatrix( deduped_9_1, deduped_23_1 );
     hoisted_6_1 := deduped_22_1;
     hoisted_5_1 := deduped_21_1;
-    hoisted_4_1 := deduped_18_1;
-    hoisted_3_1 := deduped_13_1;
+    hoisted_4_1 := deduped_15_1;
+    hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_20_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if deduped_16_1 then
-                        return HomalgZeroMatrix( 1, deduped_19_1, deduped_23_1 );
+                    if deduped_19_1 then
+                        return HomalgZeroMatrix( 1, deduped_16_1, deduped_23_1 );
                     else
-                        return ConvertMatrixToRow( deduped_11_1 );
+                        return ConvertMatrixToRow( deduped_17_1 );
                     fi;
                     return;
-                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
+                      end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_17_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( deduped_8_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                    end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_17_1 ), (KroneckerMat( deduped_10_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                          end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_23_1 ) ) * KroneckerMat( (KroneckerMat( deduped_8_1, deduped_11_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                          end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_23_1 ) ) * KroneckerMat( (KroneckerMat( deduped_10_1, deduped_17_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
-                                end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ), deduped_11_1 ) * KroneckerMat( deduped_12_1, function (  )
-                            if deduped_16_1 then
-                                return HomalgZeroMatrix( deduped_19_1, 1, deduped_23_1 );
+                                end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_23_1 ), deduped_17_1 ) * KroneckerMat( deduped_18_1, function (  )
+                            if deduped_19_1 then
+                                return HomalgZeroMatrix( deduped_16_1, 1, deduped_23_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_11_1 );
+                                return ConvertMatrixToColumn( deduped_17_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_9_1 ) * HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                        end(  ) )), deduped_12_1 ) * HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_23_1 ) * (KroneckerMat( deduped_9_1, deduped_12_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+                      end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_23_1 ) * (KroneckerMat( deduped_12_1, deduped_18_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                          end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_23_1 ), deduped_12_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_22_1, deduped_23_1 ), function (  )
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_23_1 ), deduped_18_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_22_1, deduped_23_1 ), function (  )
                       if (deduped_21_1 = 0) then
                           return HomalgZeroMatrix( (deduped_21_1 * deduped_21_1), 1, deduped_23_1 );
                       else
-                          return ConvertMatrixToColumn( deduped_12_1 );
+                          return ConvertMatrixToColumn( deduped_18_1 );
                       fi;
                       return;
                   end(  ) ))) );
@@ -3577,19 +3577,19 @@ end
 ########
 function ( cat_1, morphisms_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := morphisms_1[1];
-    deduped_11_1 := Length( morphisms_1 );
-    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_12_1 := Length( morphisms_1 );
+    deduped_11_1 := UnderlyingRing( cat_1 );
+    deduped_10_1 := morphisms_1[1];
     deduped_9_1 := List( morphisms_1, function ( logic_new_func_x_2 )
             return Dimension( Source( logic_new_func_x_2 ) );
         end );
     deduped_8_1 := Sum( deduped_9_1 );
     deduped_7_1 := Sum( deduped_9_1{[ 1 .. 1 - 1 ]} ) + 1;
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
+    hoisted_5_1 := deduped_12_1;
+    hoisted_4_1 := deduped_11_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := List( morphisms_1, Source );
-    deduped_6_1 := List( [ 1 .. deduped_11_1 ], function ( logic_new_func_x_2 )
+    deduped_6_1 := List( [ 1 .. deduped_12_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_3_1[logic_new_func_x_2];
             return UnionOfRows( HomalgZeroMatrix( Sum( hoisted_2_1{[ 1 .. (logic_new_func_x_2 - 1) ]}, function ( c_3 )
@@ -3598,10 +3598,10 @@ function ( cat_1, morphisms_1 )
                           return Dimension( c_3 );
                       end ), deduped_1_2, hoisted_4_1 ) ) * UnderlyingMatrix( morphisms_1[logic_new_func_x_2] );
         end );
-    morphism_attr_1_1 := CertainColumns( SyzygiesOfRows( (UnionOfColumns( deduped_10_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_11_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_10_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_11_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] ) * UnderlyingMatrix( deduped_12_1 );
+    morphism_attr_1_1 := CertainColumns( SyzygiesOfRows( (UnionOfColumns( deduped_11_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_12_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_11_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_12_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] ) * UnderlyingMatrix( deduped_10_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), Range( deduped_12_1 ), UnderlyingMatrix, morphism_attr_1_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), Range( deduped_10_1 ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3613,19 +3613,19 @@ end
 ########
 function ( cat_1, morphisms_1, P_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := morphisms_1[1];
-    deduped_11_1 := Length( morphisms_1 );
-    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_12_1 := Length( morphisms_1 );
+    deduped_11_1 := UnderlyingRing( cat_1 );
+    deduped_10_1 := morphisms_1[1];
     deduped_9_1 := List( morphisms_1, function ( logic_new_func_x_2 )
             return Dimension( Source( logic_new_func_x_2 ) );
         end );
     deduped_8_1 := Sum( deduped_9_1 );
     deduped_7_1 := Sum( deduped_9_1{[ 1 .. 1 - 1 ]} ) + 1;
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
+    hoisted_5_1 := deduped_12_1;
+    hoisted_4_1 := deduped_11_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := List( morphisms_1, Source );
-    deduped_6_1 := List( [ 1 .. deduped_11_1 ], function ( logic_new_func_x_2 )
+    deduped_6_1 := List( [ 1 .. deduped_12_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_3_1[logic_new_func_x_2];
             return UnionOfRows( HomalgZeroMatrix( Sum( hoisted_2_1{[ 1 .. (logic_new_func_x_2 - 1) ]}, function ( c_3 )
@@ -3634,10 +3634,10 @@ function ( cat_1, morphisms_1, P_1 )
                           return Dimension( c_3 );
                       end ), deduped_1_2, hoisted_4_1 ) ) * UnderlyingMatrix( morphisms_1[logic_new_func_x_2] );
         end );
-    morphism_attr_1_1 := CertainColumns( SyzygiesOfRows( (UnionOfColumns( deduped_10_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_11_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_10_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_11_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] ) * UnderlyingMatrix( deduped_12_1 );
+    morphism_attr_1_1 := CertainColumns( SyzygiesOfRows( (UnionOfColumns( deduped_11_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_12_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_11_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_12_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] ) * UnderlyingMatrix( deduped_10_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), Range( deduped_12_1 ), UnderlyingMatrix, morphism_attr_1_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), Range( deduped_10_1 ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3749,19 +3749,19 @@ end
 ########
 function ( cat_1, morphisms_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := morphisms_1[1];
-    deduped_11_1 := Length( morphisms_1 );
-    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_12_1 := Length( morphisms_1 );
+    deduped_11_1 := UnderlyingRing( cat_1 );
+    deduped_10_1 := morphisms_1[1];
     deduped_9_1 := List( morphisms_1, function ( logic_new_func_x_2 )
             return Dimension( Range( logic_new_func_x_2 ) );
         end );
     deduped_8_1 := Sum( deduped_9_1 );
     deduped_7_1 := Sum( deduped_9_1{[ 1 .. 1 - 1 ]} ) + 1;
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
+    hoisted_5_1 := deduped_12_1;
+    hoisted_4_1 := deduped_11_1;
     hoisted_3_1 := List( morphisms_1, Range );
     hoisted_2_1 := deduped_9_1;
-    deduped_6_1 := List( [ 1 .. deduped_11_1 ], function ( logic_new_func_x_2 )
+    deduped_6_1 := List( [ 1 .. deduped_12_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_2_1[logic_new_func_x_2];
             return UnderlyingMatrix( morphisms_1[logic_new_func_x_2] ) * UnionOfColumns( HomalgZeroMatrix( deduped_1_2, Sum( hoisted_3_1{[ 1 .. (logic_new_func_x_2 - 1) ]}, function ( c_3 )
@@ -3770,9 +3770,9 @@ function ( cat_1, morphisms_1 )
                           return Dimension( c_3 );
                       end ), hoisted_4_1 ) );
         end );
-    morphism_attr_1_1 := UnderlyingMatrix( deduped_12_1 ) * CertainRows( SyzygiesOfColumns( (UnionOfRows( deduped_10_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_11_1 - 1 ]} ) + -1 * UnionOfRows( deduped_10_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_11_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] );
+    morphism_attr_1_1 := UnderlyingMatrix( deduped_10_1 ) * CertainRows( SyzygiesOfColumns( (UnionOfRows( deduped_11_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_12_1 - 1 ]} ) + -1 * UnionOfRows( deduped_11_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_12_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( deduped_12_1 ), ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, Source( deduped_10_1 ), ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
@@ -3785,19 +3785,19 @@ end
 ########
 function ( cat_1, morphisms_1, P_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := morphisms_1[1];
-    deduped_11_1 := Length( morphisms_1 );
-    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_12_1 := Length( morphisms_1 );
+    deduped_11_1 := UnderlyingRing( cat_1 );
+    deduped_10_1 := morphisms_1[1];
     deduped_9_1 := List( morphisms_1, function ( logic_new_func_x_2 )
             return Dimension( Range( logic_new_func_x_2 ) );
         end );
     deduped_8_1 := Sum( deduped_9_1 );
     deduped_7_1 := Sum( deduped_9_1{[ 1 .. 1 - 1 ]} ) + 1;
-    hoisted_5_1 := deduped_11_1;
-    hoisted_4_1 := deduped_10_1;
+    hoisted_5_1 := deduped_12_1;
+    hoisted_4_1 := deduped_11_1;
     hoisted_3_1 := List( morphisms_1, Range );
     hoisted_2_1 := deduped_9_1;
-    deduped_6_1 := List( [ 1 .. deduped_11_1 ], function ( logic_new_func_x_2 )
+    deduped_6_1 := List( [ 1 .. deduped_12_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_2_1[logic_new_func_x_2];
             return UnderlyingMatrix( morphisms_1[logic_new_func_x_2] ) * UnionOfColumns( HomalgZeroMatrix( deduped_1_2, Sum( hoisted_3_1{[ 1 .. (logic_new_func_x_2 - 1) ]}, function ( c_3 )
@@ -3806,9 +3806,9 @@ function ( cat_1, morphisms_1, P_1 )
                           return Dimension( c_3 );
                       end ), hoisted_4_1 ) );
         end );
-    morphism_attr_1_1 := UnderlyingMatrix( deduped_12_1 ) * CertainRows( SyzygiesOfColumns( (UnionOfRows( deduped_10_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_11_1 - 1 ]} ) + -1 * UnionOfRows( deduped_10_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_11_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] );
+    morphism_attr_1_1 := UnderlyingMatrix( deduped_10_1 ) * CertainRows( SyzygiesOfColumns( (UnionOfRows( deduped_11_1, deduped_8_1, deduped_6_1{[ 1 .. deduped_12_1 - 1 ]} ) + -1 * UnionOfRows( deduped_11_1, deduped_8_1, deduped_6_1{[ 2 .. deduped_12_1 ]} )) ), [ deduped_7_1 .. (deduped_7_1 - 1 + deduped_9_1[1]) ] );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, Source( deduped_12_1 ), ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, Source( deduped_10_1 ), ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
@@ -3936,17 +3936,17 @@ end
 ########
 function ( cat_1, objects_1, k_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_2_1, deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ) );
+            end ), deduped_2_1, deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_4_1, UnderlyingMatrix, morphism_attr_1_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_3_1, UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3958,17 +3958,17 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_2_1, deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ) );
+            end ), deduped_2_1, deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_4_1, UnderlyingMatrix, morphism_attr_1_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_3_1, UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -3980,17 +3980,17 @@ end
 ########
 function ( cat_1, objects_1, k_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := objects_1[k_1];
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := Dimension( deduped_4_1 );
+    deduped_4_1 := UnderlyingRing( cat_1 );
+    deduped_3_1 := objects_1[k_1];
+    deduped_2_1 := Dimension( deduped_3_1 );
     morphism_attr_1_1 := UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_3_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+            end ), deduped_2_1, deduped_4_1 ), HomalgIdentityMatrix( deduped_2_1, deduped_4_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                 return Dimension( c_2 );
-            end ), deduped_2_1, deduped_3_1 ) );
+            end ), deduped_2_1, deduped_4_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
-             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_4_1, UnderlyingMatrix, morphism_attr_1_1 );
+             ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), deduped_3_1, UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         
@@ -4002,15 +4002,15 @@ end
 ########
 function ( cat_1, objects_1, k_1, P_1 )
     local deduped_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := objects_1[k_1];
-    deduped_2_1 := UnderlyingRing( cat_1 );
-    deduped_1_1 := Dimension( deduped_3_1 );
+    deduped_3_1 := UnderlyingRing( cat_1 );
+    deduped_2_1 := objects_1[k_1];
+    deduped_1_1 := Dimension( deduped_2_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-           ), cat_1, P_1, deduped_3_1, UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
+           ), cat_1, P_1, deduped_2_1, UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( objects_1{[ 1 .. k_1 - 1 ]}, function ( c_2 )
                   return Dimension( c_2 );
-              end ), deduped_1_1, deduped_2_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_2_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
+              end ), deduped_1_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_3_1 ), HomalgZeroMatrix( Sum( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( c_2 )
                   return Dimension( c_2 );
-              end ), deduped_1_1, deduped_2_1 ) ) );
+              end ), deduped_1_1, deduped_3_1 ) ) );
 end
 ########
         
@@ -4254,32 +4254,32 @@ function ( cat_1, a_1 )
     local morphism_attr_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
     deduped_9_1 := UnderlyingRing( cat_1 );
     deduped_8_1 := Dimension( a_1 );
-    deduped_7_1 := deduped_8_1 * 1;
-    deduped_6_1 := deduped_8_1 * deduped_8_1;
-    deduped_5_1 := deduped_8_1 = 0;
-    deduped_4_1 := HomalgIdentityMatrix( 1, deduped_9_1 );
-    deduped_3_1 := HomalgIdentityMatrix( deduped_8_1, deduped_9_1 );
+    deduped_7_1 := deduped_8_1 = 0;
+    deduped_6_1 := deduped_8_1 * 1;
+    deduped_5_1 := HomalgIdentityMatrix( 1, deduped_9_1 );
+    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_9_1 );
+    deduped_3_1 := deduped_8_1 * deduped_8_1;
     hoisted_2_1 := deduped_8_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                      if deduped_5_1 then
-                          return HomalgZeroMatrix( 1, deduped_6_1, deduped_9_1 );
+                      if deduped_7_1 then
+                          return HomalgZeroMatrix( 1, deduped_3_1, deduped_9_1 );
                       else
-                          return ConvertMatrixToRow( deduped_3_1 );
+                          return ConvertMatrixToRow( deduped_4_1 );
                       fi;
                       return;
-                  end(  ), deduped_4_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+                  end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
                             local deduped_1_2;
                             deduped_1_2 := (i_2 - 1);
                             return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                        end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_9_1 ), deduped_4_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+                        end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, deduped_9_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, 1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                      end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_9_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), deduped_3_1 ) * function (  )
-              if deduped_5_1 then
-                  return HomalgZeroMatrix( deduped_6_1, 1, deduped_9_1 );
+                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_9_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), deduped_4_1 ) * function (  )
+              if deduped_7_1 then
+                  return HomalgZeroMatrix( deduped_3_1, 1, deduped_9_1 );
               else
-                  return ConvertMatrixToColumn( deduped_3_1 );
+                  return ConvertMatrixToColumn( deduped_4_1 );
               fi;
               return;
           end(  );
@@ -4462,17 +4462,17 @@ end
 ########
 function ( cat_1, arg2_1, arg3_1, arg4_1 )
     local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := arg2_1[1];
-    deduped_9_1 := UnderlyingRing( cat_1 );
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := arg2_1[1];
     deduped_8_1 := [ 1 .. Length( arg2_1 ) ];
-    deduped_7_1 := [ 1 .. Length( deduped_10_1 ) ];
-    hoisted_4_1 := deduped_9_1;
+    deduped_7_1 := [ 1 .. Length( deduped_9_1 ) ];
+    hoisted_4_1 := deduped_10_1;
     hoisted_3_1 := deduped_8_1;
     hoisted_2_1 := arg3_1[1];
-    hoisted_1_1 := deduped_10_1;
-    hoisted_6_1 := RightDivide( UnionOfColumns( deduped_9_1, 1, List( deduped_8_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := deduped_9_1;
+    hoisted_6_1 := RightDivide( UnionOfColumns( deduped_10_1, 1, List( deduped_8_1, function ( logic_new_func_x_2 )
                 return ConvertMatrixToRow( UnderlyingMatrix( arg4_1[logic_new_func_x_2] ) );
-            end ) ), UnionOfRows( deduped_9_1, Sum( List( deduped_8_1, function ( logic_new_func_x_2 )
+            end ) ), UnionOfRows( deduped_10_1, Sum( List( deduped_8_1, function ( logic_new_func_x_2 )
                   return Dimension( Source( arg2_1[logic_new_func_x_2][1] ) ) * Dimension( Range( arg3_1[logic_new_func_x_2][1] ) );
               end ) ), List( deduped_7_1, function ( logic_new_func_x_2 )
                 return UnionOfColumns( hoisted_4_1, Dimension( Range( hoisted_1_1[logic_new_func_x_2] ) ) * Dimension( Source( hoisted_2_1[logic_new_func_x_2] ) ), List( hoisted_3_1, function ( logic_new_func_x_3 )
@@ -4586,64 +4586,64 @@ function ( cat_1, a_1, b_1 )
     deduped_23_1 := UnderlyingRing( cat_1 );
     deduped_22_1 := Dimension( b_1 );
     deduped_21_1 := Dimension( a_1 );
-    deduped_20_1 := deduped_22_1 * 1;
-    deduped_19_1 := deduped_21_1 * 1;
-    deduped_18_1 := deduped_21_1 * deduped_22_1;
-    deduped_17_1 := deduped_20_1 * deduped_21_1;
-    deduped_16_1 := deduped_18_1 * deduped_18_1;
-    deduped_15_1 := deduped_19_1 * deduped_20_1;
-    deduped_14_1 := HomalgIdentityMatrix( 1, deduped_23_1 );
-    deduped_13_1 := HomalgIdentityMatrix( deduped_22_1, deduped_23_1 );
-    deduped_12_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
-    deduped_11_1 := deduped_18_1 * deduped_15_1;
-    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_19_1, deduped_23_1 );
-    deduped_8_1 := HomalgIdentityMatrix( deduped_18_1, deduped_23_1 );
-    deduped_7_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_20_1 := HomalgIdentityMatrix( 1, deduped_23_1 );
+    deduped_19_1 := HomalgIdentityMatrix( deduped_22_1, deduped_23_1 );
+    deduped_18_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
+    deduped_17_1 := deduped_22_1 * 1;
+    deduped_16_1 := deduped_21_1 * 1;
+    deduped_15_1 := deduped_21_1 * deduped_22_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_17_1, deduped_23_1 );
+    deduped_13_1 := deduped_17_1 * deduped_21_1;
+    deduped_12_1 := HomalgIdentityMatrix( deduped_16_1, deduped_23_1 );
+    deduped_11_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_10_1 := deduped_15_1 * deduped_15_1;
+    deduped_9_1 := deduped_16_1 * deduped_17_1;
+    deduped_8_1 := deduped_15_1 * deduped_9_1;
+    deduped_7_1 := HomalgIdentityMatrix( deduped_9_1, deduped_23_1 );
     hoisted_6_1 := deduped_22_1;
-    hoisted_5_1 := deduped_20_1;
+    hoisted_5_1 := deduped_17_1;
     hoisted_4_1 := deduped_21_1;
-    hoisted_3_1 := deduped_15_1;
-    hoisted_2_1 := deduped_18_1;
-    morphism_attr_1_1 := KroneckerMat( deduped_12_1, deduped_13_1 ) * (KroneckerMat( function (  )
-                      if (deduped_18_1 = 0) then
-                          return HomalgZeroMatrix( 1, deduped_16_1, deduped_23_1 );
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_15_1;
+    morphism_attr_1_1 := KroneckerMat( deduped_18_1, deduped_19_1 ) * (KroneckerMat( function (  )
+                      if (deduped_15_1 = 0) then
+                          return HomalgZeroMatrix( 1, deduped_10_1, deduped_23_1 );
                       else
-                          return ConvertMatrixToRow( deduped_8_1 );
+                          return ConvertMatrixToRow( deduped_11_1 );
                       fi;
                       return;
-                  end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
+                  end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                             local deduped_1_2;
                             deduped_1_2 := (i_2 - 1);
                             return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                        end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_8_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
+                        end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                      end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_8_1 ), (KroneckerMat( KroneckerMat( deduped_9_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( KroneckerMat( deduped_12_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                            end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ) ), deduped_13_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_9_1, deduped_12_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                            end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_23_1 ) ), deduped_19_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_12_1, deduped_18_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                                       local deduped_1_2;
                                       deduped_1_2 := (i_2 - 1);
                                       return (REM_INT( deduped_1_2, 1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                                  end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_23_1 ), deduped_12_1 ) * KroneckerMat( deduped_14_1, function (  )
+                                  end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_18_1 ) * KroneckerMat( deduped_20_1, function (  )
                               if (deduped_21_1 = 0) then
                                   return HomalgZeroMatrix( (deduped_21_1 * deduped_21_1), 1, deduped_23_1 );
                               else
-                                  return ConvertMatrixToColumn( deduped_12_1 );
+                                  return ConvertMatrixToColumn( deduped_18_1 );
                               fi;
                               return;
-                          end(  ) )), deduped_10_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, (KroneckerMat( deduped_10_1, deduped_13_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                          end(  ) )), deduped_14_1 ), deduped_19_1 ) * KroneckerMat( deduped_20_1, (KroneckerMat( deduped_14_1, deduped_19_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
                                   local deduped_1_2;
                                   deduped_1_2 := (i_2 - 1);
                                   return (REM_INT( deduped_1_2, 1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                              end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_23_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, function (  )
+                              end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ), deduped_19_1 ) * KroneckerMat( deduped_20_1, function (  )
                           if (deduped_22_1 = 0) then
                               return HomalgZeroMatrix( (deduped_22_1 * deduped_22_1), 1, deduped_23_1 );
                           else
-                              return ConvertMatrixToColumn( deduped_13_1 );
+                              return ConvertMatrixToColumn( deduped_19_1 );
                           fi;
                           return;
                       end(  ) )) )) ));
@@ -4665,64 +4665,64 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
     deduped_23_1 := UnderlyingRing( cat_1 );
     deduped_22_1 := Dimension( b_1 );
     deduped_21_1 := Dimension( a_1 );
-    deduped_20_1 := deduped_22_1 * 1;
-    deduped_19_1 := deduped_21_1 * 1;
-    deduped_18_1 := deduped_21_1 * deduped_22_1;
-    deduped_17_1 := deduped_20_1 * deduped_21_1;
-    deduped_16_1 := deduped_18_1 * deduped_18_1;
-    deduped_15_1 := deduped_19_1 * deduped_20_1;
-    deduped_14_1 := HomalgIdentityMatrix( 1, deduped_23_1 );
-    deduped_13_1 := HomalgIdentityMatrix( deduped_22_1, deduped_23_1 );
-    deduped_12_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
-    deduped_11_1 := deduped_18_1 * deduped_15_1;
-    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_23_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_19_1, deduped_23_1 );
-    deduped_8_1 := HomalgIdentityMatrix( deduped_18_1, deduped_23_1 );
-    deduped_7_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_20_1 := HomalgIdentityMatrix( 1, deduped_23_1 );
+    deduped_19_1 := HomalgIdentityMatrix( deduped_22_1, deduped_23_1 );
+    deduped_18_1 := HomalgIdentityMatrix( deduped_21_1, deduped_23_1 );
+    deduped_17_1 := deduped_22_1 * 1;
+    deduped_16_1 := deduped_21_1 * 1;
+    deduped_15_1 := deduped_21_1 * deduped_22_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_17_1, deduped_23_1 );
+    deduped_13_1 := deduped_17_1 * deduped_21_1;
+    deduped_12_1 := HomalgIdentityMatrix( deduped_16_1, deduped_23_1 );
+    deduped_11_1 := HomalgIdentityMatrix( deduped_15_1, deduped_23_1 );
+    deduped_10_1 := deduped_15_1 * deduped_15_1;
+    deduped_9_1 := deduped_16_1 * deduped_17_1;
+    deduped_8_1 := deduped_15_1 * deduped_9_1;
+    deduped_7_1 := HomalgIdentityMatrix( deduped_9_1, deduped_23_1 );
     hoisted_6_1 := deduped_22_1;
-    hoisted_5_1 := deduped_20_1;
+    hoisted_5_1 := deduped_17_1;
     hoisted_4_1 := deduped_21_1;
-    hoisted_3_1 := deduped_15_1;
-    hoisted_2_1 := deduped_18_1;
-    morphism_attr_1_1 := KroneckerMat( deduped_12_1, deduped_13_1 ) * (KroneckerMat( function (  )
-                      if (deduped_18_1 = 0) then
-                          return HomalgZeroMatrix( 1, deduped_16_1, deduped_23_1 );
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_15_1;
+    morphism_attr_1_1 := KroneckerMat( deduped_18_1, deduped_19_1 ) * (KroneckerMat( function (  )
+                      if (deduped_15_1 = 0) then
+                          return HomalgZeroMatrix( 1, deduped_10_1, deduped_23_1 );
                       else
-                          return ConvertMatrixToRow( deduped_8_1 );
+                          return ConvertMatrixToRow( deduped_11_1 );
                       fi;
                       return;
-                  end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
+                  end(  ), deduped_7_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                             local deduped_1_2;
                             deduped_1_2 := (i_2 - 1);
                             return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                        end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_8_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
+                        end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_23_1 ), deduped_7_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_8_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                      end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_8_1 ), (KroneckerMat( KroneckerMat( deduped_9_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                      end ) ), deduped_8_1 ), deduped_8_1, deduped_8_1, deduped_23_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( KroneckerMat( deduped_12_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                            end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ) ), deduped_13_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_9_1, deduped_12_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                            end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_23_1 ) ), deduped_19_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_12_1, deduped_18_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                                       local deduped_1_2;
                                       deduped_1_2 := (i_2 - 1);
                                       return (REM_INT( deduped_1_2, 1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                                  end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_23_1 ), deduped_12_1 ) * KroneckerMat( deduped_14_1, function (  )
+                                  end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_23_1 ), deduped_18_1 ) * KroneckerMat( deduped_20_1, function (  )
                               if (deduped_21_1 = 0) then
                                   return HomalgZeroMatrix( (deduped_21_1 * deduped_21_1), 1, deduped_23_1 );
                               else
-                                  return ConvertMatrixToColumn( deduped_12_1 );
+                                  return ConvertMatrixToColumn( deduped_18_1 );
                               fi;
                               return;
-                          end(  ) )), deduped_10_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, (KroneckerMat( deduped_10_1, deduped_13_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                          end(  ) )), deduped_14_1 ), deduped_19_1 ) * KroneckerMat( deduped_20_1, (KroneckerMat( deduped_14_1, deduped_19_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
                                   local deduped_1_2;
                                   deduped_1_2 := (i_2 - 1);
                                   return (REM_INT( deduped_1_2, 1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                              end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_23_1 ), deduped_13_1 ) * KroneckerMat( deduped_14_1, function (  )
+                              end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_23_1 ), deduped_19_1 ) * KroneckerMat( deduped_20_1, function (  )
                           if (deduped_22_1 = 0) then
                               return HomalgZeroMatrix( (deduped_22_1 * deduped_22_1), 1, deduped_23_1 );
                           else
-                              return ConvertMatrixToColumn( deduped_13_1 );
+                              return ConvertMatrixToColumn( deduped_19_1 );
                           fi;
                           return;
                       end(  ) )) )) ));
@@ -4746,66 +4746,66 @@ function ( cat_1, list_1 )
     deduped_25_1 := Dimension( list_1[2] );
     deduped_24_1 := Dimension( list_1[3] );
     deduped_23_1 := Dimension( list_1[1] );
-    deduped_22_1 := deduped_24_1 * deduped_26_1;
-    deduped_21_1 := deduped_23_1 * deduped_25_1;
-    deduped_20_1 := deduped_23_1 * deduped_24_1;
-    deduped_19_1 := deduped_22_1 * deduped_23_1;
-    deduped_18_1 := deduped_20_1 * deduped_20_1;
-    deduped_17_1 := deduped_21_1 * deduped_22_1;
-    deduped_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
-    deduped_15_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
-    deduped_14_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
-    deduped_13_1 := deduped_20_1 * deduped_17_1;
-    deduped_12_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_21_1, deduped_27_1 );
-    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_27_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
+    deduped_22_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
+    deduped_21_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
+    deduped_20_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
+    deduped_19_1 := deduped_24_1 * deduped_26_1;
+    deduped_18_1 := deduped_23_1 * deduped_25_1;
+    deduped_17_1 := deduped_23_1 * deduped_24_1;
+    deduped_16_1 := HomalgIdentityMatrix( deduped_19_1, deduped_27_1 );
+    deduped_15_1 := deduped_19_1 * deduped_23_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_18_1, deduped_27_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
+    deduped_12_1 := deduped_17_1 * deduped_17_1;
+    deduped_11_1 := deduped_18_1 * deduped_19_1;
+    deduped_10_1 := deduped_17_1 * deduped_11_1;
+    deduped_9_1 := HomalgIdentityMatrix( deduped_11_1, deduped_27_1 );
     hoisted_8_1 := deduped_24_1;
     hoisted_7_1 := deduped_26_1;
     hoisted_6_1 := deduped_25_1;
-    hoisted_5_1 := deduped_22_1;
+    hoisted_5_1 := deduped_19_1;
     hoisted_4_1 := deduped_23_1;
-    hoisted_3_1 := deduped_17_1;
-    hoisted_2_1 := deduped_20_1;
+    hoisted_3_1 := deduped_11_1;
+    hoisted_2_1 := deduped_17_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if (deduped_20_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_18_1, deduped_27_1 );
+                    if (deduped_17_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_12_1, deduped_27_1 );
                     else
-                        return ConvertMatrixToRow( deduped_10_1 );
+                        return ConvertMatrixToRow( deduped_13_1 );
                     fi;
                     return;
-                end(  ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+                end(  ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_12_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_9_1 ) * KroneckerMat( deduped_10_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
+                      end ) ), deduped_12_1 ), deduped_12_1, deduped_12_1, deduped_27_1 ), deduped_9_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_27_1 ) ) * KroneckerMat( TransposedMatrix( deduped_10_1 ), (KroneckerMat( KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_27_1 ) ), deduped_14_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_11_1, deduped_15_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_21_1 ], function ( i_2 )
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_14_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_21_1 ), deduped_21_1, deduped_21_1, deduped_27_1 ), deduped_15_1 ) * KroneckerMat( deduped_16_1, function (  )
+                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( deduped_22_1, function (  )
                             if (deduped_23_1 = 0) then
                                 return HomalgZeroMatrix( (deduped_23_1 * deduped_23_1), 1, deduped_27_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_15_1 );
+                                return ConvertMatrixToColumn( deduped_21_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_12_1 ), deduped_14_1 ) * KroneckerMat( deduped_16_1, (KroneckerMat( deduped_12_1, deduped_14_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_22_1 ], function ( i_2 )
+                        end(  ) )), deduped_16_1 ), deduped_20_1 ) * KroneckerMat( deduped_22_1, (KroneckerMat( deduped_16_1, deduped_20_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_22_1 ), deduped_22_1, deduped_22_1, deduped_27_1 ), deduped_14_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_27_1 ), function (  )
+                            end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_27_1 ), function (  )
                         if (deduped_24_1 = 0) then
                             return HomalgZeroMatrix( (deduped_24_1 * deduped_24_1), 1, deduped_27_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_14_1 );
+                            return ConvertMatrixToColumn( deduped_20_1 );
                         fi;
                         return;
                     end(  ) )) )) );
@@ -4829,66 +4829,66 @@ function ( cat_1, list_1 )
     deduped_26_1 := Dimension( list_1[2] );
     deduped_25_1 := Dimension( list_1[3] );
     deduped_24_1 := Dimension( list_1[1] );
-    deduped_23_1 := deduped_25_1 * deduped_27_1;
-    deduped_22_1 := deduped_24_1 * deduped_26_1;
-    deduped_21_1 := deduped_24_1 * deduped_25_1;
-    deduped_20_1 := deduped_23_1 * deduped_24_1;
-    deduped_19_1 := deduped_21_1 * deduped_21_1;
-    deduped_18_1 := deduped_22_1 * deduped_23_1;
-    deduped_17_1 := HomalgIdentityMatrix( deduped_26_1, deduped_28_1 );
-    deduped_16_1 := HomalgIdentityMatrix( deduped_24_1, deduped_28_1 );
-    deduped_15_1 := HomalgIdentityMatrix( deduped_25_1, deduped_28_1 );
-    deduped_14_1 := deduped_21_1 * deduped_18_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_23_1, deduped_28_1 );
-    deduped_12_1 := HomalgIdentityMatrix( deduped_22_1, deduped_28_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_21_1, deduped_28_1 );
-    deduped_10_1 := HomalgIdentityMatrix( deduped_18_1, deduped_28_1 );
+    deduped_23_1 := HomalgIdentityMatrix( deduped_26_1, deduped_28_1 );
+    deduped_22_1 := HomalgIdentityMatrix( deduped_24_1, deduped_28_1 );
+    deduped_21_1 := HomalgIdentityMatrix( deduped_25_1, deduped_28_1 );
+    deduped_20_1 := deduped_25_1 * deduped_27_1;
+    deduped_19_1 := deduped_24_1 * deduped_26_1;
+    deduped_18_1 := deduped_24_1 * deduped_25_1;
+    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_28_1 );
+    deduped_16_1 := deduped_20_1 * deduped_24_1;
+    deduped_15_1 := HomalgIdentityMatrix( deduped_19_1, deduped_28_1 );
+    deduped_14_1 := HomalgIdentityMatrix( deduped_18_1, deduped_28_1 );
+    deduped_13_1 := deduped_18_1 * deduped_18_1;
+    deduped_12_1 := deduped_19_1 * deduped_20_1;
+    deduped_11_1 := deduped_18_1 * deduped_12_1;
+    deduped_10_1 := HomalgIdentityMatrix( deduped_12_1, deduped_28_1 );
     hoisted_8_1 := deduped_25_1;
     hoisted_7_1 := deduped_27_1;
     hoisted_6_1 := deduped_26_1;
-    hoisted_5_1 := deduped_23_1;
+    hoisted_5_1 := deduped_20_1;
     hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_18_1;
-    hoisted_2_1 := deduped_21_1;
+    hoisted_3_1 := deduped_12_1;
+    hoisted_2_1 := deduped_18_1;
     deduped_9_1 := KroneckerMat( function (  )
-                    if (deduped_21_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_19_1, deduped_28_1 );
+                    if (deduped_18_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_13_1, deduped_28_1 );
                     else
-                        return ConvertMatrixToRow( deduped_11_1 );
+                        return ConvertMatrixToRow( deduped_14_1 );
                     fi;
                     return;
-                end(  ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                end(  ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_28_1 ), deduped_10_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                      end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_28_1 ), deduped_10_1 ) * KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_28_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( KroneckerMat( deduped_12_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                    end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_28_1 ) ) * KroneckerMat( TransposedMatrix( deduped_14_1 ), (KroneckerMat( KroneckerMat( deduped_15_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_28_1 ) ), deduped_15_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_12_1, deduped_16_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_22_1 ], function ( i_2 )
+                          end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_28_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_15_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_22_1 ), deduped_22_1, deduped_22_1, deduped_28_1 ), deduped_16_1 ) * KroneckerMat( deduped_17_1, function (  )
+                                end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_28_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, function (  )
                             if (deduped_24_1 = 0) then
                                 return HomalgZeroMatrix( (deduped_24_1 * deduped_24_1), 1, deduped_28_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_16_1 );
+                                return ConvertMatrixToColumn( deduped_22_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_13_1 ), deduped_15_1 ) * KroneckerMat( deduped_17_1, (KroneckerMat( deduped_13_1, deduped_15_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_23_1 ], function ( i_2 )
+                        end(  ) )), deduped_17_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_17_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_23_1 ), deduped_23_1, deduped_23_1, deduped_28_1 ), deduped_15_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_28_1 ), function (  )
+                            end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_28_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_28_1 ), function (  )
                         if (deduped_25_1 = 0) then
                             return HomalgZeroMatrix( (deduped_25_1 * deduped_25_1), 1, deduped_28_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_15_1 );
+                            return ConvertMatrixToColumn( deduped_21_1 );
                         fi;
                         return;
                     end(  ) )) )) );
@@ -4913,66 +4913,66 @@ function ( cat_1, source_1, list_1, range_1 )
     deduped_26_1 := Dimension( list_1[2] );
     deduped_25_1 := Dimension( list_1[3] );
     deduped_24_1 := Dimension( list_1[1] );
-    deduped_23_1 := deduped_25_1 * deduped_27_1;
-    deduped_22_1 := deduped_24_1 * deduped_26_1;
-    deduped_21_1 := deduped_24_1 * deduped_25_1;
-    deduped_20_1 := deduped_23_1 * deduped_24_1;
-    deduped_19_1 := deduped_21_1 * deduped_21_1;
-    deduped_18_1 := deduped_22_1 * deduped_23_1;
-    deduped_17_1 := HomalgIdentityMatrix( deduped_26_1, deduped_28_1 );
-    deduped_16_1 := HomalgIdentityMatrix( deduped_24_1, deduped_28_1 );
-    deduped_15_1 := HomalgIdentityMatrix( deduped_25_1, deduped_28_1 );
-    deduped_14_1 := deduped_21_1 * deduped_18_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_23_1, deduped_28_1 );
-    deduped_12_1 := HomalgIdentityMatrix( deduped_22_1, deduped_28_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_21_1, deduped_28_1 );
-    deduped_10_1 := HomalgIdentityMatrix( deduped_18_1, deduped_28_1 );
+    deduped_23_1 := HomalgIdentityMatrix( deduped_26_1, deduped_28_1 );
+    deduped_22_1 := HomalgIdentityMatrix( deduped_24_1, deduped_28_1 );
+    deduped_21_1 := HomalgIdentityMatrix( deduped_25_1, deduped_28_1 );
+    deduped_20_1 := deduped_25_1 * deduped_27_1;
+    deduped_19_1 := deduped_24_1 * deduped_26_1;
+    deduped_18_1 := deduped_24_1 * deduped_25_1;
+    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_28_1 );
+    deduped_16_1 := deduped_20_1 * deduped_24_1;
+    deduped_15_1 := HomalgIdentityMatrix( deduped_19_1, deduped_28_1 );
+    deduped_14_1 := HomalgIdentityMatrix( deduped_18_1, deduped_28_1 );
+    deduped_13_1 := deduped_18_1 * deduped_18_1;
+    deduped_12_1 := deduped_19_1 * deduped_20_1;
+    deduped_11_1 := deduped_18_1 * deduped_12_1;
+    deduped_10_1 := HomalgIdentityMatrix( deduped_12_1, deduped_28_1 );
     hoisted_8_1 := deduped_25_1;
     hoisted_7_1 := deduped_27_1;
     hoisted_6_1 := deduped_26_1;
-    hoisted_5_1 := deduped_23_1;
+    hoisted_5_1 := deduped_20_1;
     hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_18_1;
-    hoisted_2_1 := deduped_21_1;
+    hoisted_3_1 := deduped_12_1;
+    hoisted_2_1 := deduped_18_1;
     deduped_9_1 := KroneckerMat( function (  )
-                    if (deduped_21_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_19_1, deduped_28_1 );
+                    if (deduped_18_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_13_1, deduped_28_1 );
                     else
-                        return ConvertMatrixToRow( deduped_11_1 );
+                        return ConvertMatrixToRow( deduped_14_1 );
                     fi;
                     return;
-                end(  ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                end(  ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_28_1 ), deduped_10_1 ) * KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                      end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_28_1 ), deduped_10_1 ) * KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_28_1 ) ) * KroneckerMat( TransposedMatrix( deduped_11_1 ), (KroneckerMat( KroneckerMat( deduped_12_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                    end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_28_1 ) ) * KroneckerMat( TransposedMatrix( deduped_14_1 ), (KroneckerMat( KroneckerMat( deduped_15_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_28_1 ) ), deduped_15_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_12_1, deduped_16_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_22_1 ], function ( i_2 )
+                          end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_28_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_15_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_22_1 ), deduped_22_1, deduped_22_1, deduped_28_1 ), deduped_16_1 ) * KroneckerMat( deduped_17_1, function (  )
+                                end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_28_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, function (  )
                             if (deduped_24_1 = 0) then
                                 return HomalgZeroMatrix( (deduped_24_1 * deduped_24_1), 1, deduped_28_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_16_1 );
+                                return ConvertMatrixToColumn( deduped_22_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_13_1 ), deduped_15_1 ) * KroneckerMat( deduped_17_1, (KroneckerMat( deduped_13_1, deduped_15_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_23_1 ], function ( i_2 )
+                        end(  ) )), deduped_17_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_17_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_23_1 ), deduped_23_1, deduped_23_1, deduped_28_1 ), deduped_15_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_28_1 ), function (  )
+                            end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_28_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_28_1 ), function (  )
                         if (deduped_25_1 = 0) then
                             return HomalgZeroMatrix( (deduped_25_1 * deduped_25_1), 1, deduped_28_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_15_1 );
+                            return ConvertMatrixToColumn( deduped_21_1 );
                         fi;
                         return;
                     end(  ) )) )) );
@@ -4997,66 +4997,66 @@ function ( cat_1, source_1, list_1, range_1 )
     deduped_25_1 := Dimension( list_1[2] );
     deduped_24_1 := Dimension( list_1[3] );
     deduped_23_1 := Dimension( list_1[1] );
-    deduped_22_1 := deduped_24_1 * deduped_26_1;
-    deduped_21_1 := deduped_23_1 * deduped_25_1;
-    deduped_20_1 := deduped_23_1 * deduped_24_1;
-    deduped_19_1 := deduped_22_1 * deduped_23_1;
-    deduped_18_1 := deduped_20_1 * deduped_20_1;
-    deduped_17_1 := deduped_21_1 * deduped_22_1;
-    deduped_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
-    deduped_15_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
-    deduped_14_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
-    deduped_13_1 := deduped_20_1 * deduped_17_1;
-    deduped_12_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
-    deduped_11_1 := HomalgIdentityMatrix( deduped_21_1, deduped_27_1 );
-    deduped_10_1 := HomalgIdentityMatrix( deduped_20_1, deduped_27_1 );
-    deduped_9_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
+    deduped_22_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
+    deduped_21_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
+    deduped_20_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
+    deduped_19_1 := deduped_24_1 * deduped_26_1;
+    deduped_18_1 := deduped_23_1 * deduped_25_1;
+    deduped_17_1 := deduped_23_1 * deduped_24_1;
+    deduped_16_1 := HomalgIdentityMatrix( deduped_19_1, deduped_27_1 );
+    deduped_15_1 := deduped_19_1 * deduped_23_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_18_1, deduped_27_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
+    deduped_12_1 := deduped_17_1 * deduped_17_1;
+    deduped_11_1 := deduped_18_1 * deduped_19_1;
+    deduped_10_1 := deduped_17_1 * deduped_11_1;
+    deduped_9_1 := HomalgIdentityMatrix( deduped_11_1, deduped_27_1 );
     hoisted_8_1 := deduped_24_1;
     hoisted_7_1 := deduped_26_1;
     hoisted_6_1 := deduped_25_1;
-    hoisted_5_1 := deduped_22_1;
+    hoisted_5_1 := deduped_19_1;
     hoisted_4_1 := deduped_23_1;
-    hoisted_3_1 := deduped_17_1;
-    hoisted_2_1 := deduped_20_1;
+    hoisted_3_1 := deduped_11_1;
+    hoisted_2_1 := deduped_17_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                    if (deduped_20_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_18_1, deduped_27_1 );
+                    if (deduped_17_1 = 0) then
+                        return HomalgZeroMatrix( 1, deduped_12_1, deduped_27_1 );
                     else
-                        return ConvertMatrixToRow( deduped_10_1 );
+                        return ConvertMatrixToRow( deduped_13_1 );
                     fi;
                     return;
-                end(  ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+                end(  ), deduped_9_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_12_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_9_1 ) * KroneckerMat( deduped_10_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_13_1 ], function ( i_2 )
+                      end ) ), deduped_12_1 ), deduped_12_1, deduped_12_1, deduped_27_1 ), deduped_9_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_13_1 ), deduped_13_1, deduped_13_1, deduped_27_1 ) ) * KroneckerMat( TransposedMatrix( deduped_10_1 ), (KroneckerMat( KroneckerMat( deduped_11_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
+                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
                               return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_27_1 ) ), deduped_14_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_11_1, deduped_15_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_21_1 ], function ( i_2 )
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_14_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_21_1 ), deduped_21_1, deduped_21_1, deduped_27_1 ), deduped_15_1 ) * KroneckerMat( deduped_16_1, function (  )
+                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( deduped_22_1, function (  )
                             if (deduped_23_1 = 0) then
                                 return HomalgZeroMatrix( (deduped_23_1 * deduped_23_1), 1, deduped_27_1 );
                             else
-                                return ConvertMatrixToColumn( deduped_15_1 );
+                                return ConvertMatrixToColumn( deduped_21_1 );
                             fi;
                             return;
-                        end(  ) )), deduped_12_1 ), deduped_14_1 ) * KroneckerMat( deduped_16_1, (KroneckerMat( deduped_12_1, deduped_14_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_22_1 ], function ( i_2 )
+                        end(  ) )), deduped_16_1 ), deduped_20_1 ) * KroneckerMat( deduped_22_1, (KroneckerMat( deduped_16_1, deduped_20_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
                                 local deduped_1_2;
                                 deduped_1_2 := (i_2 - 1);
                                 return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_22_1 ), deduped_22_1, deduped_22_1, deduped_27_1 ), deduped_14_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_27_1 ), function (  )
+                            end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_27_1 ), function (  )
                         if (deduped_24_1 = 0) then
                             return HomalgZeroMatrix( (deduped_24_1 * deduped_24_1), 1, deduped_27_1 );
                         else
-                            return ConvertMatrixToColumn( deduped_14_1 );
+                            return ConvertMatrixToColumn( deduped_20_1 );
                         fi;
                         return;
                     end(  ) )) )) );
@@ -5119,27 +5119,27 @@ function ( cat_1, a_1, b_1, f_1 )
     deduped_9_1 := Dimension( a_1 );
     deduped_8_1 := Dimension( b_1 );
     deduped_7_1 := deduped_8_1 * deduped_9_1;
-    deduped_6_1 := deduped_8_1 * deduped_8_1;
-    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_4_1 := deduped_8_1 * deduped_8_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_8_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                     if (deduped_8_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
+                        return HomalgZeroMatrix( 1, deduped_4_1, deduped_10_1 );
                     else
-                        return ConvertMatrixToRow( deduped_4_1 );
+                        return ConvertMatrixToRow( deduped_5_1 );
                     fi;
                     return;
-                end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+                      end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( deduped_5_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( f_1 ) );
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_5_1 ), UnderlyingMatrix( f_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -5210,31 +5210,31 @@ function ( cat_1, alpha_1 )
     deduped_9_1 := UnderlyingRing( cat_1 );
     deduped_8_1 := HomalgIdentityMatrix( 1, deduped_9_1 );
     deduped_7_1 := Dimension( Source( alpha_1 ) );
-    deduped_6_1 := deduped_7_1 * 1;
-    deduped_5_1 := deduped_7_1 * deduped_7_1;
-    deduped_4_1 := deduped_7_1 = 0;
-    deduped_3_1 := HomalgIdentityMatrix( deduped_7_1, deduped_9_1 );
+    deduped_6_1 := deduped_7_1 = 0;
+    deduped_5_1 := deduped_7_1 * 1;
+    deduped_4_1 := HomalgIdentityMatrix( deduped_7_1, deduped_9_1 );
+    deduped_3_1 := deduped_7_1 * deduped_7_1;
     hoisted_2_1 := deduped_7_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
-                      if deduped_4_1 then
-                          return HomalgZeroMatrix( 1, deduped_5_1, deduped_9_1 );
+                      if deduped_6_1 then
+                          return HomalgZeroMatrix( 1, deduped_3_1, deduped_9_1 );
                       else
-                          return ConvertMatrixToRow( deduped_3_1 );
+                          return ConvertMatrixToRow( deduped_4_1 );
                       fi;
                       return;
-                  end(  ), deduped_8_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
+                  end(  ), deduped_8_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_3_1 ], function ( i_2 )
                             local deduped_1_2;
                             deduped_1_2 := (i_2 - 1);
                             return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                        end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_9_1 ), deduped_8_1 ) * KroneckerMat( deduped_3_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+                        end ) ), deduped_3_1 ), deduped_3_1, deduped_3_1, deduped_9_1 ), deduped_8_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_5_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, 1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, 1 ) + 1);
-                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_9_1 ) ) * KroneckerMat( TransposedMatrix( deduped_3_1 ), UnderlyingMatrix( alpha_1 ) ) * function (  )
-              if deduped_4_1 then
-                  return HomalgZeroMatrix( deduped_5_1, 1, deduped_9_1 );
+                      end ) ), deduped_5_1 ), deduped_5_1, deduped_5_1, deduped_9_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( alpha_1 ) ) * function (  )
+              if deduped_6_1 then
+                  return HomalgZeroMatrix( deduped_3_1, 1, deduped_9_1 );
               else
-                  return ConvertMatrixToColumn( deduped_3_1 );
+                  return ConvertMatrixToColumn( deduped_4_1 );
               fi;
               return;
           end(  );
@@ -5703,27 +5703,27 @@ function ( cat_1, t_1, a_1, alpha_1 )
     deduped_9_1 := Dimension( t_1 );
     deduped_8_1 := Dimension( a_1 );
     deduped_7_1 := deduped_8_1 * deduped_9_1;
-    deduped_6_1 := deduped_8_1 * deduped_8_1;
-    deduped_5_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
-    deduped_4_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_6_1 := HomalgIdentityMatrix( deduped_9_1, deduped_10_1 );
+    deduped_5_1 := HomalgIdentityMatrix( deduped_8_1, deduped_10_1 );
+    deduped_4_1 := deduped_8_1 * deduped_8_1;
     hoisted_3_1 := deduped_9_1;
     hoisted_2_1 := deduped_8_1;
     morphism_attr_1_1 := KroneckerMat( function (  )
                     if (deduped_8_1 = 0) then
-                        return HomalgZeroMatrix( 1, deduped_6_1, deduped_10_1 );
+                        return HomalgZeroMatrix( 1, deduped_4_1, deduped_10_1 );
                     else
-                        return ConvertMatrixToRow( deduped_4_1 );
+                        return ConvertMatrixToRow( deduped_5_1 );
                     fi;
                     return;
-                end(  ), deduped_5_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_6_1 ], function ( i_2 )
+                end(  ), deduped_6_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_4_1 ], function ( i_2 )
                           local deduped_1_2;
                           deduped_1_2 := (i_2 - 1);
                           return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_6_1 ), deduped_6_1, deduped_6_1, deduped_10_1 ), deduped_5_1 ) * KroneckerMat( deduped_4_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
+                      end ) ), deduped_4_1 ), deduped_4_1, deduped_4_1, deduped_10_1 ), deduped_6_1 ) * KroneckerMat( deduped_5_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
                         local deduped_1_2;
                         deduped_1_2 := (i_2 - 1);
                         return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_4_1 ), UnderlyingMatrix( alpha_1 ) );
+                    end ) ), deduped_7_1 ), deduped_7_1, deduped_7_1, deduped_10_1 ) ) * KroneckerMat( TransposedMatrix( deduped_5_1 ), UnderlyingMatrix( alpha_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NrRows( morphism_attr_1_1 ) ), a_1, UnderlyingMatrix, morphism_attr_1_1 );


### PR DESCRIPTION
See commit message for details.

Note: The object and morphism filters of the range category of a homomorphism structure are now used in method installation if the range category is known. Thus, `SetRangeCategoryOfHomomorphismStructure` should be called before calling `AddDistinguishedObject` et al. A warning is displayed if this is not the case.