### PR TITLE
Disable compatibility in tests

### DIFF
--- a/FreydCategoriesForCAP/tst/ClosedAndCoclosedRows.tst
+++ b/FreydCategoriesForCAP/tst/ClosedAndCoclosedRows.tst
@@ -989,33 +989,33 @@ false
 # Tensor product and internal (co)hom compatibility
 #############################################################
 
-gap> tensor_to_hom_compatibility_abcd := TensorProductInternalHomCompatibilityMorphism( [ a, b, c, d ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb := TensorProductInternalHomCompatibilityMorphism( [ c, a, d, b ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd := TensorProductInternalHomCompatibilityMorphism( [ a, b, c, d ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb := TensorProductInternalHomCompatibilityMorphism( [ c, a, d, b ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd := InternalCoHomTensorProductCompatibilityMorphism( [ a, b, c, d ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac := InternalCoHomTensorProductCompatibilityMorphism( [ b, d, a, c ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd := InternalCoHomTensorProductCompatibilityMorphism( [ a, b, c, d ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac := InternalCoHomTensorProductCompatibilityMorphism( [ b, d, a, c ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-# Correspondence
+# # Correspondence
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-true
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-true
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-false
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-false
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# false
 
 #########################################################
 # Tensor product duality compatibility
@@ -1615,37 +1615,37 @@ false
 # Inverse tensor product and internal (co)hom compatibility
 ######################################################################
 
-gap> tensor_to_hom_compatibility_inverse_abcd := TensorProductInternalHomCompatibilityMorphismInverse( [ a, b, c, d ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb := TensorProductInternalHomCompatibilityMorphismInverse( [ c, a, d, b ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd := TensorProductInternalHomCompatibilityMorphismInverse( [ a, b, c, d ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb := TensorProductInternalHomCompatibilityMorphismInverse( [ c, a, d, b ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a, b, c, d ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b, d, a, c ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a, b, c, d ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b, d, a, c ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-# Correspondence
+# # Correspondence
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# false
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# false
 
 #######################################################################
 # Coevaluation for (co)dual

--- a/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
+++ b/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
@@ -1500,39 +1500,39 @@ false
 # Tensor product and internal (co)hom compatibility
 #############################################################
 
-gap> tensor_to_hom_compatibility_abcd_rows := TensorProductInternalHomCompatibilityMorphism( [ a_rows, b_rows, c_rows, d_rows ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb_rows := TensorProductInternalHomCompatibilityMorphism( [ c_rows, a_rows, d_rows, b_rows ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd_rows := TensorProductInternalHomCompatibilityMorphism( [ a_rows, b_rows, c_rows, d_rows ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb_rows := TensorProductInternalHomCompatibilityMorphism( [ c_rows, a_rows, d_rows, b_rows ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd_rows := InternalCoHomTensorProductCompatibilityMorphism( [ a_rows, b_rows, c_rows, d_rows ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac_rows := InternalCoHomTensorProductCompatibilityMorphism( [ b_rows, d_rows, a_rows, c_rows ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd_rows := InternalCoHomTensorProductCompatibilityMorphism( [ a_rows, b_rows, c_rows, d_rows ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac_rows := InternalCoHomTensorProductCompatibilityMorphism( [ b_rows, d_rows, a_rows, c_rows ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-gap> tensor_to_hom_compatibility_abcd_cols := TensorProductInternalHomCompatibilityMorphism( [ a_cols, b_cols, c_cols, d_cols ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb_cols := TensorProductInternalHomCompatibilityMorphism( [ c_cols, a_cols, d_cols, b_cols ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd_cols := TensorProductInternalHomCompatibilityMorphism( [ a_cols, b_cols, c_cols, d_cols ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb_cols := TensorProductInternalHomCompatibilityMorphism( [ c_cols, a_cols, d_cols, b_cols ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd_cols := InternalCoHomTensorProductCompatibilityMorphism( [ a_cols, b_cols, c_cols, d_cols ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac_cols := InternalCoHomTensorProductCompatibilityMorphism( [ b_cols, d_cols, a_cols, c_cols ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd_cols := InternalCoHomTensorProductCompatibilityMorphism( [ a_cols, b_cols, c_cols, d_cols ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac_cols := InternalCoHomTensorProductCompatibilityMorphism( [ b_cols, d_cols, a_cols, c_cols ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-# Opposite correspondence
+# # Opposite correspondence
 
-gap> tensor_to_hom_compatibility_abcd_cols = Opposite( cohom_to_tensor_compatibility_bdac_rows ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-true
-gap> tensor_to_hom_compatibility_cadb_cols = Opposite( cohom_to_tensor_compatibility_abcd_rows ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-true
+# gap> tensor_to_hom_compatibility_abcd_cols = Opposite( cohom_to_tensor_compatibility_bdac_rows ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# true
+# gap> tensor_to_hom_compatibility_cadb_cols = Opposite( cohom_to_tensor_compatibility_abcd_rows ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# true
 
-gap> cohom_to_tensor_compatibility_abcd_cols = Opposite( tensor_to_hom_compatibility_cadb_rows ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-true
-gap> cohom_to_tensor_compatibility_bdac_cols = Opposite( tensor_to_hom_compatibility_abcd_rows ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-true
+# gap> cohom_to_tensor_compatibility_abcd_cols = Opposite( tensor_to_hom_compatibility_cadb_rows ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# true
+# gap> cohom_to_tensor_compatibility_bdac_cols = Opposite( tensor_to_hom_compatibility_abcd_rows ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# true
 
-gap> tensor_to_hom_compatibility_abcd_cols = Opposite( cohom_to_tensor_compatibility_abcd_rows ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-false
-gap> tensor_to_hom_compatibility_cadb_cols = Opposite( cohom_to_tensor_compatibility_bdac_rows ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-false
+# gap> tensor_to_hom_compatibility_abcd_cols = Opposite( cohom_to_tensor_compatibility_abcd_rows ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# false
+# gap> tensor_to_hom_compatibility_cadb_cols = Opposite( cohom_to_tensor_compatibility_bdac_rows ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# false
 
-gap> cohom_to_tensor_compatibility_abcd_cols = Opposite( tensor_to_hom_compatibility_abcd_rows ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-false
-gap> cohom_to_tensor_compatibility_bdac_cols = Opposite( tensor_to_hom_compatibility_cadb_rows ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-false
+# gap> cohom_to_tensor_compatibility_abcd_cols = Opposite( tensor_to_hom_compatibility_abcd_rows ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# false
+# gap> cohom_to_tensor_compatibility_bdac_cols = Opposite( tensor_to_hom_compatibility_cadb_rows ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# false
 
 #########################################################
 # Tensor product duality compatibility
@@ -2359,39 +2359,39 @@ false
 # Inverse tensor product and internal (co)hom compatibility
 ######################################################################
 
-gap> tensor_to_hom_compatibility_inverse_abcd_rows := TensorProductInternalHomCompatibilityMorphismInverse( [ a_rows, b_rows, c_rows, d_rows ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb_rows := TensorProductInternalHomCompatibilityMorphismInverse( [ c_rows, a_rows, d_rows, b_rows ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd_rows := TensorProductInternalHomCompatibilityMorphismInverse( [ a_rows, b_rows, c_rows, d_rows ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb_rows := TensorProductInternalHomCompatibilityMorphismInverse( [ c_rows, a_rows, d_rows, b_rows ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_rows := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_rows, b_rows, c_rows, d_rows ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac_rows := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_rows, d_rows, a_rows, c_rows ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd_rows := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_rows, b_rows, c_rows, d_rows ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac_rows := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_rows, d_rows, a_rows, c_rows ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-gap> tensor_to_hom_compatibility_inverse_abcd_cols := TensorProductInternalHomCompatibilityMorphismInverse( [ a_cols, b_cols, c_cols, d_cols ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb_cols := TensorProductInternalHomCompatibilityMorphismInverse( [ c_cols, a_cols, d_cols, b_cols ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd_cols := TensorProductInternalHomCompatibilityMorphismInverse( [ a_cols, b_cols, c_cols, d_cols ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb_cols := TensorProductInternalHomCompatibilityMorphismInverse( [ c_cols, a_cols, d_cols, b_cols ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_cols := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_cols, b_cols, c_cols, d_cols ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac_cols := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_cols, d_cols, a_cols, c_cols ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd_cols := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_cols, b_cols, c_cols, d_cols ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac_cols := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_cols, d_cols, a_cols, c_cols ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-# Opposite correspondence
+# # Opposite correspondence
 
-gap> tensor_to_hom_compatibility_inverse_abcd_cols = Opposite( cohom_to_tensor_compatibility_inverse_bdac_rows ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-true
-gap> tensor_to_hom_compatibility_inverse_cadb_cols = Opposite( cohom_to_tensor_compatibility_inverse_abcd_rows ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-true
+# gap> tensor_to_hom_compatibility_inverse_abcd_cols = Opposite( cohom_to_tensor_compatibility_inverse_bdac_rows ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# true
+# gap> tensor_to_hom_compatibility_inverse_cadb_cols = Opposite( cohom_to_tensor_compatibility_inverse_abcd_rows ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# true
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_cols = Opposite( tensor_to_hom_compatibility_inverse_cadb_rows ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-true
-gap> cohom_to_tensor_compatibility_inverse_bdac_cols = Opposite( tensor_to_hom_compatibility_inverse_abcd_rows ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-true
+# gap> cohom_to_tensor_compatibility_inverse_abcd_cols = Opposite( tensor_to_hom_compatibility_inverse_cadb_rows ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# true
+# gap> cohom_to_tensor_compatibility_inverse_bdac_cols = Opposite( tensor_to_hom_compatibility_inverse_abcd_rows ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# true
 
-gap> tensor_to_hom_compatibility_inverse_abcd_cols = Opposite( cohom_to_tensor_compatibility_inverse_abcd_rows ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-false
-gap> tensor_to_hom_compatibility_inverse_cadb_cols = Opposite( cohom_to_tensor_compatibility_inverse_bdac_rows ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-false
+# gap> tensor_to_hom_compatibility_inverse_abcd_cols = Opposite( cohom_to_tensor_compatibility_inverse_abcd_rows ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# false
+# gap> tensor_to_hom_compatibility_inverse_cadb_cols = Opposite( cohom_to_tensor_compatibility_inverse_bdac_rows ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# false
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_cols = Opposite( tensor_to_hom_compatibility_inverse_abcd_rows ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-false
-gap> cohom_to_tensor_compatibility_inverse_bdac_cols = Opposite( tensor_to_hom_compatibility_inverse_cadb_rows ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-false
+# gap> cohom_to_tensor_compatibility_inverse_abcd_cols = Opposite( tensor_to_hom_compatibility_inverse_abcd_rows ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# false
+# gap> cohom_to_tensor_compatibility_inverse_bdac_cols = Opposite( tensor_to_hom_compatibility_inverse_cadb_rows ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# false
 
 #######################################################################
 # Coevaluation for (co)dual

--- a/LinearAlgebraForCAP/tst/ClosedAndCoclosedInMatrixCategory.tst
+++ b/LinearAlgebraForCAP/tst/ClosedAndCoclosedInMatrixCategory.tst
@@ -989,33 +989,33 @@ false
 # Tensor product and internal (co)hom compatibility
 #############################################################
 
-gap> tensor_to_hom_compatibility_abcd := TensorProductInternalHomCompatibilityMorphism( [ a, b, c, d ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb := TensorProductInternalHomCompatibilityMorphism( [ c, a, d, b ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd := TensorProductInternalHomCompatibilityMorphism( [ a, b, c, d ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb := TensorProductInternalHomCompatibilityMorphism( [ c, a, d, b ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd := InternalCoHomTensorProductCompatibilityMorphism( [ a, b, c, d ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac := InternalCoHomTensorProductCompatibilityMorphism( [ b, d, a, c ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd := InternalCoHomTensorProductCompatibilityMorphism( [ a, b, c, d ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac := InternalCoHomTensorProductCompatibilityMorphism( [ b, d, a, c ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-# Correspondence
+# # Correspondence
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-true
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-true
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-false
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-false
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_abcd ) ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_cadb ) ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# false
 
 #########################################################
 # Tensor product duality compatibility
@@ -1615,37 +1615,37 @@ false
 # Inverse tensor product and internal (co)hom compatibility
 ######################################################################
 
-gap> tensor_to_hom_compatibility_inverse_abcd := TensorProductInternalHomCompatibilityMorphismInverse( [ a, b, c, d ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb := TensorProductInternalHomCompatibilityMorphismInverse( [ c, a, d, b ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd := TensorProductInternalHomCompatibilityMorphismInverse( [ a, b, c, d ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb := TensorProductInternalHomCompatibilityMorphismInverse( [ c, a, d, b ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a, b, c, d ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b, d, a, c ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a, b, c, d ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b, d, a, c ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-# Correspondence
+# # Correspondence
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-true
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# true
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-true
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# true
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  Tranpose( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# false
 
-gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-false
+# gap> UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) = TransposedMatrix( UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  Tranpose( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_abcd ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_abcd ) ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  Tranpose( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# false
 
-gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-false
+# gap> UnderlyingMatrix( cohom_to_tensor_compatibility_inverse_bdac ) = TransposedMatrix( UnderlyingMatrix( tensor_to_hom_compatibility_inverse_cadb ) ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  Tranpose( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# false
 
 #######################################################################
 # Coevaluation for (co)dual

--- a/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
+++ b/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
@@ -1499,39 +1499,39 @@ false
 # Tensor product and internal (co)hom compatibility
 #############################################################
 
-gap> tensor_to_hom_compatibility_abcd_mc := TensorProductInternalHomCompatibilityMorphism( [ a_mc, b_mc, c_mc, d_mc ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb_mc := TensorProductInternalHomCompatibilityMorphism( [ c_mc, a_mc, d_mc, b_mc ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd_mc := TensorProductInternalHomCompatibilityMorphism( [ a_mc, b_mc, c_mc, d_mc ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb_mc := TensorProductInternalHomCompatibilityMorphism( [ c_mc, a_mc, d_mc, b_mc ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd_mc := InternalCoHomTensorProductCompatibilityMorphism( [ a_mc, b_mc, c_mc, d_mc ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac_mc := InternalCoHomTensorProductCompatibilityMorphism( [ b_mc, d_mc, a_mc, c_mc ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd_mc := InternalCoHomTensorProductCompatibilityMorphism( [ a_mc, b_mc, c_mc, d_mc ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac_mc := InternalCoHomTensorProductCompatibilityMorphism( [ b_mc, d_mc, a_mc, c_mc ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-gap> tensor_to_hom_compatibility_abcd_mcop := TensorProductInternalHomCompatibilityMorphism( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
-gap> tensor_to_hom_compatibility_cadb_mcop := TensorProductInternalHomCompatibilityMorphism( [ c_mcop, a_mcop, d_mcop, b_mcop ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
+# gap> tensor_to_hom_compatibility_abcd_mcop := TensorProductInternalHomCompatibilityMorphism( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )
+# gap> tensor_to_hom_compatibility_cadb_mcop := TensorProductInternalHomCompatibilityMorphism( [ c_mcop, a_mcop, d_mcop, b_mcop ] );; # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )
 
-gap> cohom_to_tensor_compatibility_abcd_mcop := InternalCoHomTensorProductCompatibilityMorphism( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
-gap> cohom_to_tensor_compatibility_bdac_mcop := InternalCoHomTensorProductCompatibilityMorphism( [ b_mcop, d_mcop, a_mcop, c_mcop ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
+# gap> cohom_to_tensor_compatibility_abcd_mcop := InternalCoHomTensorProductCompatibilityMorphism( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )
+# gap> cohom_to_tensor_compatibility_bdac_mcop := InternalCoHomTensorProductCompatibilityMorphism( [ b_mcop, d_mcop, a_mcop, c_mcop ] );; # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )
 
-# Opposite correspondence
+# # Opposite correspondence
 
-gap> tensor_to_hom_compatibility_abcd_mcop = Opposite( cohom_to_tensor_compatibility_bdac_mc ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-true
-gap> tensor_to_hom_compatibility_cadb_mcop = Opposite( cohom_to_tensor_compatibility_abcd_mc ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-true
+# gap> tensor_to_hom_compatibility_abcd_mcop = Opposite( cohom_to_tensor_compatibility_bdac_mc ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  ==  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# true
+# gap> tensor_to_hom_compatibility_cadb_mcop = Opposite( cohom_to_tensor_compatibility_abcd_mc ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  ==  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# true
 
-gap> cohom_to_tensor_compatibility_abcd_mcop = Opposite( tensor_to_hom_compatibility_cadb_mc ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-true
-gap> cohom_to_tensor_compatibility_bdac_mcop = Opposite( tensor_to_hom_compatibility_abcd_mc ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-true
+# gap> cohom_to_tensor_compatibility_abcd_mcop = Opposite( tensor_to_hom_compatibility_cadb_mc ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  ==  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# true
+# gap> cohom_to_tensor_compatibility_bdac_mcop = Opposite( tensor_to_hom_compatibility_abcd_mc ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  ==  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# true
 
-gap> tensor_to_hom_compatibility_abcd_mcop = Opposite( cohom_to_tensor_compatibility_abcd_mc ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
-false
-gap> tensor_to_hom_compatibility_cadb_mcop = Opposite( cohom_to_tensor_compatibility_bdac_mc ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
-false
+# gap> tensor_to_hom_compatibility_abcd_mcop = Opposite( cohom_to_tensor_compatibility_abcd_mc ); # Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d )  =/=  op( Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d ) )
+# false
+# gap> tensor_to_hom_compatibility_cadb_mcop = Opposite( cohom_to_tensor_compatibility_bdac_mc ); # Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b )  =/=  op( Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c ) )
+# false
 
-gap> cohom_to_tensor_compatibility_abcd_mcop = Opposite( tensor_to_hom_compatibility_abcd_mc ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
-false
-gap> cohom_to_tensor_compatibility_bdac_mcop = Opposite( tensor_to_hom_compatibility_cadb_mc ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
-false
+# gap> cohom_to_tensor_compatibility_abcd_mcop = Opposite( tensor_to_hom_compatibility_abcd_mc ); # Cohom( a x b, c x d ) -> Cohom( a, c ) x Cohom( b, d )  =/=  op( Hom( a, b ) x Hom( c, d ) -> Hom( a x c, b x d ) )
+# false
+# gap> cohom_to_tensor_compatibility_bdac_mcop = Opposite( tensor_to_hom_compatibility_cadb_mc ); # Cohom( b x d, a x c ) -> Cohom( b, a ) x Cohom( d, c )  =/=  op( Hom( c, a ) x Hom( d, b ) -> Hom( c x d, a x b ) )
+# false
 
 #########################################################
 # Tensor product duality compatibility
@@ -2358,39 +2358,39 @@ false
 # Inverse tensor product and internal (co)hom compatibility
 ######################################################################
 
-gap> tensor_to_hom_compatibility_inverse_abcd_mc := TensorProductInternalHomCompatibilityMorphismInverse( [ a_mc, b_mc, c_mc, d_mc ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb_mc := TensorProductInternalHomCompatibilityMorphismInverse( [ c_mc, a_mc, d_mc, b_mc ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd_mc := TensorProductInternalHomCompatibilityMorphismInverse( [ a_mc, b_mc, c_mc, d_mc ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb_mc := TensorProductInternalHomCompatibilityMorphismInverse( [ c_mc, a_mc, d_mc, b_mc ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_mc := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_mc, b_mc, c_mc, d_mc ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac_mc := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_mc, d_mc, a_mc, c_mc ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd_mc := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_mc, b_mc, c_mc, d_mc ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac_mc := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_mc, d_mc, a_mc, c_mc ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-gap> tensor_to_hom_compatibility_inverse_abcd_mcop := TensorProductInternalHomCompatibilityMorphismInverse( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
-gap> tensor_to_hom_compatibility_inverse_cadb_mcop := TensorProductInternalHomCompatibilityMorphismInverse( [ c_mcop, a_mcop, d_mcop, b_mcop ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
+# gap> tensor_to_hom_compatibility_inverse_abcd_mcop := TensorProductInternalHomCompatibilityMorphismInverse( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )
+# gap> tensor_to_hom_compatibility_inverse_cadb_mcop := TensorProductInternalHomCompatibilityMorphismInverse( [ c_mcop, a_mcop, d_mcop, b_mcop ] );; # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_mcop := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
-gap> cohom_to_tensor_compatibility_inverse_bdac_mcop := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_mcop, d_mcop, a_mcop, c_mcop ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
+# gap> cohom_to_tensor_compatibility_inverse_abcd_mcop := InternalCoHomTensorProductCompatibilityMorphismInverse( [ a_mcop, b_mcop, c_mcop, d_mcop ] );; # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )
+# gap> cohom_to_tensor_compatibility_inverse_bdac_mcop := InternalCoHomTensorProductCompatibilityMorphismInverse( [ b_mcop, d_mcop, a_mcop, c_mcop ] );; # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )
 
-# Opposite correspondence
+# # Opposite correspondence
 
-gap> tensor_to_hom_compatibility_inverse_abcd_mcop = Opposite( cohom_to_tensor_compatibility_inverse_bdac_mc ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-true
-gap> tensor_to_hom_compatibility_inverse_cadb_mcop = Opposite( cohom_to_tensor_compatibility_inverse_abcd_mc ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-true
+# gap> tensor_to_hom_compatibility_inverse_abcd_mcop = Opposite( cohom_to_tensor_compatibility_inverse_bdac_mc ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  ==  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# true
+# gap> tensor_to_hom_compatibility_inverse_cadb_mcop = Opposite( cohom_to_tensor_compatibility_inverse_abcd_mc ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  ==  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# true
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_mcop = Opposite( tensor_to_hom_compatibility_inverse_cadb_mc ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-true
-gap> cohom_to_tensor_compatibility_inverse_bdac_mcop = Opposite( tensor_to_hom_compatibility_inverse_abcd_mc ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-true
+# gap> cohom_to_tensor_compatibility_inverse_abcd_mcop = Opposite( tensor_to_hom_compatibility_inverse_cadb_mc ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  ==  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# true
+# gap> cohom_to_tensor_compatibility_inverse_bdac_mcop = Opposite( tensor_to_hom_compatibility_inverse_abcd_mc ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  ==  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# true
 
-gap> tensor_to_hom_compatibility_inverse_abcd_mcop = Opposite( cohom_to_tensor_compatibility_inverse_abcd_mc ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
-false
-gap> tensor_to_hom_compatibility_inverse_cadb_mcop = Opposite( cohom_to_tensor_compatibility_inverse_bdac_mc ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
-false
+# gap> tensor_to_hom_compatibility_inverse_abcd_mcop = Opposite( cohom_to_tensor_compatibility_inverse_abcd_mc ); # Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d )  =/=  op( Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d ) )
+# false
+# gap> tensor_to_hom_compatibility_inverse_cadb_mcop = Opposite( cohom_to_tensor_compatibility_inverse_bdac_mc ); # Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b )  =/=  op( Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c ) )
+# false
 
-gap> cohom_to_tensor_compatibility_inverse_abcd_mcop = Opposite( tensor_to_hom_compatibility_inverse_abcd_mc ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
-false
-gap> cohom_to_tensor_compatibility_inverse_bdac_mcop = Opposite( tensor_to_hom_compatibility_inverse_cadb_mc ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
-false
+# gap> cohom_to_tensor_compatibility_inverse_abcd_mcop = Opposite( tensor_to_hom_compatibility_inverse_abcd_mc ); # Cohom( a, c ) x Cohom( b, d ) -> Cohom( a x b, c x d )  =/=  op( Hom( a x c, b x d ) -> Hom( a, b ) x Hom( c, d ) )
+# false
+# gap> cohom_to_tensor_compatibility_inverse_bdac_mcop = Opposite( tensor_to_hom_compatibility_inverse_cadb_mc ); # Cohom( b, a ) x Cohom( d, c ) -> Cohom( b x d, a x c )  =/=  op( Hom( c x d, a x b ) -> Hom( c, a ) x Hom( d, b ) )
+# false
 
 #######################################################################
 # Coevaluation for (co)dual


### PR DESCRIPTION
To increase the speed, see https://github.com/homalg-project/CAP_project/pull/787#issuecomment-1022272044
This is only until I refine the tests.

The two tests in LinearAlgebra still take roughly double the time than those of Freyd.