### PR TITLE
Declare and install generic algorithms for projective and injective dimension

### DIFF
--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -1418,6 +1418,25 @@ DeclareOperation( "AddInjectiveColift",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
+#! to the category for the basic operation `InjectiveDimension`.
+#! $F: ( arg2 ) \mapsto \mathtt{InjectiveDimension}(arg2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddInjectiveDimension",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddInjectiveDimension",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddInjectiveDimension",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddInjectiveDimension",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
 #! to the category for the basic operation `InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure`.
 #! $F: ( alpha ) \mapsto \mathtt{InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure}(alpha)$.
 #! @Returns nothing
@@ -3427,6 +3446,25 @@ DeclareOperation( "AddProjectionOntoCoequalizerWithGivenCoequalizer",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddProjectionOntoCoequalizerWithGivenCoequalizer",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation `ProjectiveDimension`.
+#! $F: ( arg2 ) \mapsto \mathtt{ProjectiveDimension}(arg2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddProjectiveDimension",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddProjectiveDimension",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddProjectiveDimension",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddProjectiveDimension",
                   [ IsCapCategory, IsList ] );
 
 #! @Description

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -148,7 +148,9 @@ Perform(
       [ "IsPreAbelianCategory", "IsPreAbelianCategory" ],
       [ "IsAbelianCategory", "IsAbelianCategory" ],
       [ "IsAbelianCategoryWithEnoughProjectives", "IsAbelianCategoryWithEnoughInjectives" ],
-      [ "IsAbelianCategoryWithEnoughInjectives", "IsAbelianCategoryWithEnoughProjectives" ]
+      [ "IsAbelianCategoryWithEnoughInjectives", "IsAbelianCategoryWithEnoughProjectives" ],
+      [ "IsLocallyOfFiniteProjectiveDimension", "IsLocallyOfFiniteInjectiveDimension" ],
+      [ "IsLocallyOfFiniteInjectiveDimension", "IsLocallyOfFiniteProjectiveDimension" ]
     ],
     AddCategoricalProperty );
 

--- a/CAP/gap/CategoryConstructor.gi
+++ b/CAP/gap/CategoryConstructor.gi
@@ -244,7 +244,7 @@ InstallMethod( CategoryConstructor,
         info := CAP_INTERNAL_METHOD_NAME_RECORD.(name);
         
         # check if filters and return_type are known
-        unknown_filters := Filtered( info.filter_list, filter -> not filter in [ "category", "object", "morphism", IsInt, IsRingElement, IsCyclotomic, "list_of_objects", "list_of_morphisms" ] );
+        unknown_filters := Filtered( info.filter_list, filter -> not filter in [ "category", "object", "morphism", IsInt, IsRingElement, "nonneg_integer_or_infinity", "list_of_objects", "list_of_morphisms" ] );
         
         if not IsEmpty( unknown_filters ) then
             
@@ -326,7 +326,7 @@ InstallMethod( CategoryConstructor,
                     
                     return Concatenation( options.underlying_morphism_getter_string, "( cat, ", argument_name, " )" );
                     
-                elif filter = IsInt or filter = IsRingElement or filter = IsCyclotomic then
+                elif filter = IsInt or filter = IsRingElement or filter = "nonneg_integer_or_infinity" then
                     
                     return argument_name;
                     

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -416,3 +416,25 @@ DeclareOperation( "SimplifyObject_IsoFromInputObject",
 #! @Arguments A, i
 DeclareOperation( "SimplifyObject_IsoToInputObject",
                   [ IsCapCategoryObject, IsObject ] );
+
+###################################
+##
+#! @Section Dimensions
+##
+###################################
+
+#! @Description
+#! The argument is an object $A$.
+#! The output is a the projective dimension of $A$.
+#! @Returns a nonnegative integer or infinity
+#! @Arguments A
+DeclareAttribute( "ProjectiveDimension",
+                  IsCapCategoryObject );
+
+#! @Description
+#! The argument is an object $A$.
+#! The output is a the injective dimension of $A$.
+#! @Returns a nonnegative integer or infinity
+#! @Arguments A
+DeclareAttribute( "InjectiveDimension",
+                  IsCapCategoryObject );

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2367,6 +2367,52 @@ AddDerivationToCAP( IsomorphismFromItsConstructionAsAnImageObjectToHomologyObjec
     
 end : Description := "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject as the inverse of IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject" );
 
+###########################
+##
+## Methods returning a nonnegative integer or infinity
+##
+###########################
+
+##
+AddDerivationToCAP( ProjectiveDimension,
+                    
+  function( cat, obj )
+    local dim, syzygy_obj;
+
+    dim := 0;
+    
+    syzygy_obj := obj;
+
+    while not IsProjective( cat, syzygy_obj ) do
+      syzygy_obj := KernelObject( cat, EpimorphismFromSomeProjectiveObject( cat, syzygy_obj ) );
+      dim := dim + 1;
+    od;
+    
+    return dim;
+
+end : CategoryFilter := IsLocallyOfFiniteProjectiveDimension and IsAbelianCategory,
+Description := "ProjectiveDimension by iteratively testing whether the syzygy object is projective" );
+
+##
+AddDerivationToCAP( InjectiveDimension,
+                    
+  function( cat, obj )
+    local dim, cosyzygy_obj;
+
+    dim := 0;
+    
+    cosyzygy_obj := obj;
+
+    while not IsInjective( cat, cosyzygy_obj ) do
+      cosyzygy_obj := CokernelObject( cat, MonomorphismIntoSomeInjectiveObject( cat, cosyzygy_obj ) );
+      dim := dim + 1;
+    od;
+    
+    return dim;
+
+end : CategoryFilter := IsLocallyOfFiniteInjectiveDimension and IsAbelianCategory,
+Description := "InjectiveDimension by iteratively testing whether the cosyzygy object is injective" );
+
 
 ###########################
 ##

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -344,6 +344,10 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 input_sanity_check_functions[i] := function( arg, i )
                     CAP_INTERNAL_ASSERT_IS_LIST_OF_TWO_CELLS_OF_CATEGORY( arg, category, function( ) return input_human_readable_identifier_getter( i ); end );
                 end;
+            elif filter = "non_neg_integer_or_infinity" then
+                input_sanity_check_functions[i] := function( arg, i )
+                    CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY( arg, function( ) return input_human_readable_identifier_getter( i ); end );
+                end;
             else
                 Display( Concatenation( "Warning: You should add an input sanity check for the following filter: ", String( filter ) ) );
                 input_sanity_check_functions[i] := ReturnTrue;
@@ -416,6 +420,10 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 if result <> fail then
                     CAP_INTERNAL_ASSERT_IS_LIST_OF_MORPHISMS_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
                 fi;
+            end;
+        elif record.return_type = "non_neg_integer_or_infinity" then
+            output_sanity_check_function := function( result )
+                CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY( result, output_human_readable_identifier_getter );
             end;
         else
             Display( Concatenation( "Warning: You should add an output sanity check for the following return_type: ", String( record.return_type ) ) );

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -344,7 +344,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                 input_sanity_check_functions[i] := function( arg, i )
                     CAP_INTERNAL_ASSERT_IS_LIST_OF_TWO_CELLS_OF_CATEGORY( arg, category, function( ) return input_human_readable_identifier_getter( i ); end );
                 end;
-            elif filter = "non_neg_integer_or_infinity" then
+            elif filter = "nonneg_integer_or_infinity" then
                 input_sanity_check_functions[i] := function( arg, i )
                     CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY( arg, function( ) return input_human_readable_identifier_getter( i ); end );
                 end;
@@ -421,7 +421,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     CAP_INTERNAL_ASSERT_IS_LIST_OF_MORPHISMS_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
                 fi;
             end;
-        elif record.return_type = "non_neg_integer_or_infinity" then
+        elif record.return_type = "nonneg_integer_or_infinity" then
             output_sanity_check_function := function( result )
                 CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY( result, output_human_readable_identifier_getter );
             end;

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -18,7 +18,7 @@ InstallValue( CAP_INTERNAL_VALID_RETURN_TYPES,
         "other_morphism",
         "list_of_morphisms",
         "list_of_morphisms_or_fail",
-        "non_neg_integer_or_infinity",
+        "nonneg_integer_or_infinity",
     ]
 #! @EndCode
 );
@@ -3297,7 +3297,7 @@ IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject := rec(
   
 ## SimplifyObject*
 SimplifyObject := rec(
-  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "object", "nonneg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "B" ] ],
   return_type := "object",
   dual_operation := "SimplifyObject",
@@ -3322,7 +3322,7 @@ SimplifyObject := rec(
   ),
 
 SimplifyObject_IsoFromInputObject := rec(
-  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "object", "nonneg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "A", "B" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyObject_IsoToInputObject",
@@ -3339,7 +3339,7 @@ SimplifyObject_IsoFromInputObject := rec(
   ),
 
 SimplifyObject_IsoToInputObject := rec(
-  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "object", "nonneg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "B", "A" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyObject_IsoFromInputObject",
@@ -3349,7 +3349,7 @@ SimplifyObject_IsoToInputObject := rec(
 
 ## SimplifyMorphism
 SimplifyMorphism := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyMorphism",
@@ -3359,7 +3359,7 @@ SimplifyMorphism := rec(
 
 ## SimplifySource*
 SimplifySource := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange",
@@ -3368,7 +3368,7 @@ SimplifySource := rec(
   ),
 
 SimplifySource_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_source" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange_IsoFromInputObject",
@@ -3385,7 +3385,7 @@ SimplifySource_IsoToInputObject := rec(
   ),
   
 SimplifySource_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange_IsoToInputObject",
@@ -3395,7 +3395,7 @@ SimplifySource_IsoFromInputObject := rec(
 
 ## SimplifyRange*
 SimplifyRange := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource",
@@ -3404,7 +3404,7 @@ SimplifyRange := rec(
   ),
 
 SimplifyRange_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Bp", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource_IsoFromInputObject",
@@ -3421,7 +3421,7 @@ SimplifyRange_IsoToInputObject := rec(
   ),
   
 SimplifyRange_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_range", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource_IsoToInputObject",
@@ -3431,7 +3431,7 @@ SimplifyRange_IsoFromInputObject := rec(
 
 ## SimplifySourceAndRange*
 SimplifySourceAndRange := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange",
@@ -3440,7 +3440,7 @@ SimplifySourceAndRange := rec(
   ),
 
 SimplifySourceAndRange_IsoToInputSource := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_source" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoFromInputRange",
@@ -3449,7 +3449,7 @@ SimplifySourceAndRange_IsoToInputSource := rec(
   ),
   
 SimplifySourceAndRange_IsoFromInputSource := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoToInputRange",
@@ -3458,7 +3458,7 @@ SimplifySourceAndRange_IsoFromInputSource := rec(
   ),
 
 SimplifySourceAndRange_IsoToInputRange := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Bp", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoFromInputSource",
@@ -3467,7 +3467,7 @@ SimplifySourceAndRange_IsoToInputRange := rec(
   ),
   
 SimplifySourceAndRange_IsoFromInputRange := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_range", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoToInputSource",
@@ -3477,7 +3477,7 @@ SimplifySourceAndRange_IsoFromInputRange := rec(
 
 ## SimplifyEndo*
 SimplifyEndo := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo",
@@ -3498,7 +3498,7 @@ SimplifyEndo := rec(
   ),
 
 SimplifyEndo_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo_IsoToInputObject",
@@ -3507,7 +3507,7 @@ SimplifyEndo_IsoFromInputObject := rec(
   ),
 
 SimplifyEndo_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
+  filter_list := [ "category", "morphism", "nonneg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo_IsoFromInputObject",
@@ -3531,7 +3531,19 @@ SomeReductionBySplitEpiSummand_MorphismFromInputRange := rec(
   filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "B", "Bp" ] ],
   return_type := "morphism",
-  )
+  ),
+
+ProjectiveDimension := rec(
+  filter_list := [ "category", "object" ],
+  return_type := "nonneg_integer_or_infinity",
+  dual_operation := "InjectiveDimension",
+  ),
+
+InjectiveDimension := rec(
+  filter_list := [ "category", "object" ],
+  return_type := "nonneg_integer_or_infinity",
+  dual_operation := "ProjectiveDimension",
+  ),
 
 ) );
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -18,6 +18,7 @@ InstallValue( CAP_INTERNAL_VALID_RETURN_TYPES,
         "other_morphism",
         "list_of_morphisms",
         "list_of_morphisms_or_fail",
+        "non_neg_integer_or_infinity",
     ]
 #! @EndCode
 );
@@ -3296,7 +3297,7 @@ IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject := rec(
   
 ## SimplifyObject*
 SimplifyObject := rec(
-  filter_list := [ "category", "object", IsCyclotomic ],
+  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "B" ] ],
   return_type := "object",
   dual_operation := "SimplifyObject",
@@ -3321,7 +3322,7 @@ SimplifyObject := rec(
   ),
 
 SimplifyObject_IsoFromInputObject := rec(
-  filter_list := [ "category", "object", IsCyclotomic ],
+  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "A", "B" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyObject_IsoToInputObject",
@@ -3338,7 +3339,7 @@ SimplifyObject_IsoFromInputObject := rec(
   ),
 
 SimplifyObject_IsoToInputObject := rec(
-  filter_list := [ "category", "object", IsCyclotomic ],
+  filter_list := [ "category", "object", "non_neg_integer_or_infinity" ],
   io_type := [ [ "A", "n" ], [ "B", "A" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyObject_IsoFromInputObject",
@@ -3348,7 +3349,7 @@ SimplifyObject_IsoToInputObject := rec(
 
 ## SimplifyMorphism
 SimplifyMorphism := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyMorphism",
@@ -3358,7 +3359,7 @@ SimplifyMorphism := rec(
 
 ## SimplifySource*
 SimplifySource := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange",
@@ -3367,7 +3368,7 @@ SimplifySource := rec(
   ),
 
 SimplifySource_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_source" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange_IsoFromInputObject",
@@ -3384,7 +3385,7 @@ SimplifySource_IsoToInputObject := rec(
   ),
   
 SimplifySource_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyRange_IsoToInputObject",
@@ -3394,7 +3395,7 @@ SimplifySource_IsoFromInputObject := rec(
 
 ## SimplifyRange*
 SimplifyRange := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource",
@@ -3403,7 +3404,7 @@ SimplifyRange := rec(
   ),
 
 SimplifyRange_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Bp", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource_IsoFromInputObject",
@@ -3420,7 +3421,7 @@ SimplifyRange_IsoToInputObject := rec(
   ),
   
 SimplifyRange_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_range", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySource_IsoToInputObject",
@@ -3430,7 +3431,7 @@ SimplifyRange_IsoFromInputObject := rec(
 
 ## SimplifySourceAndRange*
 SimplifySourceAndRange := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange",
@@ -3439,7 +3440,7 @@ SimplifySourceAndRange := rec(
   ),
 
 SimplifySourceAndRange_IsoToInputSource := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_source" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoFromInputRange",
@@ -3448,7 +3449,7 @@ SimplifySourceAndRange_IsoToInputSource := rec(
   ),
   
 SimplifySourceAndRange_IsoFromInputSource := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoToInputRange",
@@ -3457,7 +3458,7 @@ SimplifySourceAndRange_IsoFromInputSource := rec(
   ),
 
 SimplifySourceAndRange_IsoToInputRange := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Bp", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoFromInputSource",
@@ -3466,7 +3467,7 @@ SimplifySourceAndRange_IsoToInputRange := rec(
   ),
   
 SimplifySourceAndRange_IsoFromInputRange := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_range", "Bp" ] ],
   return_type := "morphism",
   dual_operation := "SimplifySourceAndRange_IsoToInputSource",
@@ -3476,7 +3477,7 @@ SimplifySourceAndRange_IsoFromInputRange := rec(
 
 ## SimplifyEndo*
 SimplifyEndo := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo",
@@ -3497,7 +3498,7 @@ SimplifyEndo := rec(
   ),
 
 SimplifyEndo_IsoFromInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "mor_source", "Ap" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo_IsoToInputObject",
@@ -3506,7 +3507,7 @@ SimplifyEndo_IsoFromInputObject := rec(
   ),
 
 SimplifyEndo_IsoToInputObject := rec(
-  filter_list := [ "category", "morphism", IsCyclotomic ],
+  filter_list := [ "category", "morphism", "non_neg_integer_or_infinity" ],
   io_type := [ [ "mor", "n" ], [ "Ap", "mor_range" ] ],
   return_type := "morphism",
   dual_operation := "SimplifyEndo_IsoFromInputObject",

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -202,7 +202,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                     
                     return Concatenation( "List( ", argument_name, ", x -> MorphismDatum( cat, x ) )" );
                     
-                elif filter = "non_neg_integer_or_infinity" then
+                elif filter = "nonneg_integer_or_infinity" then
                     
                     return argument_name;
                     
@@ -293,7 +293,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                 
                 return_statement := "return result";
                 
-            elif return_type = "non_neg_integer_or_infinity" then
+            elif return_type = "nonneg_integer_or_infinity" then
                 
                 return_statement := "return result";
 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -202,6 +202,10 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                     
                     return Concatenation( "List( ", argument_name, ", x -> MorphismDatum( cat, x ) )" );
                     
+                elif filter = "non_neg_integer_or_infinity" then
+                    
+                    return argument_name;
+                    
                 else
                     
                     Error( "this case is not handled yet" );
@@ -289,6 +293,10 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                 
                 return_statement := "return result";
                 
+            elif return_type = "non_neg_integer_or_infinity" then
+                
+                return_statement := "return result";
+
             else
                 
                 Error( "this case is not handled yet" );

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -138,6 +138,12 @@ DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_LIST_OF_MORPHISMS_OF_CATEGORY" );
 #!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>list_of_twocells</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_LIST_OF_TWO_CELLS_OF_CATEGORY" );
 
+#! @Arguments nnintorinf, human_readable_identifier_getter
+#! @Description
+#!  The function throws an error if <A>nnintorinf</A> is not a non negative integer or infinity.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>nnintorinf</A> in the error message.
+DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY" );
+
 DeclareGlobalFunction( "ListKnownCategoricalProperties" );
 
 DeclareGlobalFunction( "CAP_MergeRecords" );

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -140,7 +140,7 @@ DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_LIST_OF_TWO_CELLS_OF_CATEGORY" );
 
 #! @Arguments nnintorinf, human_readable_identifier_getter
 #! @Description
-#!  The function throws an error if <A>nnintorinf</A> is not a non negative integer or infinity.
+#!  The function throws an error if <A>nnintorinf</A> is not a nonnegative integer or infinity.
 #!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>nnintorinf</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY" );
 

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -464,6 +464,8 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   list[ i ] := IsList;
               elif current_entry = "list_of_twocells" then
                   list[ i ] := IsList;
+              elif current_entry = "non_neg_integer_or_infinity" then
+                  list[ i ] := IsCyclotomic;
               else
                   Error( "filter type is not recognized, see the documentation for allowed values" );
               fi;

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -464,7 +464,7 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS,
                   list[ i ] := IsList;
               elif current_entry = "list_of_twocells" then
                   list[ i ] := IsList;
-              elif current_entry = "non_neg_integer_or_infinity" then
+              elif current_entry = "nonneg_integer_or_infinity" then
                   list[ i ] := IsCyclotomic;
               else
                   Error( "filter type is not recognized, see the documentation for allowed values" );

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -266,3 +266,17 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_LIST_OF_TWO_CELLS_OF_CATEGORY,
     od;
     
 end );
+
+##
+InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY,
+  
+  function( nnintorinf, human_readable_identifier_getter )
+    local generic_help_string;
+    
+    generic_help_string := " You can access the object and category via the local variable 'nnintorinf' in a break loop.";
+    
+    if not ( IsInfinity( nnintorinf ) or ( IsInt( nnintorinf ) and nnintorinf >= 0 ) ) then
+        Error( Concatenation( human_readable_identifier_getter(), " is not a non negative integer or infinity.", generic_help_string ) );
+    fi;
+    
+end );

--- a/CAP/gap/ToolsForCategories_AfterLoading.gi
+++ b/CAP/gap/ToolsForCategories_AfterLoading.gi
@@ -276,7 +276,7 @@ InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY,
     generic_help_string := " You can access the object and category via the local variable 'nnintorinf' in a break loop.";
     
     if not ( IsInfinity( nnintorinf ) or ( IsInt( nnintorinf ) and nnintorinf >= 0 ) ) then
-        Error( Concatenation( human_readable_identifier_getter(), " is not a non negative integer or infinity.", generic_help_string ) );
+        Error( Concatenation( human_readable_identifier_getter(), " is not a nonnegative integer or infinity.", generic_help_string ) );
     fi;
     
 end );

--- a/FreydCategoriesForCAP/examples/ProjInjBij.g
+++ b/FreydCategoriesForCAP/examples/ProjInjBij.g
@@ -1,6 +1,6 @@
 #! @Chapter Examples and Tests
 
-#! @Section Testing if an object is projective, injective, bijective
+#! @Section Testing if an object is projective, injective, bijective, and computing projective/injective dimensions
 
 LoadPackage( "FreydCategoriesForCAP" );;
 LoadPackage( "RingsForHomalg" );
@@ -9,22 +9,36 @@ LoadPackage( "RingsForHomalg" );
 R := HomalgRingOfIntegers();;
 rows := CategoryOfRows( R );;
 adelman := AdelmanCategory( rows );;
-obj1 := CategoryOfRowsObject( 1, rows );;
-alpha := ProjectionInFactorOfDirectSum( [ obj1, obj1 ], 1 );;
+rowobj := CategoryOfRowsObject( 1, rows );;
+alpha := ProjectionInFactorOfDirectSum( [ rowobj, rowobj ], 1 );;
 alpha := AsAdelmanCategoryMorphism( alpha );;
 obj := CokernelObject( alpha );;
 IsBijectiveObject( obj );
 #! true
-beta := 2 * IdentityMorphism( obj1 );;
+beta := 2 * IdentityMorphism( rowobj );;
 beta := AsAdelmanCategoryMorphism( beta );;
 obj1 := CokernelObject( beta );;
 obj2 := KernelObject( beta );;
+obj3 := ImageObject( beta );;
+obj4 := HomologyObject( beta, beta );;
 IsBijectiveObject( obj1 );
 #! false
 IsInjective( obj1 );
 #! true
+ProjectiveDimension( obj1 );
+#! 2
 IsBijectiveObject( obj2 );
 #! false
 IsProjective( obj2 );
 #! true
+InjectiveDimension( obj2 );
+#! 2
+ProjectiveDimension( obj3 );
+#! 1
+InjectiveDimension( obj3 );
+#! 1
+ProjectiveDimension( obj4 );
+#! 2
+InjectiveDimension( obj4 );
+#! 2
 #! @EndExample

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -54,6 +54,9 @@ InstallMethod( AdelmanCategory,
     ## this is the purpose of the Adelman category
     SetIsAbelianCategory( adelman_category, true );
     
+    SetIsLocallyOfFiniteProjectiveDimension( adelman_category, true );
+    SetIsLocallyOfFiniteInjectiveDimension( adelman_category, true );
+    
     SetUnderlyingCategory( adelman_category, underlying_category );
     
     if HasIsLinearCategoryOverCommutativeRing( underlying_category )


### PR DESCRIPTION
My introduction of the type `non_neg_integer_or_infinity` leads to deletions of precompiled code, which I think is a bad sign.

@zickgraf Did I forget something in the introduction of that type, or do you need to adjust the compiler?