### PR TITLE
Only list known categorical properties in InfoOfInstalledOperationsOfCategory

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.04-08",
+Version := "2022.04-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -13,9 +13,7 @@ InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
         return;
     fi;
     
-    list_of_properties := ShallowCopy( RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ) );
-
-    Remove( list_of_properties, Position( list_of_properties, "EveryCategory" ) );
+    list_of_properties := Intersection( ListKnownCategoricalProperties( category ), RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ) );
     
     list_of_properties := Filtered( list_of_properties, p -> CheckConstructivenessOfCategory( category, p ) = [ ] );
     

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -20,7 +20,8 @@ InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
     list_of_properties := MaximalObjects( list_of_properties,
                                   { p1, p2 } ->
                                   IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p2 ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p1 ) ) or
-                                  ( IsProperty( ValueGlobal( p2 ) ) and ( p1 in ListImpliedFilters( ValueGlobal( p2 ) ) ) ) );
+                                  p1 in ListImpliedFilters( ValueGlobal( p2 ) )
+                          );
     
     StableSortBy( list_of_properties, p -> Length( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p ) ) );
     


### PR DESCRIPTION
Otherwise any constructively pre-Abelian category which can compute LiftAlongMonomorphism and ColiftAlongEpimorphism will be displayed as Abelian, which is wrong in general.

Of course this means that we have to explicitly set the corresponding properties, but I see no way around this.