### PR TITLE
simplified InfoStringOfInstalledOperationsOfCategory

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.04-02",
+Version := "2022.04-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/PrintingFunctions.gd
+++ b/CAP/gap/PrintingFunctions.gd
@@ -5,8 +5,6 @@
 #
 #! @Chapter Pretty print methods
 
-DeclareGlobalVariable( "CAP_INTERNAL_CATEGORY_PROPERTY_RANK_AND_STRING" );
-
 DeclareGlobalFunction( "InfoStringOfInstalledOperationsOfCategory" );
 
 DeclareGlobalFunction( "InfoOfInstalledOperationsOfCategory" );

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -3,133 +3,37 @@
 #
 # Implementations
 #
-InstallValue( CAP_INTERNAL_CATEGORY_PROPERTY_RANK_AND_STRING, rec( ) );
-
-BindGlobal( "__CAP_INTERNAL_RANK_CATEGORY_FROM_METHOD_RECORD",
-  function( )
-    local list_of_names, i, current, caps_positions, name_list, j, return_list, entries, added;
-    
-    list_of_names := ShallowCopy( RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ) );
-    
-    Remove( list_of_names, Position( list_of_names, "EveryCategory" ) );
-    
-    name_list := [ ];
-    
-    for i in list_of_names do
-        
-        current := ShallowCopy( i );
-        
-        current := current{[ 3 .. Length( current ) ]};
-        
-        if EndsWith( current, "Category" ) then
-            current := current{[ 1 .. Length( current ) - 8 ]};
-        fi;
-        
-        caps_positions := Filtered( [ 1 .. Length( current ) ], j -> current[ j ] in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" );
-        
-        if 1 in caps_positions then
-            Remove( caps_positions, Position( caps_positions, 1 ) );
-        fi;
-        
-        current := LowercaseString( current );
-        
-        for j in Reversed( caps_positions ) do
-            current := Concatenation( current{[ 1 .. j - 1 ]}, " ", current{[ j .. Length( current ) ]} );
-        od;
-        
-        Add( name_list, [ i, current ] );
-        
-    od;
-    
-    return_list := [ ];
-    
-    for i in name_list do
-        
-        entries := CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( i [ 1 ] );
-        
-        added := false;
-        
-        for j in return_list do
-            
-            if ForAll( j, k -> IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( k[ 1 ] ), entries )
-                            or IsSubset( entries, CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( k[ 1 ] ) ) ) then
-                
-                Add( j, i );
-                added := true;
-                break;
-                
-            fi;
-            
-        od;
-        
-        if not added then
-            
-            Add( return_list, [ i ] );
-            
-        fi;
-        
-    od;
-    
-    for i in return_list do
-        Sort( i, function( j, k ) return IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( j[ 1 ] ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( k[ 1 ] ) ); end );
-    od;
-    
-    # Some cosmetics for the lists:
-    # Write Abel with a capital, its the man ;).
-    # Change the order so that the list with Abelian is at the end.
-    
-    for i in return_list do
-        for j in i do
-            j[ 2 ] := ReplacedString( j[ 2 ], "abelian", "Abelian" );
-        od;
-    od;
-    
-    for i in [ 1 .. Length( return_list ) ] do
-        if ForAny( return_list[ i ], j -> j[2] = "Abelian" ) then
-            return_list := Concatenation( return_list{[ 1 .. i - 1 ]}, return_list{[ i + 1 .. Length( return_list ) ]}, [ return_list[ i ] ] );
-        fi;
-    od;
-    
-    return return_list;
-    
-end );
-
-CAP_INTERNAL_CATEGORY_PROPERTY_RANK_AND_STRING.sorted_list := __CAP_INTERNAL_RANK_CATEGORY_FROM_METHOD_RECORD();
-
 InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
   
   function( category )
-    local prim_operations, derived_operations, adjectives, current_stack, current_property, current_adjective, string;
+    local list_of_properties, property, string;
     
     if not IsCapCategory( category ) then
         Error( "first argument must be a category" );
         return;
     fi;
     
-    prim_operations := ListPrimitivelyInstalledOperationsOfCategory( category );
-    derived_operations := ListInstalledOperationsOfCategory( category );
+    list_of_properties := ShallowCopy( RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ) );
+
+    Remove( list_of_properties, Position( list_of_properties, "EveryCategory" ) );
     
-    prim_operations := Length( prim_operations );
-    derived_operations := Length( derived_operations );
+    list_of_properties := Filtered( list_of_properties, p -> CheckConstructivenessOfCategory( category, p ) = [ ] );
     
-    adjectives := [ ];
+    list_of_properties := MaximalObjects( list_of_properties,
+                                  { p1, p2 } -> IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p2 ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p1 ) ) );
     
-    for current_stack in __CAP_INTERNAL_RANK_CATEGORY_FROM_METHOD_RECORD() do
-        for current_property in current_stack do
-            if Length( CheckConstructivenessOfCategory( category, current_property[ 1 ] ) ) = 0 then
-                Add( adjectives, current_property[ 1 ] );
-                break;
-            fi;
-        od;
-    od;
+    StableSortBy( list_of_properties, p -> Length( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p ) ) );
     
-    string := ShallowCopy( String( prim_operations ) );
+    string := ShallowCopy( String( Length( ListPrimitivelyInstalledOperationsOfCategory( category ) ) ) );
     Append( string, " primitive operations were used to derive " );
-    Append( string, String( derived_operations ) );
-    Append( string, " operations for this category which" );
-    for current_adjective in adjectives do
+    Append( string, String( Length( ListInstalledOperationsOfCategory( category ) ) ) );
+    Append( string, " operations for this category" );
+    if not IsEmpty( list_of_properties ) then
+        Append( string, " which constructively" );
+    fi;
+    for property in list_of_properties do
         Append( string, "\n* " );
-        Append( string, current_adjective );
+        Append( string, property );
     od;
     
     return string;

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2022.03-02",
+Version := "2022.04-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -71,7 +71,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2021.10-06" ],
+                           [ "CAP", ">= 2022.04-03" ],
                            [ "ModulePresentationsForCAP", ">=2019.08.07" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "ComplexesAndFilteredObjectsForCAP", ">=2016.09.19" ],

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -15,8 +15,8 @@ S := GradedRing( Q["x,y"] );
 Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
-#! 40 primitive operations were used to derive 232 operations for this category which
-#! * IsAbCategory
+#! 40 primitive operations were used to derive 232 operations for this category
+#! which constructively
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
 #ListPrimitivelyInstalledOperationsOfCategory( Sgrmod );
@@ -71,8 +71,8 @@ CohP1 := Sgrmod / C;
 #! The Serre quotient category of The category of graded left f.p. modules
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian
 InfoOfInstalledOperationsOfCategory( CohP1 );
-#! 21 primitive operations were used to derive 187 operations for this category which
-#! * IsAbCategory
+#! 21 primitive operations were used to derive 187 operations for this category
+#! which constructively
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );
 #! Localization functor of The Serre quotient category of The category of graded left


### PR DESCRIPTION
using MaximalObjects and got rid of
* __CAP_INTERNAL_RANK_CATEGORY_FROM_METHOD_RECORD
* CAP_INTERNAL_CATEGORY_PROPERTY_RANK_AND_STRING
