### PR TITLE
Rename IsIdenticalToIdentity/ZeroMorphism to IsEqualToIdentity/ZeroMorphism and deprecate CokernelFunctorial in favor of CokernelObjectFunctorial

### DIFF
--- a/CAP/LogicForCategories/PropositionsForAbCategories.tex
+++ b/CAP/LogicForCategories/PropositionsForAbCategories.tex
@@ -6,7 +6,7 @@
 
 \begin{sequent}
 \begin{align*}
-   a: \Obj, b: \Obj ~|~ () \vdash \IsIdenticalToZeroMorphism \big( \ZeroMorphism( a, b ) \big)
+   a: \Obj, b: \Obj ~|~ () \vdash \IsEqualToZeroMorphism \big( \ZeroMorphism( a, b ) \big)
 \end{align*}
 \end{sequent}
 

--- a/CAP/LogicForCategories/PropositionsForGeneralCategories.tex
+++ b/CAP/LogicForCategories/PropositionsForGeneralCategories.tex
@@ -12,7 +12,7 @@
 
 \begin{sequent}
  \begin{align*}
-  A:\Obj ~|~ () \vdash \IsIdenticalToIdentityMorphism\big( \IdentityMorphism( A ) \big)
+  A:\Obj ~|~ () \vdash \IsEqualToIdentityMorphism\big( \IdentityMorphism( A ) \big)
  \end{align*}
 \end{sequent}
 

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.05-03",
+Version := "2022.05-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -1855,6 +1855,44 @@ DeclareOperation( "AddIsEqualForObjects",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
+#! to the category for the basic operation `IsEqualToIdentityMorphism`.
+#! $F: ( arg2 ) \mapsto \mathtt{IsEqualToIdentityMorphism}(arg2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsEqualToIdentityMorphism",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsEqualToIdentityMorphism",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsEqualToIdentityMorphism",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsEqualToIdentityMorphism",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation `IsEqualToZeroMorphism`.
+#! $F: ( arg2 ) \mapsto \mathtt{IsEqualToZeroMorphism}(arg2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsEqualToZeroMorphism",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsEqualToZeroMorphism",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsEqualToZeroMorphism",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsEqualToZeroMorphism",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
 #! to the category for the basic operation `IsHomSetInhabited`.
 #! $F: ( arg2, arg3 ) \mapsto \mathtt{IsHomSetInhabited}(arg2, arg3)$.
 #! @Returns nothing
@@ -1888,44 +1926,6 @@ DeclareOperation( "AddIsIdempotent",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddIsIdempotent",
-                  [ IsCapCategory, IsList ] );
-
-#! @Description
-#! The arguments are a category $C$ and a function $F$.
-#! This operation adds the given function $F$
-#! to the category for the basic operation `IsIdenticalToIdentityMorphism`.
-#! $F: ( arg2 ) \mapsto \mathtt{IsIdenticalToIdentityMorphism}(arg2)$.
-#! @Returns nothing
-#! @Arguments C, F
-DeclareOperation( "AddIsIdenticalToIdentityMorphism",
-                  [ IsCapCategory, IsFunction ] );
-
-DeclareOperation( "AddIsIdenticalToIdentityMorphism",
-                  [ IsCapCategory, IsFunction, IsInt ] );
-
-DeclareOperation( "AddIsIdenticalToIdentityMorphism",
-                  [ IsCapCategory, IsList, IsInt ] );
-
-DeclareOperation( "AddIsIdenticalToIdentityMorphism",
-                  [ IsCapCategory, IsList ] );
-
-#! @Description
-#! The arguments are a category $C$ and a function $F$.
-#! This operation adds the given function $F$
-#! to the category for the basic operation `IsIdenticalToZeroMorphism`.
-#! $F: ( arg2 ) \mapsto \mathtt{IsIdenticalToZeroMorphism}(arg2)$.
-#! @Returns nothing
-#! @Arguments C, F
-DeclareOperation( "AddIsIdenticalToZeroMorphism",
-                  [ IsCapCategory, IsFunction ] );
-
-DeclareOperation( "AddIsIdenticalToZeroMorphism",
-                  [ IsCapCategory, IsFunction, IsInt ] );
-
-DeclareOperation( "AddIsIdenticalToZeroMorphism",
-                  [ IsCapCategory, IsList, IsInt ] );
-
-DeclareOperation( "AddIsIdenticalToZeroMorphism",
                   [ IsCapCategory, IsList ] );
 
 #! @Description

--- a/CAP/gap/CategoryConstructor.gi
+++ b/CAP/gap/CategoryConstructor.gi
@@ -155,17 +155,17 @@ InstallMethod( CategoryConstructor,
     # plausibility check
     if not "IsEqualForMorphisms" in options.list_of_operations_to_install then
         
-        if "IsIdenticalToIdentityMorphism" in options.list_of_operations_to_install then
+        if "IsEqualToIdentityMorphism" in options.list_of_operations_to_install then
             
             # COVERAGE_IGNORE_NEXT_LINE
-            Display( "WARNING: You want to lift `IsIdenticalToIdentityMorphism` but not `IsEqualForMorphisms` in CategoryConstructor. Since the specification of the former depends on the latter, this is probably an error." );
+            Display( "WARNING: You want to lift `IsEqualToIdentityMorphism` but not `IsEqualForMorphisms` in CategoryConstructor. Since the specification of the former depends on the latter, this is probably an error." );
             
         fi;
         
-        if "IsIdenticalToZeroMorphism" in options.list_of_operations_to_install then
+        if "IsEqualToZeroMorphism" in options.list_of_operations_to_install then
             
             # COVERAGE_IGNORE_NEXT_LINE
-            Display( "WARNING: You want to lift `IsIdenticalToZeroMorphism` but not `IsEqualForMorphisms` in CategoryConstructor. Since the specification of the former depends on the latter, this is probably an error." );
+            Display( "WARNING: You want to lift `IsEqualToZeroMorphism` but not `IsEqualForMorphisms` in CategoryConstructor. Since the specification of the former depends on the latter, this is probably an error." );
             
         fi;
         

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -277,7 +277,7 @@ DeclareOperation( "RandomMorphism", [ IsCapCategory, IsList ] );
 #! otherwise the output is <C>false</C>.
 #! @Returns a boolean
 #! @Arguments alpha
-DeclareProperty( "IsIdenticalToIdentityMorphism",
+DeclareProperty( "IsEqualToIdentityMorphism",
                  IsCapCategoryMorphism );
 
 #! @Description
@@ -286,9 +286,8 @@ DeclareProperty( "IsIdenticalToIdentityMorphism",
 #! otherwise the output is <C>false</C>.
 #! @Returns a boolean
 #! @Arguments alpha
-DeclareProperty( "IsIdenticalToZeroMorphism",
+DeclareProperty( "IsEqualToZeroMorphism",
                  IsCapCategoryMorphism );
-
 
 ## This is not a categorical property because non-endomorphisms 
 ## can be mapped to endomorphisms under equivalences of categories.

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -452,6 +452,11 @@ InstallMethod( AddPropertyToMatchAtIsCongruentForMorphisms,
     
 end );
 
+# deprecated legacy aliases
+InstallDeprecatedAlias( "IsIdenticalToIdentityMorphism", "IsEqualToIdentityMorphism", "2023.05.17" );
+InstallDeprecatedAlias( "AddIsIdenticalToIdentityMorphism", "AddIsEqualToIdentityMorphism", "2023.05.17" );
+InstallDeprecatedAlias( "IsIdenticalToZeroMorphism", "IsEqualToZeroMorphism", "2023.05.17" );
+InstallDeprecatedAlias( "AddIsIdenticalToZeroMorphism", "AddIsEqualToZeroMorphism", "2023.05.17" );
 
 ######################################
 ##

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -848,7 +848,7 @@ AddDerivationToCAP( IsZeroForMorphisms,
 end : Description := "IsZeroForMorphisms by deciding whether the given morphism is congruent to the zero morphism" );
 
 ##
-AddDerivationToCAP( IsIdenticalToIdentityMorphism,
+AddDerivationToCAP( IsEqualToIdentityMorphism,
                     [ [ IsEqualForMorphismsOnMor, 1 ],
                       [ IdentityMorphism, 1 ] ],
                     
@@ -856,16 +856,16 @@ AddDerivationToCAP( IsIdenticalToIdentityMorphism,
     
     return IsEqualForMorphismsOnMor( cat, morphism, IdentityMorphism( cat, Source( morphism ) ) );
     
-end : Description := "IsIdenticalToIdentityMorphism using IsEqualForMorphismsOnMor and IdentityMorphism" );
+end : Description := "IsEqualToIdentityMorphism using IsEqualForMorphismsOnMor and IdentityMorphism" );
 
 ##
-AddDerivationToCAP( IsIdenticalToZeroMorphism,
+AddDerivationToCAP( IsEqualToZeroMorphism,
                     
   function( cat, morphism )
     
     return IsEqualForMorphisms( cat, morphism, ZeroMorphism( cat, Source( morphism ), Range( morphism ) ) );
     
-end : Description := "IsIdenticalToZeroMorphism using IsEqualForMorphisms and ZeroMorphism" );
+end : Description := "IsEqualToZeroMorphism using IsEqualForMorphisms and ZeroMorphism" );
 
 ##
 AddDerivationToCAP( IsZeroForObjects,

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1734,7 +1734,7 @@ AddDerivationToCAP( HomologyObjectFunctorialWithGivenHomologyObjects,
       PreCompose( cat, KernelEmbedding( cat, delta ), CokernelProjection( cat, gamma ) )
     );
     
-    cok_functorial := CokernelFunctorial( cat, alpha, epsilon, gamma );
+    cok_functorial := CokernelObjectFunctorial( cat, alpha, epsilon, gamma );
     
     functorial_mor :=
       LiftAlongMonomorphism( cat,

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -2316,18 +2316,18 @@ IsInitial := rec(
   dual_operation := "IsTerminal",
   property_of := "object" ),
 
-IsIdenticalToIdentityMorphism := rec(
+IsEqualToIdentityMorphism := rec(
   filter_list := [ "category", "morphism" ],
   well_defined_todo := false,
   return_type := "bool",
-  dual_operation := "IsIdenticalToIdentityMorphism",
+  dual_operation := "IsEqualToIdentityMorphism",
   property_of := "morphism" ),
 
-IsIdenticalToZeroMorphism := rec(
+IsEqualToZeroMorphism := rec(
   filter_list := [ "category", "morphism" ],
   well_defined_todo := false,
   return_type := "bool",
-  dual_operation := "IsIdenticalToZeroMorphism",
+  dual_operation := "IsEqualToZeroMorphism",
   property_of := "morphism" ),
 
 CoastrictionToImage := rec(

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -279,10 +279,6 @@ DeclareOperation( "CokernelColiftWithGivenCokernelObject",
 DeclareOperation( "CokernelObjectFunctorial",
                   [ IsList ] );
 
-DeclareSynonym( "CokernelFunctorial", CokernelObjectFunctorial );
-## FIXME: Change this once we have moved to GAP 4.9
-## DeclareDeprecatedSynonym( "CokernelFunctorial", CokernelObjectFunctorial );
-
 #! @Description
 #! The arguments are three morphisms
 #! $\alpha: A \rightarrow B, \nu: B \rightarrow B', \alpha': A' \rightarrow B'$.
@@ -322,10 +318,6 @@ DeclareOperation( "CokernelObjectFunctorialWithGivenCokernelObjects",
                   [ IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism,
                     IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ] );
 
-
-DeclareSynonym( "CokernelFunctorialWithGivenCokernelObjects", CokernelObjectFunctorialWithGivenCokernelObjects );
-## FIXME:
-## DeclareDeprecatedSynonym( "CokernelFunctorialWithGivenCokernelObjects", CokernelObjectFunctorialWithGivenCokernelObjects );
 
 #! @Chapter Universal Objects
 

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -5,6 +5,10 @@
 #
 #! @Chapter Universal Objects
 
+# deprecated legacy aliases
+InstallDeprecatedAlias( "CokernelFunctorial", "CokernelObjectFunctorial", "2023.05.17" );
+InstallDeprecatedAlias( "CokernelFunctorialWithGivenCokernelObjects", "CokernelObjectFunctorialWithGivenCokernelObjects", "2023.05.17" );
+
 ####################################
 ##
 ## Coproduct and Pushout

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.05-03",
+Version := "2022.05-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -63,9 +63,9 @@
 #! * <Ref BookName="CAP" Func="IsEqualForMorphisms" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualForMorphismsOnMor" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualForObjects" Label="for Is" />
+#! * <Ref BookName="CAP" Func="IsEqualToIdentityMorphism" Label="for Is" />
+#! * <Ref BookName="CAP" Func="IsEqualToZeroMorphism" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsIdempotent" Label="for Is" />
-#! * <Ref BookName="CAP" Func="IsIdenticalToIdentityMorphism" Label="for Is" />
-#! * <Ref BookName="CAP" Func="IsIdenticalToZeroMorphism" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsInitial" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsIsomorphism" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsLiftable" Label="for Is" />

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -517,13 +517,13 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
             
             return left_morphism;
             
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToIdentityMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToIdentityMorphism ] ],
         
         [ function( cat, identity_morphism, right_morphism )
             
             return right_morphism;
             
-          end, [ IsCapCategory, IsIdenticalToIdentityMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToIdentityMorphism, IsCapCategoryMorphism ] ],
         
         [ function( cat, left_morphism, zero_morphism )
             

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2022.05-01",
+Version := "2022.05-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GradedModulePresentationsForCAP/gap/LiftPresentationTransformation.gi
+++ b/GradedModulePresentationsForCAP/gap/LiftPresentationTransformation.gi
@@ -22,7 +22,7 @@ BindGlobal( "CAP_INTERNAL_LiftNaturalTransformationToGradedModuleFunctor",
     
     source_functor := Source( natural_transformation );
     
-    if not IsIdenticalToIdentityMorphism( source_functor ) then
+    if not IsEqualToIdentityMorphism( source_functor ) then
         Error( "source is not identity functor" );
     fi;
     

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
-Version := "2022.05-01",
+Version := "2022.05-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
@@ -620,13 +620,13 @@ InstallGlobalFunction( CAP_INTERNAL_INSTALL_OPERATIONS_FOR_SEMISIMPLE_CATEGORY,
             
             return left_morphism;
             
-          end, [ , IsIdenticalToIdentityMorphism ] ],
+          end, [ , IsEqualToIdentityMorphism ] ],
         
         [ function( identity_morphism, right_morphism )
             
             return right_morphism;
             
-          end, [ IsIdenticalToIdentityMorphism, ] ],
+          end, [ IsEqualToIdentityMorphism, ] ],
         
       ]
     

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.05-02",
+Version := "2022.05-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -271,13 +271,13 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY,
             
             return left_morphism;
             
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToIdentityMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToIdentityMorphism ] ],
         
         [ function( cat, identity_morphism, right_morphism )
             
             return right_morphism;
             
-          end, [ IsCapCategory, IsIdenticalToIdentityMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToIdentityMorphism, IsCapCategoryMorphism ] ],
         
         [ function( cat, left_morphism, zero_morphism )
             

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -2557,20 +2557,7 @@ end
     , 100 );
     
     ##
-    AddIsIdempotent( cat,
-        
-########
-function ( cat_1, arg2_1 )
-    local deduped_1_1;
-    deduped_1_1 := UnderlyingMatrix( arg2_1 );
-    return deduped_1_1 * deduped_1_1 = deduped_1_1;
-end
-########
-        
-    , 201 : IsPrecompiledDerivation := true );
-    
-    ##
-    AddIsIdenticalToIdentityMorphism( cat,
+    AddIsEqualToIdentityMorphism( cat,
         
 ########
 function ( cat_1, arg2_1 )
@@ -2588,7 +2575,7 @@ end
     , 403 : IsPrecompiledDerivation := true );
     
     ##
-    AddIsIdenticalToZeroMorphism( cat,
+    AddIsEqualToZeroMorphism( cat,
         
 ########
 function ( cat_1, arg2_1 )
@@ -2597,6 +2584,19 @@ end
 ########
         
     , 202 : IsPrecompiledDerivation := true );
+    
+    ##
+    AddIsIdempotent( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    local deduped_1_1;
+    deduped_1_1 := UnderlyingMatrix( arg2_1 );
+    return deduped_1_1 * deduped_1_1 = deduped_1_1;
+end
+########
+        
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddIsInitial( cat,

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1634,7 +1634,7 @@ function ( cat_1, H_1_1, L_1, H_2_1 )
 end
 ########
         
-    , 3815 : IsPrecompiledDerivation := true );
+    , 4421 : IsPrecompiledDerivation := true );
     
     ##
     AddHomomorphismStructureOnMorphisms( cat,

--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ModulePresentationsForCAP",
 Subtitle := "Category R-pres for CAP",
-Version := "2022.05-01",
+Version := "2022.05-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -528,13 +528,13 @@ InstallGlobalFunction( ADD_PRECOMPOSE_LEFT,
             
             return left_morphism;
             
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToIdentityMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToIdentityMorphism ] ],
         
         [ function( cat, identity_morphism, right_morphism )
             
             return right_morphism;
             
-          end, [ IsCapCategory, IsIdenticalToIdentityMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToIdentityMorphism, IsCapCategoryMorphism ] ],
         
         [ function( cat, left_morphism, zero_morphism )
             
@@ -542,7 +542,7 @@ InstallGlobalFunction( ADD_PRECOMPOSE_LEFT,
                                          HomalgZeroMatrix( NrRows( UnderlyingMatrix( left_morphism ) ), NrColumns( UnderlyingMatrix( zero_morphism ) ), homalg_ring ),
                                          Range( zero_morphism ) );
           
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToZeroMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToZeroMorphism ] ],
         
         [ function( cat, zero_morphism, right_morphism )
             
@@ -550,7 +550,7 @@ InstallGlobalFunction( ADD_PRECOMPOSE_LEFT,
                                          HomalgZeroMatrix( NrRows( UnderlyingMatrix( zero_morphism ) ), NrColumns( UnderlyingMatrix( right_morphism ) ), homalg_ring ),
                                          Range( right_morphism ) );
           
-          end, [ IsCapCategory, IsIdenticalToZeroMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToZeroMorphism, IsCapCategoryMorphism ] ],
       ]
       
     );
@@ -579,13 +579,13 @@ InstallGlobalFunction( ADD_PRECOMPOSE_RIGHT,
             
             return left_morphism;
             
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToIdentityMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToIdentityMorphism ] ],
         
         [ function( cat, identity_morphism, right_morphism )
             
             return right_morphism;
             
-          end, [ IsCapCategory, IsIdenticalToIdentityMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToIdentityMorphism, IsCapCategoryMorphism ] ],
         
         
         [ function( cat, left_morphism, zero_morphism )
@@ -594,7 +594,7 @@ InstallGlobalFunction( ADD_PRECOMPOSE_RIGHT,
                                          HomalgZeroMatrix( NrRows( UnderlyingMatrix( zero_morphism ) ), NrColumns( UnderlyingMatrix( left_morphism ) ), homalg_ring ),
                                          Range( zero_morphism ) );
           
-          end, [ IsCapCategory, IsCapCategoryMorphism, IsIdenticalToZeroMorphism ] ],
+          end, [ IsCapCategory, IsCapCategoryMorphism, IsEqualToZeroMorphism ] ],
         
         [ function( cat, zero_morphism, right_morphism )
             
@@ -602,7 +602,7 @@ InstallGlobalFunction( ADD_PRECOMPOSE_RIGHT,
                                          HomalgZeroMatrix( NrRows( UnderlyingMatrix( right_morphism ) ), NrColumns( UnderlyingMatrix( zero_morphism ) ), homalg_ring ),
                                          Range( right_morphism ) );
           
-          end, [ IsCapCategory, IsIdenticalToZeroMorphism, IsCapCategoryMorphism ] ],
+          end, [ IsCapCategory, IsEqualToZeroMorphism, IsCapCategoryMorphism ] ],
       ]
       
     );


### PR DESCRIPTION
@sebastianpos Are those two changes okay? (You do not have to look at the code, there is nothing special.)