### PR TITLE
Outline wrapped arguments

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.04-05",
+Version := "2022.04-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/CapJitInlinedBindings.g
+++ b/CompilerForCAP/examples/CapJitInlinedBindings.g
@@ -53,41 +53,4 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 tree = tree2;
 #! true
 
-
-
-# test (nested) cancellation in CapJitInlinedBindings
-QQ := HomalgFieldOfRationals( );;
-vec := MatrixCategory( QQ );;
-op := Opposite( vec );;
-
-# we have to work hard to not write semicolons so AutoDoc
-# does not begin a new statement
-func := EvalString( ReplacedString( """function( )
-  local obj_tmp, dimension_tmp, obj, obj_op, obj_op_unwrapped, dimension@
-    
-    obj_tmp := ObjectifyObjectForCAPWithAttributes( rec( ), vec, Dimension, 1 )@
-    
-    dimension_tmp := Dimension( obj_tmp )@
-    
-    obj := ObjectifyObjectForCAPWithAttributes(
-        rec( ), vec, Dimension, dimension_tmp )@
-    
-    obj_op := ObjectifyObjectForCAPWithAttributes( rec( ), op, Opposite, obj )@
-    
-    obj_op_unwrapped := Opposite( obj_op )@
-    
-    dimension := Dimension( obj_op_unwrapped )@
-    
-    return dimension@
-    
-end""", "@", ";" ) );;
-
-tree := ENHANCED_SYNTAX_TREE( func );;
-
-tree := CapJitInlinedBindings( tree );;
-Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
-#! function (  )
-#!     return 1;
-#! end
-
 #! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -169,11 +169,12 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     rule_phase_functions := [
         CapJitInferredDataTypes,
         CapJitAppliedLogic,
+        CapJitDroppedUnusedBindings,
         CapJitDroppedHandledEdgeCases,
         CapJitInlinedArguments,
         CapJitInlinedSimpleFunctionCalls,
         CapJitInlinedFunctionCalls,
-        CapJitDroppedUnusedBindings,
+        CapJitOutlinedWrappedArguments,
         CapJitInlinedBindings,
     ];
     
@@ -227,6 +228,16 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     od;
     
     # post-processing
+    
+    if debug then
+        # COVERAGE_IGNORE_BLOCK_START
+        compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+        Display( compiled_func );
+        Error( "apply CapJitInlinedBindingsFully" );
+        # COVERAGE_IGNORE_BLOCK_END
+    fi;
+    
+    tree := CapJitInlinedBindingsFully( tree );
     
     if category_as_first_argument then
         

--- a/CompilerForCAP/gap/DropUnusedBindings.gi
+++ b/CompilerForCAP/gap/DropUnusedBindings.gi
@@ -40,6 +40,8 @@ InstallGlobalFunction( CapJitDroppedUnusedBindings, function ( tree )
                 
                 pre_func := function ( tree, additional_arguments )
                     
+                    # WARNING for refactoring: the logic for Iterated/CapFixpoint applies CapJitDroppedUnusedBindings to subtrees
+                    
                     # we can ignore arguments because those are never bound
                     if tree.type = "EXPR_REF_FVAR" and tree.func_id = func.id and tree.name in func.bindings.names then
                         

--- a/CompilerForCAP/gap/InlineBindings.gd
+++ b/CompilerForCAP/gap/InlineBindings.gd
@@ -7,13 +7,15 @@
 
 #! @Section Compilation steps
 
-# helper
+# helpers
 DeclareGlobalFunction( "CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY" );
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_INLINED_BINDINGS" );
 
 #! @Description
 #!   Example: transforms `function() local x; x := 1; return x^2; end` into `function() return 1^2; end()`.
 #!   Details: Replaces references to local variables of a function by the value of the corresponding binding of the function.
 #!   If the option `inline_var_refs_only` is set to `true`, this is only done if the value is a reference to a (local or global) variable.
+#!   If the option `inline_fully` is NOT set to `true`, wrapped arguments are not inlined (see <Ref Func="CapJitOutlinedWrappedArguments" />).
 #!   Also drops the inlined bindings.
 #! @Returns a record
 #! @Arguments tree
@@ -24,3 +26,9 @@ DeclareGlobalFunction( "CapJitInlinedBindings" );
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitInlinedBindingsToVariableReferences" );
+
+#! @Description
+#!   Short hand for `CapJitInlinedBindings( `<A>tree</A>` : inline_fully := true )`.
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitInlinedBindingsFully" );

--- a/CompilerForCAP/gap/Logic.gd
+++ b/CompilerForCAP/gap/Logic.gd
@@ -7,6 +7,10 @@
 
 #! @Section Logic
 
+#! Warning: When writing logic functions and templates keep in mind that wrapped arguments are outlined, see <Ref Func="CapJitOutlinedWrappedArguments" />.
+#! This means that for example a logic template of the form `ObjectifyObjectForCAPWithAttributes( rec( ), cat, attr, MyFunction( x ) )` will
+#! never match because `MyFunction( x )` is outlined to a local variable.
+
 #! @Description
 #!   Adds the function <A>func</A> to the list of logic functions.
 #!   For a list of pre-installed logic functions, which can be used as guiding examples, see `CompilerForCAP/gap/Logic.gi`.

--- a/CompilerForCAP/gap/OutlineWrappedArguments.gd
+++ b/CompilerForCAP/gap/OutlineWrappedArguments.gd
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Declarations
+#
+#! @Chapter Improving and extending the compiler
+
+#! @Section Compilation steps
+
+#! @Description
+#!   Outlines wrapped arguments to local variables. This includes:
+#!     * the attribute values in `ObjectifyObjectForCAPWithAttributes`
+#!     * the attribute values (including the arguments `source` and `range`) in `ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes`
+#!     * the entries of literal lists
+#! @Returns a record
+#! @Arguments tree
+DeclareGlobalFunction( "CapJitOutlinedWrappedArguments" );

--- a/CompilerForCAP/gap/OutlineWrappedArguments.gi
+++ b/CompilerForCAP/gap/OutlineWrappedArguments.gi
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CompilerForCAP: Speed up computations in CAP categories
+#
+# Implementations
+#
+
+BindGlobal( "CAP_JIT_INTERNAL_GET_KEY_AND_POSITIONS_TO_OUTLINE", function ( tree, func_stack )
+  local key, positions_to_outline, source, fvar, func, range;
+    
+    if tree.type = "EXPR_LIST" then
+        
+        key := "list";
+        
+        positions_to_outline := [ 1 .. tree.list.length ];
+        
+    elif CapJitIsCallToGlobalFunction( tree, "ObjectifyObjectForCAPWithAttributes" ) then
+        
+        key := "args";
+        
+        # ObjectifyObjectForCAPWithAttributes( rec( ), cat, attr1, val1, attr2, val2, ... );
+        positions_to_outline := [ 4, 6 .. tree.args.length ];
+        
+    elif CapJitIsCallToGlobalFunction( tree, "ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes" ) then
+        
+        key := "args";
+        
+        # ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat, source, range, attr1, val1, attr2, val2, ... );
+        positions_to_outline := Concatenation( [ 3, 4 ], [ 6, 8 .. tree.args.length ] );
+        
+        # HACK: The logic for Iterated/CapFixpoint checks if source and range are of the form
+        # `Source( first_argument_of_function )` and `Range( first_argument_of_function )`.
+        # Thus, we must not outline source and range in this case.
+        # Better solution: introduce `Iterated/CapFixpointForMorphismWithGivenSourceAndRange`
+        
+        source := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( tree.args.3, func_stack );
+        
+        if CapJitIsCallToGlobalFunction( source, "Source" ) and source.args.length = 1 and source.args.1.type = "EXPR_REF_FVAR" then
+            
+            fvar := source.args.1;
+            
+            func := First( func_stack, func -> func.id = fvar.func_id );
+            Assert( 0, func <> fail );
+            
+            if fvar.name = func.nams[1] and func.narg > 0 then
+                
+                RemoveSet( positions_to_outline, 3 );
+                
+            fi;
+            
+        fi;
+        
+        range := CAP_JIT_INTERNAL_RESOLVE_EXPR_REF_FVAR_RECURSIVELY( tree.args.4, func_stack );
+        
+        if CapJitIsCallToGlobalFunction( range, "Range" ) and range.args.length = 1 and range.args.1.type = "EXPR_REF_FVAR" then
+            
+            fvar := range.args.1;
+            
+            func := First( func_stack, func -> func.id = fvar.func_id );
+            Assert( 0, func <> fail );
+            
+            if fvar.name = func.nams[1] and func.narg > 0 then
+                
+                RemoveSet( positions_to_outline, 4 );
+                
+            fi;
+            
+        fi;
+        
+    else
+        
+        return fail;
+        
+    fi;
+    
+    return rec( key := key, positions_to_outline := positions_to_outline );
+    
+end );
+
+InstallGlobalFunction( CapJitOutlinedWrappedArguments, function ( tree )
+  local result_func, additional_arguments_func;
+    
+    # functions will be modified inline
+    tree := StructuralCopy( tree );
+    
+    result_func := function ( tree, result, keys, func_stack )
+      local info, func, id, new_variable_name, key, i;
+        
+        for key in keys do
+            
+            tree.(key) := result.(key);
+            
+        od;
+        
+        info := CAP_JIT_INTERNAL_GET_KEY_AND_POSITIONS_TO_OUTLINE( tree, func_stack );
+        
+        if info = fail then
+            
+            return tree;
+            
+        fi;
+        
+        func := Last( func_stack );
+        
+        id := CapJitGetNextUnusedVariableID( func );
+        
+        for i in info.positions_to_outline do
+            
+            if tree.(info.key).(i).type in [ "EXPR_INT", "EXPR_STRING", "EXPR_CHAR", "EXPR_TRUE", "EXPR_FALSE", "EXPR_REF_GVAR", "EXPR_REF_FVAR" ] then
+                continue;
+            fi;
+            
+            new_variable_name := Concatenation( "outlined_", String( id ) );
+            id := id + 1;
+            
+            func.nams := Concatenation( func.nams, [ new_variable_name ] );
+            
+            CapJitAddBinding( func.bindings, new_variable_name, tree.(info.key).(i) );
+            
+            tree.(info.key).(i) := rec(
+                type := "EXPR_REF_FVAR",
+                func_id := func.id,
+                name := new_variable_name,
+            );
+            
+        od;
+        
+        return tree;
+        
+    end;
+    
+    additional_arguments_func := function ( tree, key, func_stack )
+        
+        if tree.type = "EXPR_DECLARATIVE_FUNC" then
+            
+            return Concatenation( func_stack, [ tree ] );
+            
+        else
+            
+            return func_stack;
+            
+        fi;
+        
+    end;
+    
+    return CapJitIterateOverTree( tree, ReturnFirst, result_func, additional_arguments_func, [ ] );
+    
+end );

--- a/CompilerForCAP/init.g
+++ b/CompilerForCAP/init.g
@@ -24,6 +24,8 @@ ReadPackage( "CompilerForCAP", "gap/InlineArguments.gd" );
 
 ReadPackage( "CompilerForCAP", "gap/DropUnusedBindings.gd" );
 
+ReadPackage( "CompilerForCAP", "gap/OutlineWrappedArguments.gd" );
+
 ReadPackage( "CompilerForCAP", "gap/InlineBindings.gd" );
 
 ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gd" );

--- a/CompilerForCAP/read.g
+++ b/CompilerForCAP/read.g
@@ -24,6 +24,8 @@ ReadPackage( "CompilerForCAP", "gap/InlineArguments.gi" );
 
 ReadPackage( "CompilerForCAP", "gap/DropUnusedBindings.gi" );
 
+ReadPackage( "CompilerForCAP", "gap/OutlineWrappedArguments.gi" );
+
 ReadPackage( "CompilerForCAP", "gap/InlineBindings.gi" );
 
 ReadPackage( "CompilerForCAP", "gap/ResolveGlobalVariables.gi" );

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.04-01",
+Version := "2022.04-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gd
@@ -13,3 +13,7 @@
 
 DeclareOperation( "CategoryOfRowsAsAdditiveClosureOfRingAsCategory",
                   [ IsHomalgRing ] );
+
+# helper for compilation
+DeclareGlobalFunction( "COMPILATION_HELPER_HomalgMatrixFromRingElement" );
+CapJitAddTypeSignature( "COMPILATION_HELPER_HomalgMatrixFromRingElement", [ IsHomalgRingElement, IsHomalgRing ], IsHomalgMatrix );

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
@@ -181,3 +181,9 @@ InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
     return wrapper;
     
 end );
+
+InstallGlobalFunction( COMPILATION_HELPER_HomalgMatrixFromRingElement, function ( ring_element, ring )
+    
+    return HomalgMatrix( [ ring_element ], 1, 1, ring );
+    
+end );

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -47,7 +47,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     hoisted_1_1 := deduped_5_1;
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), deduped_4_1, source_1, range_1, UnderlyingMatrix, CoercedMatrix( deduped_5_1, UnderlyingRing( deduped_4_1 ), CoefficientsWithGivenMonomials( KroneckerMat( TransposedMatrix( deduped_6_1 ), DualKroneckerMat( UnionOfRows( deduped_5_1, NumberColumns( deduped_7_1 ), List( GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure( cat_1 ), function ( generator_2 )
-                        return HomalgMatrix( [ generator_2 ], 1, 1, hoisted_1_1 );
+                        return COMPILATION_HELPER_HomalgMatrixFromRingElement( generator_2, hoisted_1_1 );
                     end ) ), deduped_8_1 ) ), DiagMat( deduped_5_1, List( [ 1 .. NumberRows( deduped_6_1 ) ], function ( logic_new_func_x_2 )
                     return hoisted_3_1;
                 end ) ) ) ) );


### PR DESCRIPTION
This slows down the compiler a bit for small examples (10%), but gives great speedup for suited examples (200%).