### PR TITLE
Prepare monoidal test functions for rewriting

### DIFF
--- a/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
+++ b/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
@@ -92,8 +92,6 @@ gap> c_tensor_d := TensorProduct( c, d );;
 
 gap> hom_ab := InternalHom( a, b );;
 gap> hom_cd := InternalHom( c, d );;
-gap> cohom_ab := InternalCoHom( a, b );;
-gap> cohom_cd := InternalCoHom( c, d );;
 
 gap> alpha := CategoryOfRowsMorphism( a, HomalgMatrix( [ 2 .. 7 ], RankOfObject( a ), RankOfObject( b ), Q ), b );;
 gap> beta := CategoryOfRowsMorphism( c, HomalgMatrix( [ 8 .. 31 ], RankOfObject( c ), RankOfObject( d ), Q ), d );;
@@ -112,8 +110,6 @@ gap> c_tensor_d := TensorProduct( c, d );;
 
 gap> hom_ab := InternalHom( a, b );;
 gap> hom_cd := InternalHom( c, d );;
-gap> cohom_ab := InternalCoHom( a, b );;
-gap> cohom_cd := InternalCoHom( c, d );;
 
 gap> alpha := ZeroMorphism( a, b );;
 gap> beta := ZeroMorphism( c, d );;
@@ -138,8 +134,6 @@ gap> d := 4 / rows;;
 gap> a_tensor_b := TensorProduct( a, b );;
 gap> c_tensor_d := TensorProduct( c, d );;
 
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
 gap> cohom_ab := InternalCoHom( a, b );;
 gap> cohom_cd := InternalCoHom( c, d );;
 
@@ -158,8 +152,6 @@ gap> d = 0 / rows;;
 gap> a_tensor_b := TensorProduct( a, b );;
 gap> c_tensor_d := TensorProduct( c, d );;
 
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
 gap> cohom_ab := InternalCoHom( a, b );;
 gap> cohom_cd := InternalCoHom( c, d );;
 

--- a/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
+++ b/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
@@ -92,8 +92,6 @@ gap> c_tensor_d := TensorProduct( c, d );;
 
 gap> hom_ab := InternalHom( a, b );;
 gap> hom_cd := InternalHom( c, d );;
-gap> cohom_ab := InternalCoHom( a, b );;
-gap> cohom_cd := InternalCoHom( c, d );;
 
 gap> alpha := VectorSpaceMorphism( a, HomalgMatrix( [ 2 .. 7 ], Dimension( a ), Dimension( b ), Q ), b );;
 gap> beta := VectorSpaceMorphism( c, HomalgMatrix( [ 8 .. 31 ], Dimension( c ), Dimension( d ), Q ), d );;
@@ -112,8 +110,6 @@ gap> c_tensor_d := TensorProduct( c, d );;
 
 gap> hom_ab := InternalHom( a, b );;
 gap> hom_cd := InternalHom( c, d );;
-gap> cohom_ab := InternalCoHom( a, b );;
-gap> cohom_cd := InternalCoHom( c, d );;
 
 gap> alpha := ZeroMorphism( a, b );;
 gap> beta := ZeroMorphism( c, d );;
@@ -138,8 +134,6 @@ gap> d := 4 / mc;;
 gap> a_tensor_b := TensorProduct( a, b );;
 gap> c_tensor_d := TensorProduct( c, d );;
 
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
 gap> cohom_ab := InternalCoHom( a, b );;
 gap> cohom_cd := InternalCoHom( c, d );;
 
@@ -158,8 +152,6 @@ gap> d = 0 / mc;;
 gap> a_tensor_b := TensorProduct( a, b );;
 gap> c_tensor_d := TensorProduct( c, d );;
 
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
 gap> cohom_ab := InternalCoHom( a, b );;
 gap> cohom_cd := InternalCoHom( c, d );;
 

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.01-02",
+Version := "2022.02-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gi
@@ -32,8 +32,8 @@ InstallGlobalFunction( "BraidedMonoidalCategoriesTest",
             braiding_a_b := Braiding( a, b );
             braiding_b_a := Braiding( b, a );
             
-            braiding_inverse_a_b_op := BraidingInverse( a_op, b_op );
-            braiding_inverse_b_a_op := BraidingInverse( b_op, a_op );
+            braiding_inverse_a_b_op := BraidingInverse( opposite, a_op, b_op );
+            braiding_inverse_b_a_op := BraidingInverse( opposite, b_op, a_op );
             
             Assert( 0, IsCongruentForMorphisms( braiding_inverse_a_b_op, Opposite( braiding_a_b ) ) );
             Assert( 0, IsCongruentForMorphisms( braiding_inverse_b_a_op, Opposite( braiding_b_a ) ) );
@@ -52,8 +52,8 @@ InstallGlobalFunction( "BraidedMonoidalCategoriesTest",
             braiding_inverse_a_b := BraidingInverse( a, b );
             braiding_inverse_b_a := BraidingInverse( b, a );
             
-            braiding_a_b_op := Braiding( a_op, b_op );
-            braiding_b_a_op := Braiding( b_op, a_op );
+            braiding_a_b_op := Braiding( opposite, a_op, b_op );
+            braiding_b_a_op := Braiding( opposite, b_op, a_op );
             
             Assert( 0, IsCongruentForMorphisms( braiding_a_b_op, Opposite( braiding_inverse_a_b ) ) );
             Assert( 0, IsCongruentForMorphisms( braiding_b_a_op, Opposite( braiding_inverse_b_a ) ) );

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gi
@@ -217,8 +217,8 @@ InstallGlobalFunction( "ClosedMonoidalCategoriesTest",
             
             alpha_tensor_beta := TensorProductOnMorphisms( alpha, beta );
             beta_tensor_alpha := TensorProductOnMorphisms( beta, alpha );
-            alpha_tensor_beta_op := TensorProductOnMorphisms( alpha_op, beta_op );
-            beta_tensor_alpha_op := TensorProductOnMorphisms( beta_op, alpha_op );
+            alpha_tensor_beta_op := TensorProductOnMorphisms( opposite, alpha_op, beta_op );
+            beta_tensor_alpha_op := TensorProductOnMorphisms( opposite, beta_op, alpha_op );
             
             # Adjoint( a x c -> b x d )  ==  a -> Hom( c, b x d )
             tensor_to_hom_adjunction_on_alpha_tensor_beta := TensorProductToInternalHomAdjunctionMap( a, c, alpha_tensor_beta );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gi
@@ -218,8 +218,8 @@ InstallGlobalFunction( "CoclosedMonoidalCategoriesTest",
             
             alpha_tensor_beta := TensorProductOnMorphisms( alpha, beta );
             beta_tensor_alpha := TensorProductOnMorphisms( beta, alpha );
-            alpha_tensor_beta_op := TensorProductOnMorphisms( alpha_op, beta_op );
-            beta_tensor_alpha_op := TensorProductOnMorphisms( beta_op, alpha_op );
+            alpha_tensor_beta_op := TensorProductOnMorphisms( opposite, alpha_op, beta_op );
+            beta_tensor_alpha_op := TensorProductOnMorphisms( opposite, beta_op, alpha_op );
             
             # Adjoint( a x c -> b x d )  ==  Cohom( a x c, d ) -> b
             tensor_to_cohom_adjunction_on_alpha_tensor_beta := TensorProductToInternalCoHomAdjunctionMap( b, d, alpha_tensor_beta );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gd
@@ -22,5 +22,5 @@
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
 #! Pass the option 'verbose := true' to output more information.
-#! @Arguments cat, a, b, c, d, alpha, beta
+#! @Arguments cat, a, b, c, alpha, beta
 DeclareGlobalFunction( "MonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gi
@@ -59,11 +59,6 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta_op, Opposite( alpha_tensor_beta ) ) );
             Assert( 0, IsCongruentForMorphisms( beta_tensor_alpha_op, Opposite( beta_tensor_alpha ) ) );
             
-            # Convenience methods in the opposite category
-            
-            Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta_op, TensorProduct( opposite, alpha_op, beta_op ) ) );
-            Assert( 0, IsCongruentForMorphisms( beta_tensor_alpha_op, TensorProduct( opposite, beta_op, alpha_op ) ) );
-            
             # Opposite must be self-inverse
             
             Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta, Opposite( alpha_tensor_beta_op ) ) );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gi
@@ -53,16 +53,16 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             alpha_tensor_beta := TensorProductOnMorphisms( alpha, beta );
             beta_tensor_alpha := TensorProductOnMorphisms( beta, alpha );
             
-            alpha_tensor_beta_op := TensorProductOnMorphisms( alpha_op, beta_op );
-            beta_tensor_alpha_op := TensorProductOnMorphisms( beta_op, alpha_op );
+            alpha_tensor_beta_op := TensorProductOnMorphisms( opposite, alpha_op, beta_op );
+            beta_tensor_alpha_op := TensorProductOnMorphisms( opposite, beta_op, alpha_op );
             
             Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta_op, Opposite( alpha_tensor_beta ) ) );
             Assert( 0, IsCongruentForMorphisms( beta_tensor_alpha_op, Opposite( beta_tensor_alpha ) ) );
             
             # Convenience methods in the opposite category
             
-            Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta_op, TensorProduct( alpha_op, beta_op ) ) );
-            Assert( 0, IsCongruentForMorphisms( beta_tensor_alpha_op, TensorProduct( beta_op, alpha_op ) ) );
+            Assert( 0, IsCongruentForMorphisms( alpha_tensor_beta_op, TensorProduct( opposite, alpha_op, beta_op ) ) );
+            Assert( 0, IsCongruentForMorphisms( beta_tensor_alpha_op, TensorProduct( opposite, beta_op, alpha_op ) ) );
             
             # Opposite must be self-inverse
             
@@ -83,8 +83,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             left_unitor_a := LeftUnitor( a );
             left_unitor_b := LeftUnitor( b );
             
-            left_unitor_inverse_a_op := LeftUnitorInverse( a_op );
-            left_unitor_inverse_b_op := LeftUnitorInverse( b_op );
+            left_unitor_inverse_a_op := LeftUnitorInverse( opposite, a_op );
+            left_unitor_inverse_b_op := LeftUnitorInverse( opposite, b_op );
             
             Assert( 0, IsCongruentForMorphisms( left_unitor_inverse_a_op, Opposite( left_unitor_a ) ) );
             Assert( 0, IsCongruentForMorphisms( left_unitor_inverse_b_op, Opposite( left_unitor_b ) ) );
@@ -103,8 +103,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             right_unitor_a := RightUnitor( a );
             right_unitor_b := RightUnitor( b );
             
-            right_unitor_inverse_a_op := RightUnitorInverse( a_op );
-            right_unitor_inverse_b_op := RightUnitorInverse( b_op );
+            right_unitor_inverse_a_op := RightUnitorInverse( opposite, a_op );
+            right_unitor_inverse_b_op := RightUnitorInverse( opposite, b_op );
             
             Assert( 0, IsCongruentForMorphisms( right_unitor_inverse_a_op, Opposite( right_unitor_a ) ) );
             Assert( 0, IsCongruentForMorphisms( right_unitor_inverse_b_op, Opposite( right_unitor_b ) ) );
@@ -123,8 +123,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             left_unitor_inverse_a := LeftUnitorInverse( a );
             left_unitor_inverse_b := LeftUnitorInverse( b );
             
-            left_unitor_a_op := LeftUnitor( a_op );
-            left_unitor_b_op := LeftUnitor( b_op );
+            left_unitor_a_op := LeftUnitor( opposite, a_op );
+            left_unitor_b_op := LeftUnitor( opposite, b_op );
             
             Assert( 0, IsCongruentForMorphisms( left_unitor_a_op, Opposite( left_unitor_inverse_a ) ) );
             Assert( 0, IsCongruentForMorphisms( left_unitor_b_op, Opposite( left_unitor_inverse_b ) ) );
@@ -143,8 +143,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             right_unitor_inverse_a := RightUnitorInverse( a );
             right_unitor_inverse_b := RightUnitorInverse( b );
             
-            right_unitor_a_op := RightUnitor( a_op );
-            right_unitor_b_op := RightUnitor( b_op );
+            right_unitor_a_op := RightUnitor( opposite, a_op );
+            right_unitor_b_op := RightUnitor( opposite, b_op );
             
             Assert( 0, IsCongruentForMorphisms( right_unitor_a_op, Opposite( right_unitor_inverse_a ) ) );
             Assert( 0, IsCongruentForMorphisms( right_unitor_b_op, Opposite( right_unitor_inverse_b ) ) );
@@ -163,8 +163,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             associator_left_to_right_abc := AssociatorLeftToRight( a, b, c );
             associator_left_to_right_cba := AssociatorLeftToRight( c, b, a );
             
-            associator_right_to_left_abc_op := AssociatorRightToLeft( a_op, b_op, c_op );
-            associator_right_to_left_cba_op := AssociatorRightToLeft( c_op, b_op, a_op );
+            associator_right_to_left_abc_op := AssociatorRightToLeft( opposite, a_op, b_op, c_op );
+            associator_right_to_left_cba_op := AssociatorRightToLeft( opposite, c_op, b_op, a_op );
             
             Assert( 0, IsCongruentForMorphisms( associator_right_to_left_abc_op, Opposite( associator_left_to_right_abc ) ) );
             Assert( 0, IsCongruentForMorphisms( associator_right_to_left_cba_op, Opposite( associator_left_to_right_cba ) ) );
@@ -183,8 +183,8 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
             associator_right_to_left_abc := AssociatorRightToLeft( a, b, c );
             associator_right_to_left_cba := AssociatorRightToLeft( c, b, a );
             
-            associator_left_to_right_abc_op := AssociatorLeftToRight( a_op, b_op, c_op );
-            associator_left_to_right_cba_op := AssociatorLeftToRight( c_op, b_op, a_op );
+            associator_left_to_right_abc_op := AssociatorLeftToRight( opposite, a_op, b_op, c_op );
+            associator_left_to_right_cba_op := AssociatorLeftToRight( opposite, c_op, b_op, a_op );
             
             Assert( 0, IsCongruentForMorphisms( associator_left_to_right_abc_op, Opposite( associator_right_to_left_abc ) ) );
             Assert( 0, IsCongruentForMorphisms( associator_left_to_right_cba_op, Opposite( associator_right_to_left_cba ) ) );


### PR DESCRIPTION
Preparations for https://github.com/homalg-project/Toposes/pull/54 and general fixes.
- 9b96e7c5c275199a0945bc173ead7b271f433067 Adds the category argument `opposite` (only at the necessary places) to help the rewriting decide between the cartesian and cocartesian version of an operation.
- dd61dd46e739c47f01639b17997992869c7d2929 This parameter should not be listed in the docu ...
- 38c0d2a2487089f9ca2e474d465b124d0efb267b `TensorProduct( morphism, morphism )` was translated to `Product( morphism, morphism )`, respectively `Coproduct( morphism, morphism )`  which do not exist.
- 26ae619ad8afce63517e7b15dad6233131b4f3a8 Removes unused objects in the concrete test files.