### PR TITLE
Dual operations and tests for additive monoidal categories

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.03-02",
+Version := "2022.04-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesMethodRecord.gi
@@ -12,12 +12,21 @@ LeftDistributivityExpanding := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, a, DirectSum( cat, L ) )",
   output_range_getter_string := "DirectSum( cat, List( L, summand -> TensorProductOnObjects( cat, a, summand ) ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftDistributivityFactoring",
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 LeftDistributivityExpandingWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "list_of_objects", "object" ],
   io_type := [ [ "s", "a", "L", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftDistributivityFactoringWithGivenObjects",
+  dual_preprocessor_func := { cat, s, a, L, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( L ), Opposite( s ) ],
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 LeftDistributivityFactoring := rec(
   filter_list := [ "category", "object", "list_of_objects" ],
@@ -25,12 +34,21 @@ LeftDistributivityFactoring := rec(
   output_source_getter_string := "DirectSum( cat, List( L, summand -> TensorProductOnObjects( cat, a, summand ) ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, a, DirectSum( cat, L ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftDistributivityExpanding",
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 LeftDistributivityFactoringWithGivenObjects := rec(
   filter_list := [ "category", "object", "object", "list_of_objects", "object" ],
   io_type := [ [ "s", "a", "L", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "LeftDistributivityExpandingWithGivenObjects",
+  dual_preprocessor_func := { cat, s, a, L, r } -> [ Opposite( cat ), Opposite( r ), Opposite( a ), Opposite( L ), Opposite( s ) ],
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 RightDistributivityExpanding := rec(
   filter_list := [ "category", "list_of_objects", "object" ],
@@ -38,12 +56,21 @@ RightDistributivityExpanding := rec(
   output_source_getter_string := "TensorProductOnObjects( cat, DirectSum( cat, L ), a )",
   output_range_getter_string := "DirectSum( cat, List( L, summand -> TensorProductOnObjects( cat, summand, a ) ) )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightDistributivityFactoring",
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 RightDistributivityExpandingWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object", "object" ],
   io_type := [ [ "s", "L", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightDistributivityFactoringWithGivenObjects",
+  dual_preprocessor_func := { cat, s, L, a, r } -> [ Opposite( cat ), Opposite( r ), Opposite( L ), Opposite( a ), Opposite( s ) ],
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 RightDistributivityFactoring := rec(
   filter_list := [ "category", "list_of_objects", "object" ],
@@ -51,12 +78,21 @@ RightDistributivityFactoring := rec(
   output_source_getter_string := "DirectSum( cat, List( L, summand -> TensorProductOnObjects( cat, summand, a ) ) )",
   output_range_getter_string := "TensorProductOnObjects( cat, DirectSum( cat, L ), a )",
   with_given_object_position := "both",
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightDistributivityExpanding",
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 RightDistributivityFactoringWithGivenObjects := rec(
   filter_list := [ "category", "object", "list_of_objects", "object", "object" ],
   io_type := [ [ "s", "L", "a", "r" ], [ "s", "r" ] ],
-  return_type := "morphism" ),
+  return_type := "morphism",
+  dual_operation := "RightDistributivityExpandingWithGivenObjects",
+  dual_preprocessor_func := { cat, s, L, a, r } -> [ Opposite( cat ), Opposite( r ), Opposite( L ), Opposite( a ), Opposite( s ) ],
+  dual_arguments_reversed := false,
+  # Test in AdditiveMonoidalCategoriesTest
+),
 
 ) );
 

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gd
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gd
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MonoidalCategories: Monoidal and monoidal (co)closed categories
+#
+# Declarations
+#
+
+#! @Chapter Examples and Tests
+
+#! @Section Test functions
+
+#! @Description
+#! The arguments are
+#! * a CAP category $cat$
+#! * an object $a$
+#! * a list $L$ of objects
+#! This function checks for every operation
+#! declared in AdditiveMonoidalCategories.gd
+#! if it is computable in the CAP category $cat$.
+#! If yes, then the operation is executed
+#! with the parameters given above and
+#! compared to the equivalent computation in
+#! the opposite category of $cat$.
+#! Pass the options
+#! * `verbose := true` to output more information.
+#! * `only_primitive_operations := true`,
+#!    which is passed on to Opposite(),
+#!    to only primitively install
+#!    dual operations for primitively
+#!    installed operations in $cat$.
+#!    The advantage is, that more derivations might be tested.
+#!    On the downside, this might test fewer dual_pre/postprocessor_funcs.
+#! @Arguments cat, a, L
+DeclareGlobalFunction( "AdditiveMonoidalCategoriesTest" );

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gi
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MonoidalCategories: Monoidal and monoidal (co)closed categories
+#
+# Implementations
+#
+
+InstallGlobalFunction( "AdditiveMonoidalCategoriesTest",
+    
+    function( cat, a, L )
+        
+        local opposite, verbose,
+              
+              a_op, left_expanding_a_L, left_expanding_a_L_op, left_factoring_a_L, left_factoring_a_L_op, 
+              L_op, right_expanding_L_a, right_expanding_L_a_op, right_factoring_L_a, right_factoring_L_a_op;
+        
+        opposite := Opposite( cat );
+        
+        a_op := Opposite( a );
+        L_op := List( L, l -> Opposite( l ) );
+        
+        verbose := ValueOption( "verbose" ) = true;
+        
+        if CanCompute( cat, "LeftDistributivityExpanding" ) then
+            
+            if verbose then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Display( "Testing 'LeftDistributivityExpanding' ..." );
+                
+            fi;
+            
+            left_expanding_a_L := LeftDistributivityExpanding( a, L );
+            left_factoring_a_L_op := LeftDistributivityFactoring( opposite, a_op, L_op );
+            
+            Assert( 0, IsCongruentForMorphisms( left_expanding_a_L, Opposite( left_factoring_a_L_op ) ) );
+            
+        fi;
+        
+        if CanCompute( cat, "LeftDistributivityFactoring" ) then
+            
+            if verbose then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Display( "Testing 'LeftDistributivityFactoring' ..." );
+                
+            fi;
+            
+            left_factoring_a_L := LeftDistributivityFactoring( a, L );
+            left_expanding_a_L_op := LeftDistributivityExpanding( opposite, a_op, L_op );
+            
+            Assert( 0, IsCongruentForMorphisms( left_factoring_a_L, Opposite( left_expanding_a_L_op ) ) );
+            
+        fi;
+        
+        if CanCompute( cat, "RightDistributivityExpanding" ) then
+            
+            if verbose then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Display( "Testing 'RightDistributivityExpanding' ..." );
+                
+            fi;
+            
+            right_expanding_L_a := RightDistributivityExpanding( L, a );
+            right_factoring_L_a_op := RightDistributivityFactoring( opposite, L_op, a_op );
+            
+            Assert( 0, IsCongruentForMorphisms( right_expanding_L_a, Opposite( right_factoring_L_a_op ) ) );
+            
+        fi;
+        
+        if CanCompute( cat, "RightDistributivityFactoring" ) then
+            
+            if verbose then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Display( "Testing 'RightDistributivityFactoring' ..." );
+                
+            fi;
+            
+            right_factoring_L_a := RightDistributivityFactoring( L, a );
+            right_expanding_L_a_op := RightDistributivityExpanding( opposite, L_op, a_op );
+            
+            Assert( 0, IsCongruentForMorphisms( right_factoring_L_a, Opposite( right_expanding_L_a_op ) ) );
+            
+        fi;
+        
+end );

--- a/MonoidalCategories/init.g
+++ b/MonoidalCategories/init.g
@@ -56,6 +56,7 @@ ReadPackage( "MonoidalCategories", "gap/RigidSymmetricCoclosedMonoidalCategories
 
 ReadPackage( "MonoidalCategories", "gap/MonoidalCategoriesTensorProductAndUnitTest.gd" );
 ReadPackage( "MonoidalCategories", "gap/MonoidalCategoriesTest.gd" );
+ReadPackage( "MonoidalCategories", "gap/AdditiveMonoidalCategoriesTest.gd" );
 ReadPackage( "MonoidalCategories", "gap/BraidedMonoidalCategoriesTest.gd" );
 ReadPackage( "MonoidalCategories", "gap/ClosedMonoidalCategoriesTest.gd" );
 ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategoriesTest.gd" );

--- a/MonoidalCategories/read.g
+++ b/MonoidalCategories/read.g
@@ -77,6 +77,7 @@ ReadPackage( "MonoidalCategories", "gap/HomomorphismStructureDerivedMethods.gi" 
 
 ReadPackage( "MonoidalCategories", "gap/MonoidalCategoriesTensorProductAndUnitTest.gi" );
 ReadPackage( "MonoidalCategories", "gap/MonoidalCategoriesTest.gi" );
+ReadPackage( "MonoidalCategories", "gap/AdditiveMonoidalCategoriesTest.gi" );
 ReadPackage( "MonoidalCategories", "gap/BraidedMonoidalCategoriesTest.gi" );
 ReadPackage( "MonoidalCategories", "gap/ClosedMonoidalCategoriesTest.gi" );
 ReadPackage( "MonoidalCategories", "gap/CoclosedMonoidalCategoriesTest.gi" );


### PR DESCRIPTION
I noticed that there is no mathematical definition of additive monoidal categories in the manual and there is also no doctrine for it. Maybe we can talk about that on Thursday. 

I already have the code for `CategoryConstructor`, `Toposes`, etc. to translate and use the tests, but I would like to wait with PR's until this is merged.
