### PR TITLE
Use Codecov flags and exclude a non-terminating test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,55 @@ fixes:
   - "/home/gap/.gap/pkg/CAP_project/::"
 ignore:
   - "home/"
+flags:
+  CAP:
+    paths:
+      - "CAP/"
+  ActionsForCAP:
+    paths:
+      - "ActionsForCAP/"
+  AttributeCategoryForCAP:
+    paths:
+      - "AttributeCategoryForCAP/"
+  CompilerForCAP:
+    paths:
+      - "CompilerForCAP/"
+  ComplexesAndFilteredObjectsForCAP:
+    paths:
+      - "ComplexesAndFilteredObjectsForCAP/"
+  DeductiveSystemForCAP:
+    paths:
+      - "DeductiveSystemForCAP/"
+  FreydCategoriesForCAP:
+    paths:
+      - "FreydCategoriesForCAP/"
+  GeneralizedMorphismsForCAP:
+    paths:
+      - "GeneralizedMorphismsForCAP/"
+  GradedModulePresentationsForCAP:
+    paths:
+      - "GradedModulePresentationsForCAP/"
+  GroupRepresentationsForCAP:
+    paths:
+      - "GroupRepresentationsForCAP/"
+  HomologicalAlgebraForCAP:
+    paths:
+      - "HomologicalAlgebraForCAP/"
+  InternalExteriorAlgebraForCAP:
+    paths:
+      - "InternalExteriorAlgebraForCAP/"
+  LinearAlgebraForCAP:
+    paths:
+      - "LinearAlgebraForCAP/"
+  ModulePresentationsForCAP:
+    paths:
+      - "ModulePresentationsForCAP/"
+  ModulesOverLocalRingsForCAP:
+    paths:
+      - "ModulesOverLocalRingsForCAP/"
+  MonoidalCategories:
+    paths:
+      - "MonoidalCategories/"
+  ToricSheaves:
+    paths:
+      - "ToricSheaves/"

--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ActionsForCAP/README.md
+++ b/ActionsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Actions and Coactions for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=ActionsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/ActionsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/ActionsForCAP#top

--- a/AttributeCategoryForCAP/PackageInfo.g
+++ b/AttributeCategoryForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "AttributeCategoryForCAP",
 Subtitle := "Automatic enhancement with attributes of a CAP category",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/AttributeCategoryForCAP/README.md
+++ b/AttributeCategoryForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Automatic enhancement with attributes of a CAP category
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=AttributeCategoryForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/AttributeCategoryForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/AttributeCategoryForCAP#top

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.03-03",
+Version := "2022.03-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/README.md
+++ b/CAP/README.md
@@ -3,7 +3,7 @@
 
 ### Categories, Algorithms, Programming
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -29,8 +29,8 @@ Its website is located [here](http://homalg-project.github.io/CAP_project/CAP).
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=CAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/CAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/CAP#top

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/README.md
+++ b/CompilerForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Speed up computations in CAP categories
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -57,8 +57,8 @@ Thus, there is no penalty in writing high-level code: Using `CompilerForCAP`, an
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=CompilerForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/CompilerForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/CompilerForCAP#top

--- a/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
+++ b/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ComplexesAndFilteredObjectsForCAP",
 Subtitle := "Implementation of complexes, cocomplexes and filtered objects for CAP",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ComplexesAndFilteredObjectsForCAP/README.md
+++ b/ComplexesAndFilteredObjectsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Implementation of complexes, cocomplexes and filtered objects for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=ComplexesAndFilteredObjectsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/ComplexesAndFilteredObjectsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/ComplexesAndFilteredObjectsForCAP#top

--- a/DeductiveSystemForCAP/PackageInfo.g
+++ b/DeductiveSystemForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "DeductiveSystemForCAP",
 Subtitle := "Deductive system for CAP",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/DeductiveSystemForCAP/README.md
+++ b/DeductiveSystemForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Deductive system for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=DeductiveSystemForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/DeductiveSystemForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/DeductiveSystemForCAP#top

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/README.md
+++ b/FreydCategoriesForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Freyd categories - Formal (co)kernels for additive categories
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -63,8 +63,8 @@ Sebastian Posur, [*Methods of constructive category theory*](https://arxiv.org/a
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=FreydCategoriesForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/FreydCategoriesForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/FreydCategoriesForCAP#top

--- a/GeneralizedMorphismsForCAP/PackageInfo.g
+++ b/GeneralizedMorphismsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GeneralizedMorphismsForCAP",
 Subtitle := "Implementations of generalized morphisms for the CAP project",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GeneralizedMorphismsForCAP/README.md
+++ b/GeneralizedMorphismsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Implementations of generalized morphisms for the CAP project
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=GeneralizedMorphismsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/GeneralizedMorphismsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/GeneralizedMorphismsForCAP#top

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GradedModulePresentationsForCAP/README.md
+++ b/GradedModulePresentationsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Presentations for graded modules
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=GradedModulePresentationsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/GradedModulePresentationsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/GradedModulePresentationsForCAP#top

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GroupRepresentationsForCAP/README.md
+++ b/GroupRepresentationsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Skeletal category of group representations for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -25,8 +25,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=GroupRepresentationsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/GroupRepresentationsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/GroupRepresentationsForCAP#top

--- a/HomologicalAlgebraForCAP/PackageInfo.g
+++ b/HomologicalAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomologicalAlgebraForCAP",
 Subtitle := "Homological algebra algorithms for CAP",
-Version := "2022.03-02",
+Version := "2022.03-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/HomologicalAlgebraForCAP/README.md
+++ b/HomologicalAlgebraForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Homological algebra algorithms for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=HomologicalAlgebraForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/HomologicalAlgebraForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/HomologicalAlgebraForCAP#top

--- a/InternalExteriorAlgebraForCAP/PackageInfo.g
+++ b/InternalExteriorAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "InternalExteriorAlgebraForCAP",
 Subtitle := "Constructions for Modules over the Internal Exterior Algebra for CAP",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/InternalExteriorAlgebraForCAP/README.md
+++ b/InternalExteriorAlgebraForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Constructions for Modules over the Internal Exterior Algebra for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=InternalExteriorAlgebraForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/InternalExteriorAlgebraForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/InternalExteriorAlgebraForCAP#top

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/README.md
+++ b/LinearAlgebraForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Category of Matrices over a Field for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=LinearAlgebraForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/LinearAlgebraForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/LinearAlgebraForCAP#top

--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ModulePresentationsForCAP",
 Subtitle := "Category R-pres for CAP",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ModulePresentationsForCAP/README.md
+++ b/ModulePresentationsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Category R-pres for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=ModulePresentationsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/ModulePresentationsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/ModulePresentationsForCAP#top

--- a/ModulesOverLocalRingsForCAP/PackageInfo.g
+++ b/ModulesOverLocalRingsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ModulesOverLocalRingsForCAP",
 Subtitle := "Category of modules over a local ring modeled by Serre quotients for CAP",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ModulesOverLocalRingsForCAP/README.md
+++ b/ModulesOverLocalRingsForCAP/README.md
@@ -3,7 +3,7 @@
 
 ### Category of modules over a local ring modeled by Serre quotients for CAP
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=ModulesOverLocalRingsForCAP
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/ModulesOverLocalRingsForCAP
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/ModulesOverLocalRingsForCAP#top

--- a/ModulesOverLocalRingsForCAP/examples/IntersectionFormula.g
+++ b/ModulesOverLocalRingsForCAP/examples/IntersectionFormula.g
@@ -14,43 +14,44 @@ i1 := HomalgMatrix( "[ x-z, y-w ]", 2, 1, R );;
 i2 := HomalgMatrix( "[ y^6*v^2*w-y^3*v*w^20+1, x*y^4*z^4*w-z^5*w^5+x^3*y*z^2-1 ]", 2, 1, R );;
 M1 := AsLeftPresentation( i1 );;
 M2 := AsLeftPresentation( i2 );;
-OI0 := CokernelObject( Annihilator( DirectSum( M1, M2 ) ) );;
-j1 := HomalgMatrix( "[ x*z, x*w, y*z, y*w, v^2 ]", 5, 1, R );;
-j2 := HomalgMatrix( "[ y^6*v^2*w-y^3*v*w^2+1, x*y^4*z^4*w-z^5*w^5+x^3*y*z^2-1, x^7 ]", 3, 1, R );;
-M1 := AsLeftPresentation( j1 );;
-M2 := AsLeftPresentation( j2 );;
-OJ0 := CokernelObject( Annihilator( DirectSum( M1, M2 ) ) );;
-M := AsSerreQuotientCategoryObject( category, OI0 );;
-N := AsSerreQuotientCategoryObject( category, OJ0 );;
-Min := FunctorMinimalModel( category );;
-M_min := ApplyFunctor( Min, M );;
-N_min := ApplyFunctor( Min, N );;
-T := TorComplex( M_min, N_min );;
-H0 := HomologyFunctor( category, 0 );;
-H1 := HomologyFunctor( category, 1 );;
-H2 := HomologyFunctor( category, 2 );;
-h0 := ApplyFunctor( H0, T );;
-MinimalNumberOfGenerators( h0 );
-#! 1
-h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
-MinimalNumberOfGenerators( h0 );
-#! 3
-h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
-MinimalNumberOfGenerators( h0 );
-#! 2
-h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
-MinimalNumberOfGenerators( h0 );
-#! 0
-h1 := ApplyFunctor( H1, T );;
-MinimalNumberOfGenerators( h1 );
-#! 1
-h1 := Source( FiltrationByPrimeIdealEmbedding( h1 ) );;
-MinimalNumberOfGenerators( h1 );
-#! 1
-h1 := Source( FiltrationByPrimeIdealEmbedding( h1 ) );;
-MinimalNumberOfGenerators( h1 );
-#! 0
-h2 := ApplyFunctor( H2, T );;
-MinimalNumberOfGenerators( h2 );
-#! 0
+# the next line does not terminate in time, see https://github.com/homalg-project/CAP_project/issues/857
+#OI0 := CokernelObject( Annihilator( DirectSum( M1, M2 ) ) );;
+#j1 := HomalgMatrix( "[ x*z, x*w, y*z, y*w, v^2 ]", 5, 1, R );;
+#j2 := HomalgMatrix( "[ y^6*v^2*w-y^3*v*w^2+1, x*y^4*z^4*w-z^5*w^5+x^3*y*z^2-1, x^7 ]", 3, 1, R );;
+#M1 := AsLeftPresentation( j1 );;
+#M2 := AsLeftPresentation( j2 );;
+#OJ0 := CokernelObject( Annihilator( DirectSum( M1, M2 ) ) );;
+#M := AsSerreQuotientCategoryObject( category, OI0 );;
+#N := AsSerreQuotientCategoryObject( category, OJ0 );;
+#Min := FunctorMinimalModel( category );;
+#M_min := ApplyFunctor( Min, M );;
+#N_min := ApplyFunctor( Min, N );;
+#T := TorComplex( M_min, N_min );;
+#H0 := HomologyFunctor( category, 0 );;
+#H1 := HomologyFunctor( category, 1 );;
+#H2 := HomologyFunctor( category, 2 );;
+#h0 := ApplyFunctor( H0, T );;
+#MinimalNumberOfGenerators( h0 );
+## 1
+#h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
+#MinimalNumberOfGenerators( h0 );
+## 3
+#h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
+#MinimalNumberOfGenerators( h0 );
+## 2
+#h0 := Source( FiltrationByPrimeIdealEmbedding( h0 ) );;
+#MinimalNumberOfGenerators( h0 );
+## 0
+#h1 := ApplyFunctor( H1, T );;
+#MinimalNumberOfGenerators( h1 );
+## 1
+#h1 := Source( FiltrationByPrimeIdealEmbedding( h1 ) );;
+#MinimalNumberOfGenerators( h1 );
+## 1
+#h1 := Source( FiltrationByPrimeIdealEmbedding( h1 ) );;
+#MinimalNumberOfGenerators( h1 );
+## 0
+#h2 := ApplyFunctor( H2, T );;
+#MinimalNumberOfGenerators( h2 );
+## 0
 #! @EndExample

--- a/ModulesOverLocalRingsForCAP/tst/100_LoadPackage.tst
+++ b/ModulesOverLocalRingsForCAP/tst/100_LoadPackage.tst
@@ -7,8 +7,12 @@ gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
 gap> LoadPackage( "ModulesOverLocalRingsForCAP", false );
 true
+gap> LoadPackage( "IO_ForHomalg", false );
+true
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
 gap> LoadPackage( "ModulesOverLocalRingsForCAP" );
+true
+gap> LoadPackage( "IO_ForHomalg" );
 true
 gap> SetInfoLevel( InfoPackageLoading, package_loading_info_level );;
 gap> HOMALG_IO.show_banners := false;;

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/README.md
+++ b/MonoidalCategories/README.md
@@ -3,7 +3,7 @@
 
 ### Monoidal and monoidal (co)closed categories
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -25,8 +25,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=MonoidalCategories
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/MonoidalCategories
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/MonoidalCategories#top

--- a/ToricSheaves/PackageInfo.g
+++ b/ToricSheaves/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToricSheaves",
 Subtitle := "Toric sheaves as Serre quotients",
-Version := "2022.03-01",
+Version := "2022.03-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ToricSheaves/README.md
+++ b/ToricSheaves/README.md
@@ -3,7 +3,7 @@
 
 ### Toric sheaves as Serre quotients
 
-| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage of [CAP_project](/../../) |
+| Documentation | Latest Release | Build Status of [CAP_project](/../../) | Code Coverage |
 | ------------- | -------------- | ------------ | ------------- |
 | [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
@@ -24,8 +24,8 @@
 [tests-img]: https://github.com/homalg-project/CAP_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/CAP_project/actions?query=workflow%3ATests+branch%3Amaster
 
-[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project
+[codecov-img]: https://codecov.io/gh/homalg-project/CAP_project/branch/master/graph/badge.svg?flag=ToricSheaves
+[codecov-url]: https://codecov.io/gh/homalg-project/CAP_project/tree/master/ToricSheaves
 
 [code-img]: https://img.shields.io/badge/-View%20code-blue?logo=github
 [code-url]: https://github.com/homalg-project/CAP_project/tree/master/ToricSheaves#top

--- a/makefile
+++ b/makefile
@@ -108,8 +108,7 @@ test_ModulePresentationsForCAP:
 	$(MAKE) -C ModulePresentationsForCAP test
 
 test_ModulesOverLocalRingsForCAP:
-# does not terminate, see https://github.com/homalg-project/CAP_project/issues/857
-#	$(MAKE) -C ModulesOverLocalRingsForCAP test
+	$(MAKE) -C ModulesOverLocalRingsForCAP test
 
 test_MonoidalCategories:
 	$(MAKE) -C MonoidalCategories test
@@ -163,8 +162,7 @@ ci-test_ModulePresentationsForCAP:
 	$(MAKE) -C ModulePresentationsForCAP ci-test
 
 ci-test_ModulesOverLocalRingsForCAP:
-# does not terminate, see https://github.com/homalg-project/CAP_project/issues/857
-#	$(MAKE) -C ModulesOverLocalRingsForCAP ci-test
+	$(MAKE) -C ModulesOverLocalRingsForCAP ci-test
 
 ci-test_MonoidalCategories:
 	$(MAKE) -C MonoidalCategories ci-test

--- a/upload_codecov.sh
+++ b/upload_codecov.sh
@@ -23,4 +23,20 @@ shasum -a 256 -c codecov.SHA256SUM
 
 # execute
 chmod +x codecov
-./codecov -Z -f "coverage*.json"
+./codecov -Z -f "coverage*.json" -F CAP
+./codecov -Z -f "coverage*.json" -F ActionsForCAP
+./codecov -Z -f "coverage*.json" -F AttributeCategoryForCAP
+./codecov -Z -f "coverage*.json" -F CompilerForCAP
+./codecov -Z -f "coverage*.json" -F ComplexesAndFilteredObjectsForCAP
+./codecov -Z -f "coverage*.json" -F DeductiveSystemForCAP
+./codecov -Z -f "coverage*.json" -F FreydCategoriesForCAP
+./codecov -Z -f "coverage*.json" -F GeneralizedMorphismsForCAP
+./codecov -Z -f "coverage*.json" -F GradedModulePresentationsForCAP
+./codecov -Z -f "coverage*.json" -F GroupRepresentationsForCAP
+./codecov -Z -f "coverage*.json" -F HomologicalAlgebraForCAP
+./codecov -Z -f "coverage*.json" -F InternalExteriorAlgebraForCAP
+./codecov -Z -f "coverage*.json" -F LinearAlgebraForCAP
+./codecov -Z -f "coverage*.json" -F ModulePresentationsForCAP
+./codecov -Z -f "coverage*.json" -F ModulesOverLocalRingsForCAP
+./codecov -Z -f "coverage*.json" -F MonoidalCategories
+./codecov -Z -f "coverage*.json" -F ToricSheaves


### PR DESCRIPTION
Now `CompilerForCAP` can finally display its high code coverage in the readme :-)