### PR TITLE
Cancel Attribute( Objectify( ... ) ) during inlining

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.02-01",
+Version := "2022.02-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/CapJitInlinedBindings.g
+++ b/CompilerForCAP/examples/CapJitInlinedBindings.g
@@ -6,6 +6,8 @@
 
 LoadPackage( "CompilerForCAP", false );
 #! true
+LoadPackage( "LinearAlgebraForCAP", false );
+#! true
 
 # check that CapJitInlinedBindings is idempotent
 func := function ( )
@@ -16,14 +18,12 @@ tree := ENHANCED_SYNTAX_TREE( func );;
 tree := CapJitInlinedBindings( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function (  )
-#!     local val1_1, val2_1;
 #!     return 1;
 #! end
 
 tree2 := CapJitInlinedBindings( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 #! function (  )
-#!     local val1_1, val2_1;
 #!     return 1;
 #! end
 
@@ -41,18 +41,53 @@ tree := ENHANCED_SYNTAX_TREE( func );;
 tree := CapJitInlinedBindingsToVariableReferences( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function (  )
-#!     local f1_1, f2_1;
 #!     return IdFunc;
 #! end
 
 tree2 := CapJitInlinedBindingsToVariableReferences( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 #! function (  )
-#!     local f1_1, f2_1;
 #!     return IdFunc;
 #! end
 
 tree = tree2;
 #! true
+
+
+
+# test (nested) cancellation in CapJitInlinedBindings
+QQ := HomalgFieldOfRationals( );;
+vec := MatrixCategory( QQ );;
+op := Opposite( vec );;
+
+# we have to work hard to not write semicolons so AutoDoc
+# does not begin a new statement
+func := EvalString( ReplacedString( """function( )
+  local obj_tmp, dimension_tmp, obj, obj_op, obj_op_unwrapped, dimension@
+    
+    obj_tmp := ObjectifyObjectForCAPWithAttributes( rec( ), vec, Dimension, 1 )@
+    
+    dimension_tmp := Dimension( obj_tmp )@
+    
+    obj := ObjectifyObjectForCAPWithAttributes(
+        rec( ), vec, Dimension, dimension_tmp )@
+    
+    obj_op := ObjectifyObjectForCAPWithAttributes( rec( ), op, Opposite, obj )@
+    
+    obj_op_unwrapped := Opposite( obj_op )@
+    
+    dimension := Dimension( obj_op_unwrapped )@
+    
+    return dimension@
+    
+end""", "@", ";" ) );;
+
+tree := ENHANCED_SYNTAX_TREE( func );;
+
+tree := CapJitInlinedBindings( tree );;
+Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+#! function (  )
+#!     return 1;
+#! end
 
 #! @EndExample

--- a/CompilerForCAP/gap/InlineBindings.gd
+++ b/CompilerForCAP/gap/InlineBindings.gd
@@ -7,6 +7,9 @@
 
 #! @Section Compilation steps
 
+# helper
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY" );
+
 #! @Description
 #!   Example: transforms `function() local x; x := 1; return x^2; end` into `function() return 1^2; end()`.
 #!   Details: Replaces references to local variables of a function by the value of the corresponding binding of the function.

--- a/CompilerForCAP/gap/InlineBindings.gi
+++ b/CompilerForCAP/gap/InlineBindings.gi
@@ -3,13 +3,42 @@
 #
 # Implementations
 #
+
+# helper
+InstallGlobalFunction( "CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY", function ( tree, func_stack )
+  local func, pos;
+    
+    while tree.type = "EXPR_REF_FVAR" do
+        
+        func := First( func_stack, func -> func.id = tree.func_id );
+        Assert( 0, func <> fail );
+        
+        pos := Position( func.nams, tree.name );
+        
+        Assert( 0, pos <> fail );
+        
+        # the fvar might be an argument, which has no binding
+        if pos <= func.narg then
+            
+            break;
+            
+        fi;
+        
+        tree := CapJitValueOfBinding( func.bindings, tree.name );
+        
+    od;
+    
+    return tree;
+    
+end );
+
 InstallGlobalFunction( CapJitInlinedBindings, function ( tree )
-  local inline_var_refs_only, pre_func, additional_arguments_func;
+  local inline_var_refs_only, pre_func, result_func, additional_arguments_func;
     
     inline_var_refs_only := ValueOption( "inline_var_refs_only" ) = true;
     
     pre_func := function ( tree, func_stack )
-      local new_bindings, value, func, name;
+      local new_bindings, value, orig_tree, funccall_stack, funccall, pos, name;
         
         # drop bindings which will be inlined anyway
         # func_stack still references the original functions with unmodified bindings
@@ -27,12 +56,12 @@ InstallGlobalFunction( CapJitInlinedBindings, function ( tree )
             
             for name in tree.names do
                 
-                value := CapJitValueOfBinding( tree, name );
+                value := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( CapJitValueOfBinding( tree, name ), func_stack );
                 
                 # RETURN_VALUE and those not inlined below should be kept
                 if name = "RETURN_VALUE" or not (not inline_var_refs_only or value.type = "EXPR_REF_GVAR" or value.type = "EXPR_REF_FVAR") then
                     
-                    CapJitAddBinding( new_bindings, name, value );
+                    CapJitAddBinding( new_bindings, name, CapJitValueOfBinding( tree, name ) );
                     
                 fi;
                 
@@ -42,37 +71,150 @@ InstallGlobalFunction( CapJitInlinedBindings, function ( tree )
             
         fi;
         
-        # iterate in case the inlined value is an EXPR_REF_FVAR again
+        orig_tree := tree;
+        
+        tree := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( tree, func_stack );
+        
+        # do not try any cancellation (see below) if we should only inline references to variables
+        if inline_var_refs_only then
+            
+            if not IsIdenticalObj( orig_tree, tree ) and (tree.type = "EXPR_REF_GVAR" or tree.type = "EXPR_REF_FVAR") then
+                
+                Assert( 0, orig_tree.type = "EXPR_REF_FVAR" );
+                
+                Info( InfoCapJit, 1, "####" );
+                Info( InfoCapJit, 1, "Inline reference to binding with name ", orig_tree.name, "." );
+                
+                return CapJitCopyWithNewFunctionIDs( tree );
+                
+            else
+                
+                return orig_tree;
+                
+            fi;
+            
+        fi;
+        
+        # Try to cancel Attribute( Objectify( ... ) ) immediately for performance.
+        # Doing this would be easy in result_func but that would defeat the purpose of cancellation BEFORE inlining.
         while true do
             
-            if tree.type = "EXPR_REF_FVAR" then
+            funccall_stack := [ ];
+            
+            value := tree;
+            
+            while CapJitIsCallToGlobalFunction( value, gvar -> IsAttribute( ValueGlobal( gvar ) ) ) and value.args.length = 1 do
                 
-                func := First( func_stack, func -> func.id = tree.func_id );
-                Assert( 0, func <> fail );
+                Add( funccall_stack, value );
                 
-                # the fvar might be an argument, which has no binding
-                if Position( func.nams, tree.name ) > func.narg then
+                value := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( value.args.1, func_stack );
+                
+            od;
+            
+            while Length( funccall_stack ) > 0 and CapJitIsCallToGlobalFunction( value, gvar -> gvar = "ObjectifyObjectForCAPWithAttributes" or gvar = "ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes" ) do
+                
+                funccall := Remove( funccall_stack );
+                
+                if funccall.funcref.gvar = "CapCategory" then
                     
-                    value := CapJitValueOfBinding( func.bindings, tree.name );
+                    pos := 2;
                     
-                    if not inline_var_refs_only or value.type = "EXPR_REF_GVAR" or value.type = "EXPR_REF_FVAR" then
+                elif funccall.funcref.gvar = "Source" then
+                    
+                    Assert( 0, value.funcref.gvar = "ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes" );
+                    
+                    pos := 3;
+                    
+                elif funccall.funcref.gvar = "Range" then
+                    
+                    Assert( 0, value.funcref.gvar = "ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes" );
+                    
+                    pos := 4;
+                    
+                else
+                    
+                    pos := PositionProperty( value.args, a -> a.type = "EXPR_REF_GVAR" and IsIdenticalObj( ValueGlobal( a.gvar ), ValueGlobal( funccall.funcref.gvar ) ) );
+                    
+                    if pos = fail then
                         
-                        Info( InfoCapJit, 1, "####" );
-                        Info( InfoCapJit, 1, "Inline binding with name ", tree.name, "." );
-                        
-                        tree := CapJitCopyWithNewFunctionIDs( value );
-                        
-                        continue;
+                        # COVERAGE_IGNORE_NEXT_LINE
+                        Error( "Could not find attribute" );
                         
                     fi;
+                    
+                    pos := pos + 1;
+                    
+                fi;
+                
+                Assert( 0, pos <= value.args.length );
+                
+                Info( InfoCapJit, 1, "####" );
+                Info( InfoCapJit, 1, "Cancel ", value.funcref.gvar, " during inlining." );
+                
+                value := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( value.args.(pos), func_stack );
+                
+            od;
+            
+            if Length( funccall_stack ) = 0 and not IsIdenticalObj( tree, value ) then
+                
+                tree := value;
+                
+                # value might again be a function call of an attribute -> iterate from the beginning
+                continue;
+                
+            else
+                
+                if IsIdenticalObj( orig_tree, tree ) then
+                    
+                    return orig_tree;
+                    
+                else
+                    
+                    return CapJitCopyWithNewFunctionIDs( tree );
                     
                 fi;
                 
             fi;
             
-            return tree;
+        od;
+        
+    end;
+    
+    result_func := function ( tree, result, keys, func_stack )
+      local new_nams, name, value, key, i;
+        
+        tree := ShallowCopy( tree );
+        
+        for key in keys do
+            
+            tree.(key) := result.(key);
             
         od;
+        
+        # drop names of bindings which have been inlined
+        if tree.type = "EXPR_DECLARATIVE_FUNC" then
+            
+            new_nams := [ ];
+            
+            for i in [ 1 .. Length( tree.nams ) ] do
+                
+                name := tree.nams[i];
+                
+                if i <= tree.narg or name in tree.bindings.names then
+                    
+                    Add( new_nams, name );
+                    
+                fi;
+                
+            od;
+            
+            Assert( 0, "RETURN_VALUE" in new_nams );
+            
+            tree.nams := new_nams;
+            
+        fi;
+        
+        return tree;
         
     end;
     
@@ -90,7 +232,7 @@ InstallGlobalFunction( CapJitInlinedBindings, function ( tree )
         
     end;
     
-    return CapJitIterateOverTree( tree, pre_func, CapJitResultFuncCombineChildren, additional_arguments_func, [ ] );
+    return CapJitIterateOverTree( tree, pre_func, result_func, additional_arguments_func, [ ] );
     
 end );
 


### PR DESCRIPTION
This significantly improves runtime and memory consumption of the compilation of higher category towers.