### PR TITLE
Install logical implications in Finalize

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.02-07",
+Version := "2022.03-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -590,8 +590,6 @@ InstallMethod( CreateCapCategory,
     
       AddCategoryToFamily( category, "general" );
       
-      INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "General" );
-      
     else
       
       category!.predicate_logic := false;

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -163,7 +163,7 @@ InstallMethod( Finalize,
                [ IsCapCategory ],
   
   function( category )
-    local current_final_derivation, derivation_list, i, n, weight_list, weight, add_name, current_installs, current_tester_func, current_additional_func;
+    local derivation_list, weight_list, current_installs, current_final_derivation, current_tester_func, weight, add_name, properties_with_logic, property, i, current_additional_func, property_name;
     
     if IsFinalized( category ) then
         
@@ -176,6 +176,8 @@ InstallMethod( Finalize,
         return false;
         
     fi;
+    
+    SuspendMethodReordering( );
     
     derivation_list := ShallowCopy( CAP_INTERNAL_FINAL_DERIVATION_LIST.final_derivation_list );
     
@@ -269,6 +271,26 @@ InstallMethod( Finalize,
     od;
     
     SetIsFinalized( category, true );
+    
+    if category!.overhead then
+        
+        properties_with_logic := RecNames( category!.logical_implication_files.Propositions );
+        
+        for property_name in properties_with_logic do
+            
+            property := ValueGlobal( property_name );
+            
+            if Tester( property )( category ) and property( category ) then
+                
+                INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, property_name );
+                
+            fi;
+            
+        od;
+        
+    fi;
+    
+    ResumeMethodReordering( );
     
     return true;
     

--- a/CAP/gap/LogicForCAP.gd
+++ b/CAP/gap/LogicForCAP.gd
@@ -51,10 +51,6 @@ DeclareGlobalFunction( "ADD_EVAL_RULES_TO_CATEGORY" );
 ##
 #############################
 
-DeclareAttribute( "INSTALL_LOGICAL_IMPLICATIONS",
-                  IsCapCategory );
-
-
 DeclareGlobalFunction( "INSTALL_LOGICAL_IMPLICATIONS_HELPER" );
 
 DeclareAttribute( "CAP_CATEGORY_SOURCE_RANGE_THEOREM_INSTALL_HELPER",

--- a/CAP/gap/LogicForCAP.gi
+++ b/CAP/gap/LogicForCAP.gi
@@ -8,7 +8,7 @@ InstallValue( CATEGORIES_LOGIC_FILES,
   rec(
       
       Propositions := rec(
-          General := [
+          IsCapCategory := [
                        Filename( DirectoriesPackageLibrary( "CAP", "LogicForCategories" ), "PropositionsForGeneralCategories.tex" )
                      ],
           IsEnrichedOverCommutativeRegularSemigroup := [
@@ -27,7 +27,7 @@ InstallValue( CATEGORIES_LOGIC_FILES,
                                   Filename( DirectoriesPackageLibrary( "CAP", "LogicForCategories" ), "PropositionsForAbelianCategories.tex" )
                                ] ),
       Predicates := rec(
-          General := [
+          IsCapCategory := [
                        Filename( DirectoriesPackageLibrary( "CAP", "LogicForCategories" ), "PredicateImplicationsForGeneralCategories.tex" )
                      ],
           IsEnrichedOverCommutativeRegularSemigroup := [
@@ -46,7 +46,7 @@ InstallValue( CATEGORIES_LOGIC_FILES,
                                  Filename( DirectoriesPackageLibrary( "CAP", "LogicForCategories" ), "PredicateImplicationsForAbelianCategories.tex" )
                                ] ),
       EvalRules := rec(
-          General := [
+          IsCapCategory := [
                       Filename( DirectoriesPackageLibrary( "CAP", "LogicForCategories" ), "RelationsForGeneralCategories.tex" )
                      ],
           IsEnrichedOverCommutativeRegularSemigroup := [
@@ -92,8 +92,6 @@ InstallGlobalFunction( AddTheoremFileToCategory,
                        
   function( category, filename )
     local theorem_list, i;
-    
-    Add( category!.logical_implication_files.Propositions.General, filename );
     
     theorem_list := READ_THEOREM_FILE( filename );
     
@@ -343,8 +341,6 @@ InstallGlobalFunction( AddPredicateImplicationFileToCategory,
   function( category, filename )
     local theorem_list, i;
     
-    Add( category!.logical_implication_files.Predicates.General, filename );
-    
     theorem_list := READ_PREDICATE_IMPLICATION_FILE( filename );
     
     for i in theorem_list do
@@ -408,7 +404,7 @@ InstallGlobalFunction( AddEvalRuleFileToCategory,
   function( category, filename )
     local theorem_list, i;
     
-    Add( category!.logical_implication_files.EvalRules.General, filename );
+    Add( category!.logical_implication_files.EvalRules.IsCapCategory, filename );
     
     if IsBound( category!.logical_implication_files.EvalRules.general_rules_already_read ) and
        category!.logical_implication_files.EvalRules.general_rules_already_read = true then
@@ -466,8 +462,6 @@ InstallGlobalFunction( INSTALL_LOGICAL_IMPLICATIONS_HELPER,
   function( category, current_filter )
     local i, theorem_list, current_theorem;
 
-    SuspendMethodReordering();
-
     for i in category!.logical_implication_files.Propositions.( current_filter ) do
         
         theorem_list := READ_THEOREM_FILE( i );
@@ -491,98 +485,5 @@ InstallGlobalFunction( INSTALL_LOGICAL_IMPLICATIONS_HELPER,
         od;
         
     od;
-
-    ResumeMethodReordering();
     
 end );
-
-InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
-                        IsCapCategory and IsEnrichedOverCommutativeRegularSemigroup,
-                        0,
-                        
-  function( category )
-    
-    if category!.overhead then
-        
-        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsEnrichedOverCommutativeRegularSemigroup" );
-        
-        TryNextMethod( );
-        
-    fi;
-    
-    return false;
-    
-end );
-
-InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
-                        IsCapCategory and IsAdditiveCategory,
-                        0,
-                        
-  function( category )
-    
-    if category!.overhead then
-        
-        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAdditiveCategory" );
-        
-        TryNextMethod( );
-        
-    fi;
-    
-    return false;
-    
-end );
-
-InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
-                        IsCapCategory and IsPreAbelianCategory,
-                        0,
-                        
-  function( category )
-    
-    if category!.overhead then
-        
-        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsPreAbelianCategory" );
-        
-        TryNextMethod( );
-        
-    fi;
-    
-    return false;
-    
-end );
-
-InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
-                        IsCapCategory and IsAbelianCategory,
-                        0,
-                        
-  function( category )
-    
-    if category!.overhead then
-        
-        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbelianCategory" );
-        
-        TryNextMethod( );
-        
-    fi;
-    
-    return false;
-    
-end );
-
-InstallImmediateMethod( INSTALL_LOGICAL_IMPLICATIONS,
-                        IsCapCategory and IsAbCategory,
-                        0,
-                        
-  function( category )
-    
-    if category!.overhead then
-        
-        INSTALL_LOGICAL_IMPLICATIONS_HELPER( category, "IsAbCategory" );
-        
-        TryNextMethod( );
-        
-    fi;
-    
-    return false;
-    
-end );
-

--- a/DeductiveSystemForCAP/PackageInfo.g
+++ b/DeductiveSystemForCAP/PackageInfo.g
@@ -2,13 +2,7 @@ SetPackageInfo( rec(
 
 PackageName := "DeductiveSystemForCAP",
 Subtitle := "Deductive system for CAP",
-Version := Maximum( [
-  "2016.01-17", ## Sebas' version
-  ## this line prevents merge conflicts
-  "2015.04-15", ## Sepp's version
-  ## this line prevents merge conflicts
-  "2021.05-01", ## Fabian's version
-] ),
+Version := "2022.03-01",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
@@ -86,7 +80,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.6",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2021.05-01" ] ],
+                           [ "CAP", ">= 2022.03-01" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),

--- a/DeductiveSystemForCAP/gap/DeductiveSystem.gi
+++ b/DeductiveSystemForCAP/gap/DeductiveSystem.gi
@@ -628,7 +628,7 @@ InstallMethod( DeductiveSystem,
     
     ADDS_FOR_DEDUCTIVE_SYSTEM( deductive_system, category );
     
-    INSTALL_LOGICAL_IMPLICATIONS_HELPER_EVAL_RULES( category, deductive_system, "General" );
+    INSTALL_LOGICAL_IMPLICATIONS_HELPER_EVAL_RULES( category, deductive_system, "IsCapCategory" );
     
     return deductive_system;
     

--- a/DeductiveSystemForCAP/gap/LogicForDeductiveSystem.gd
+++ b/DeductiveSystemForCAP/gap/LogicForDeductiveSystem.gd
@@ -13,6 +13,8 @@
 
 DeclareGlobalFunction( "INSTALL_LOGICAL_IMPLICATIONS_HELPER_EVAL_RULES" );
 
+DeclareAttribute( "INSTALL_LOGICAL_IMPLICATIONS",
+                  IsCapCategory );
 
 ## Theorems
 


### PR DESCRIPTION
This allows us to suspend/resume method reordering once instead of multiple times per category. The only regression is that this way all categorical properties have to be set before calling Finalize, but setting properties afterwards is a bad idea anyway because then derivations specific to this property cannot be triggered anymore.

This gives a speedup of some 100ms per category, which is particularly noticeable when categories are created during package loading (e.g. TerminalCategory, FinSets, SkeletalFinSets).

@sebastianpos Since the modified code is very old, I would like your general okay for this, but no deep technical review should be required.