### PR TITLE
Document `only_primitive_operations` for monoidal tests

### DIFF
--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gd
@@ -19,6 +19,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b
 DeclareGlobalFunction( "BraidedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gd
@@ -25,6 +25,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
 DeclareGlobalFunction( "ClosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gd
@@ -25,6 +25,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta
 DeclareGlobalFunction( "CoclosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gd
+++ b/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gd
@@ -19,6 +19,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b
 DeclareGlobalFunction( "MonoidalCategoriesTensorProductAndUnitTest" );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gd
@@ -21,6 +21,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b, c, alpha, beta
 DeclareGlobalFunction( "MonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
@@ -20,6 +20,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b, c, d, alpha
 DeclareGlobalFunction( "RigidSymmetricClosedMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gd
@@ -12,7 +12,7 @@
 #! The arguments are
 #! * a CAP category $cat$
 #! * objects $a, b, c, d$
-#! * a morphism $\alpha: a \rightarrow b$
+#! * an endomorphism $\alpha: a \rightarrow a$
 #! This function checks for every object and morphism
 #! declared in RigidSymmetricClosedMonoidalCategories.gd
 #! if it is computable in the CAP category $cat$.

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
@@ -12,7 +12,7 @@
 #! The arguments are
 #! * a CAP category $cat$
 #! * objects $a, b, c, d$
-#! * a morphism $\alpha: a \rightarrow b$
+#! * an endomorphism $\alpha: a \rightarrow a$
 #! This function checks for every object and morphism
 #! declared in RigidSymmetricCoclosedMonoidalCategories.gd
 #! if it is computable in the CAP category $cat$.

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gd
@@ -20,6 +20,14 @@
 #! with the parameters given above and
 #! compared to the equivalent computation in
 #! the opposite category of $cat$.
-#! Pass the option 'verbose := true' to output more information.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
 #! @Arguments cat, a, b, c, d, alpha
 DeclareGlobalFunction( "RigidSymmetricCoclosedMonoidalCategoriesTest" );


### PR DESCRIPTION
As @zickgraf pointed out here: https://github.com/homalg-project/FinSetsForCAP/pull/91#issuecomment-1036257261, passing `only_primitive_operations` to `Opposite()` might trigger more derivations. This is currently not documented, but I think it might be helpful to let users know that this could (optionally) be also used for the tests. 

09ba50613cd0ea0f8144a8779bd6254a6c041ff2 fixes a typo in the documentation.