### PR TITLE
Remove `assertlevel` from documentation in new tests

### DIFF
--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gd
@@ -20,5 +20,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b
+#! @Arguments cat, a, b
 DeclareGlobalFunction( "BraidedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gd
@@ -26,5 +26,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
+#! @Arguments cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
 DeclareGlobalFunction( "ClosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gd
@@ -26,5 +26,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
+#! @Arguments cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
 DeclareGlobalFunction( "CoclosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gd
+++ b/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gd
@@ -20,5 +20,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b
+#! @Arguments cat, a, b
 DeclareGlobalFunction( "MonoidalCategoriesTensorProductAndUnitTest" );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gd
@@ -22,5 +22,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b, c, d, alpha, beta
+#! @Arguments cat, a, b, c, d, alpha, beta
 DeclareGlobalFunction( "MonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
@@ -21,5 +21,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b, c, d, alpha
+#! @Arguments cat, a, b, c, d, alpha
 DeclareGlobalFunction( "RigidSymmetricClosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
@@ -21,5 +21,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, assertlevel, a, b, c, d, alpha
+#! @Arguments cat, a, b, c, d, alpha
 DeclareGlobalFunction( "RigidSymmetricCoclosedMonoidalCategoriesTest" );


### PR DESCRIPTION
I forgot to remove the `assertlevel` from the documentation, sorry.