### PR TITLE
Use InstallOtherMethodForCompilerForCAP for with given functorial convenience

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/LimitConvenience.gi
+++ b/CAP/gap/LimitConvenience.gi
@@ -491,13 +491,13 @@ end );
             
             output_string := Concatenation( output_string, current_string );
             
+            # it is safe to use InstallOtherMethodForCompilerForCAP because there is no other four-argument convenience method for with given functorials
             current_string := ReplacedStringViaRecord( """
 ##
-InstallOtherMethod( functorial_with_given_name,
-               [ IsCapCategory, IsCapCategoryObject, filter_list, IsCapCategoryObject ],
+InstallOtherMethodForCompilerForCAP( functorial_with_given_name,
+                                     [ IsCapCategory, IsCapCategoryObject, filter_list, IsCapCategoryObject ],
                
   function( cat, source, input_arguments, range )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return functorial_with_given_name( cat, source, source_diagram_arguments, input_arguments, range_diagram_arguments, range );
     

--- a/CAP/gap/LimitConvenienceOutput.gi
+++ b/CAP/gap/LimitConvenienceOutput.gi
@@ -619,11 +619,10 @@ InstallOtherMethod( DirectProductFunctorialWithGivenDirectProducts,
 end );
 
 ##
-InstallOtherMethod( DirectProductFunctorialWithGivenDirectProducts,
-               [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
+InstallOtherMethodForCompilerForCAP( DirectProductFunctorialWithGivenDirectProducts,
+                                     [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
                
   function( cat, source, L, range )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return DirectProductFunctorialWithGivenDirectProducts( cat, source, List( L, Source ), L, List( L, Range ), range );
     
@@ -669,11 +668,10 @@ InstallOtherMethod( CoproductFunctorialWithGivenCoproducts,
 end );
 
 ##
-InstallOtherMethod( CoproductFunctorialWithGivenCoproducts,
-               [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
+InstallOtherMethodForCompilerForCAP( CoproductFunctorialWithGivenCoproducts,
+                                     [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
                
   function( cat, source, L, range )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return CoproductFunctorialWithGivenCoproducts( cat, source, List( L, Source ), L, List( L, Range ), range );
     
@@ -1303,11 +1301,10 @@ InstallOtherMethod( DirectSumFunctorialWithGivenDirectSums,
 end );
 
 ##
-InstallOtherMethod( DirectSumFunctorialWithGivenDirectSums,
-               [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
+InstallOtherMethodForCompilerForCAP( DirectSumFunctorialWithGivenDirectSums,
+                                     [ IsCapCategory, IsCapCategoryObject, IsList, IsCapCategoryObject ],
                
   function( cat, source, L, range )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return DirectSumFunctorialWithGivenDirectSums( cat, source, List( L, Source ), L, List( L, Range ), range );
     


### PR DESCRIPTION
Fixes #855.

There are more places where `InstallOtherMethodForCompilerForCAP` could be used, but since they are not needed right now I would not add them until the end of April. Then, many deprecations I added last year can be removed, which will simplify the limit convenience significantly.