### PR TITLE
Fix dual_pre_processor_func for `TensorProductOnMorphisms`

### DIFF
--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -895,7 +895,7 @@ end
 function ( cat_1, s_1, alpha_1, beta_1, r_1 )
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, s_1, r_1, Opposite, ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
-             ), OppositeCategory( cat_1 ), Opposite( s_1 ), Opposite( r_1 ), UnderlyingMatrix, KroneckerMat( UnderlyingMatrix( Opposite( alpha_1 ) ), UnderlyingMatrix( Opposite( beta_1 ) ) ) ) );
+             ), OppositeCategory( cat_1 ), Opposite( r_1 ), Opposite( s_1 ), UnderlyingMatrix, KroneckerMat( UnderlyingMatrix( Opposite( alpha_1 ) ), UnderlyingMatrix( Opposite( beta_1 ) ) ) ) );
 end
 ########
         

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.04-03",
+Version := "2022.04-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/MonoidalCategoriesMethodRecord.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesMethodRecord.gi
@@ -25,6 +25,8 @@ TensorProductOnMorphismsWithGivenTensorProducts := rec(
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
   return_type := "morphism",
   dual_operation := "TensorProductOnMorphismsWithGivenTensorProducts",
+  dual_preprocessor_func :=
+    { cat, s, alpha, beta, r } -> [ Opposite( cat ), Opposite( r ), Opposite( alpha ), Opposite( beta ), Opposite( s ) ],
   dual_arguments_reversed := false,
   # Test in MonoidalCategoriesTest
 ),


### PR DESCRIPTION
Credit to @zickgraf. Was found via [here](https://github.com/homalg-project/CAP_project/issues/886).
