### PR TITLE
Add new primitive: AdditiveGenerators

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.04-01",
+Version := "2022.04-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -31,6 +31,25 @@ DeclareOperation( "AddAdditionForMorphisms",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
+#! to the category for the basic operation `AdditiveGenerators`.
+#! $F: (  ) \mapsto \mathtt{AdditiveGenerators}()$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddAdditiveGenerators",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddAdditiveGenerators",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddAdditiveGenerators",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddAdditiveGenerators",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
 #! to the category for the basic operation `AdditiveInverseForMorphisms`.
 #! $F: ( a ) \mapsto \mathtt{AdditiveInverseForMorphisms}(a)$.
 #! @Returns nothing

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -288,6 +288,14 @@ DeclareAttribute( "RangeCategoryOfHomomorphismStructure",
 # make this mutable so we can overwrite it even if
 # some category constructor has already set it
 
+#! @Description
+#! The argument is an additive category $C$.
+#! The output is a list $L$ of objects in $C$ such that every object in $C$ is a finite direct sum of objects in $L$.
+#! @Arguments C
+#! @Returns a list of objects
+DeclareAttribute( "AdditiveGenerators",
+                  IsCapCategory );
+
 #############################################
 ##
 #! @Section Logic switcher

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -421,6 +421,10 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     CAP_INTERNAL_ASSERT_IS_LIST_OF_MORPHISMS_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
                 fi;
             end;
+        elif record.return_type = "list_of_objects" then
+            output_sanity_check_function := function( result )
+                CAP_INTERNAL_ASSERT_IS_LIST_OF_OBJECTS_OF_CATEGORY( result, category, output_human_readable_identifier_getter );
+            end;
         elif record.return_type = "nonneg_integer_or_infinity" then
             output_sanity_check_function := function( result )
                 CAP_INTERNAL_ASSERT_IS_NON_NEGATIVE_INTEGER_OR_INFINITY( result, output_human_readable_identifier_getter );

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -19,6 +19,7 @@ InstallValue( CAP_INTERNAL_VALID_RETURN_TYPES,
         "list_of_morphisms",
         "list_of_morphisms_or_fail",
         "nonneg_integer_or_infinity",
+        "list_of_objects"
     ]
 #! @EndCode
 );
@@ -3544,6 +3545,12 @@ InjectiveDimension := rec(
   return_type := "nonneg_integer_or_infinity",
   dual_operation := "ProjectiveDimension",
   ),
+
+AdditiveGenerators := rec(
+  filter_list := [ "category" ],
+  return_type := "list_of_objects",
+  dual_operation := "AdditiveGenerators",
+),
 
 ) );
 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -289,6 +289,10 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                 
                 return_statement := "return List( result, mor -> MorphismConstructor( cat, ObjectConstructor( cat, Range( mor ) ), mor, ObjectConstructor( cat, Source( mor ) ) ) )";
                 
+            elif return_type = "list_of_objects" then
+                
+                return_statement := "return List( result, obj -> ObjectConstructor( cat, obj ) )";
+                
             elif return_type = "bool" then
                 
                 return_statement := "return result";

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.04-02",
+Version := "2022.04-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -88,7 +88,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2022.01-05" ],
+                           [ "CAP", ">= 2022.04-02" ],
                            [ "MatricesForHomalg", ">= 2021.07-01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "LinearAlgebraForCAP", ">= 2020.05.16" ],

--- a/FreydCategoriesForCAP/examples/CategoryOfRows.g
+++ b/FreydCategoriesForCAP/examples/CategoryOfRows.g
@@ -54,6 +54,8 @@ Display( UnderlyingMatrix( mor ) );
 ########################################################################
 
 #! @Example
+Size( AdditiveGenerators( rows ) );
+#! 1
 ZeroObject( rows );
 #! <A row module over Z of rank 0>
 obj5 := CategoryOfRowsObject( 2, rows );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -13,6 +13,7 @@
 
 #! The following CAP operations are supported:
 #! * <Ref BookName="CAP" Func="AdditionForMorphisms" Label="for Is" />
+#! * <Ref BookName="CAP" Func="AdditiveGenerators" Label="for Is" />
 #! * <Ref BookName="CAP" Func="AdditiveInverseForMorphisms" Label="for Is" />
 #! * <Ref BookName="FreydCategoriesForCAP" Func="BiasedWeakFiberProduct" Label="for Is" />
 #! * <Ref BookName="FreydCategoriesForCAP" Func="BiasedWeakPushout" Label="for Is" />

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -482,6 +482,14 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
         
     end );
     
+    ##
+    AddAdditiveGenerators( category,
+      function( cat )
+        
+        return [ CategoryOfRowsObject( cat, 1 ) ];
+        
+    end );
+    
     ## Basic Operations for a Category
     ##
     AddIdentityMorphism( category,

--- a/FreydCategoriesForCAP/gap/QuiverRows.gi
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gi
@@ -800,6 +800,14 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_QUIVER_ROWS,
         
     end );
     
+    ##
+    AddAdditiveGenerators( category,
+      function( cat )
+        
+        return List( Vertices( UnderlyingQuiver( cat ) ), v -> AsQuiverRowsObject( v, cat ) );
+        
+    end );
+    
     ## Basic Operations for a Category
     
     ##


### PR DESCRIPTION
@zickgraf Unfortunately, this new primitive yields errors in `CompilerForCAP`. Maybe this is the case because `AdditiveGenerators` is the first primitive whose output is a list of objects?