### PR TITLE
Miscellaneous changes

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.05-04",
+Version := "2022.05-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/doc/Doc.autodoc
+++ b/CAP/doc/Doc.autodoc
@@ -22,4 +22,6 @@
 
 @Chapter Create wrapper hulls of a category
 
+@Chapter Dummy categories
+
 @Chapter Examples and Tests

--- a/CAP/examples/DummyCategory.g
+++ b/CAP/examples/DummyCategory.g
@@ -1,0 +1,20 @@
+#! @Chapter Examples and Tests
+
+#! @Section Dummy category
+
+#! @Example
+
+LoadPackage( "CAP", false );
+#! true
+
+dummy := DummyCategory( rec(
+    list_of_operations_to_install := [ "PreCompose", "IdentityMorphism", "DirectSum" ],
+    properties := [ "IsAdditiveCategory" ],
+) );;
+
+CanCompute( dummy, "DirectSum" );
+#! true
+IsAdditiveCategory( dummy );
+#! true
+
+#! @EndExample

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -1054,8 +1054,8 @@ InstallGlobalFunction( DerivationsOfMethodByCategory,
         
         if IsFilter( category_filter ) and Tester( category_filter )( category ) and not category_filter( category ) then
             continue;
-        elif IsFilter( category_filter) and not Tester( category_filter )( category ) then
-            Print( "If ", Name( category ), " would be ", NamesFilter( category_filter )[ 1 ], " then\n" );
+        elif IsFilter( category_filter ) and not Tester( category_filter )( category ) then
+            Print( "If ", Name( category ), " would be ", JoinStringsWithSeparator( Filtered( NamesFilter( category_filter ), name -> not StartsWith( name, "Has" ) ), " and " ), " then\n" );
             Print( string, " could be derived by\n" );
         elif IsFunction( category_filter ) and not category_filter( category ) then
             continue;

--- a/CAP/gap/DummyCategory.gd
+++ b/CAP/gap/DummyCategory.gd
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CAP: Categories, Algorithms, Programming
+#
+# Declarations
+#
+
+#! @Chapter Dummy categories
+#! 
+#! A dummy category pretends to support certain CAP operations but has not actual implementation.
+#! This is useful for testing or compiling against a certain set of CAP operations.
+
+####################################
+#
+#! @Section GAP categories
+#
+####################################
+
+#! @Description
+#!  The &GAP; category of a dummy CAP category.
+DeclareCategory( "IsDummyCategory",
+        IsCapCategory );
+
+#! @Description
+#!  The &GAP; category of cells in a dummy CAP category.
+DeclareCategory( "IsDummyCategoryCell",
+        IsCapCategoryCell );
+
+#! @Description
+#!  The &GAP; category of objects in a dummy CAP category.
+DeclareCategory( "IsDummyCategoryObject",
+        IsDummyCategoryCell and IsCapCategoryObject );
+
+#! @Description
+#!  The &GAP; category of morphisms in a dummy CAP category.
+DeclareCategory( "IsDummyCategoryMorphism",
+        IsDummyCategoryCell and IsCapCategoryMorphism );
+
+####################################
+#
+#! @Section Constructors
+#
+####################################
+
+#! @Description
+#!  Creates a dummy category subject to the options given via <A>options</A>, which is a record passed on to <Ref Oper="CategoryConstructor" Label="for IsRecord" />.
+#!  Note that the options `{category,object,morphism}_filter` will be set to `IsDummyCategory{,Object,Morphism}` and
+#!  `create_func_*` will be set to dummy implementations (throwing errors when actually called).
+#!  The dummy category will pretend to support empty limits by default.
+#! @Arguments options
+#! @Returns a category
+DeclareOperation( "DummyCategory",
+                  [ IsRecord ] );

--- a/CAP/gap/DummyCategory.gi
+++ b/CAP/gap/DummyCategory.gi
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# CAP: Categories, Algorithms, Programming
+#
+# Implementations
+#
+
+##
+InstallMethod( DummyCategory,
+        "for a record of options",
+        [ IsRecord ],
+        
+  function( options )
+    local category_constructor_options, dummy_function, C;
+    
+    category_constructor_options := ShallowCopy( options );
+    category_constructor_options.category_filter := IsDummyCategory;
+    category_constructor_options.category_object_filter := IsDummyCategoryObject;
+    category_constructor_options.category_morphism_filter := IsDummyCategoryMorphism;
+    
+    dummy_function := { operation_name, dummy } -> """
+        function( input_arguments )
+            
+            Error( "this is a dummy category without actual implementation" );
+            
+        end
+    """;
+    
+    category_constructor_options.create_func_bool := dummy_function;
+    category_constructor_options.create_func_object := dummy_function;
+    category_constructor_options.create_func_object_or_fail := dummy_function;
+    category_constructor_options.create_func_morphism := dummy_function;
+    category_constructor_options.create_func_morphism_or_fail := dummy_function;
+    
+    C := CategoryConstructor( category_constructor_options );
+    
+    C!.supports_empty_limits := true;
+    
+    Finalize( C );
+    
+    return C;
+    
+end );

--- a/CAP/init.g
+++ b/CAP/init.g
@@ -53,3 +53,5 @@ ReadPackage( "CAP", "gap/TerminalCategory.gd" );
 ReadPackage( "CAP", "gap/CategoryConstructor.gd" );
 
 ReadPackage( "CAP", "gap/WrapperCategory.gd" );
+
+ReadPackage( "CAP", "gap/DummyCategory.gd" );

--- a/CAP/read.g
+++ b/CAP/read.g
@@ -56,4 +56,6 @@ ReadPackage( "CAP", "gap/CategoryConstructor.gi" );
 
 ReadPackage( "CAP", "gap/WrapperCategory.gi" );
 
+ReadPackage( "CAP", "gap/DummyCategory.gi" );
+
 ReadPackage( "CAP", "gap/ToolsForCategories_AfterLoading.gi" );

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.05-04",
+Version := "2022.05-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/StopCompilationAtCategory.g
+++ b/CompilerForCAP/examples/StopCompilationAtCategory.g
@@ -1,0 +1,77 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "LinearAlgebraForCAP", false );
+#! true
+
+Q := HomalgFieldOfRationals( );;
+vec := MATRIX_CATEGORY( Q : no_precompiled_code );;
+
+func := cat -> ZeroObjectFunctorial( cat );;
+
+StopCompilationAtCategory( vec );
+
+Display( CapJitCompiledFunction( func, vec ) );
+#! WARNING: Could not find declaration of ZeroObjectFunctorial (curre\
+#! nt input: [ <Category "IsCapCategory"> ])
+#! function ( cat_1 )
+#!     return ZeroObjectFunctorial( cat_1 );
+#! end
+
+ContinueCompilationAtCategory( vec );
+
+Display( CapJitCompiledFunction( func, vec ) );
+#! function ( cat_1 )
+#!     local morphism_attr_1_1, deduped_2_1;
+#!     deduped_2_1 := ObjectifyObjectForCAPWithAttributes( rec(
+#!            ), cat_1, Dimension, 0 );
+#!     morphism_attr_1_1 
+#!      := HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) );
+#!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes
+#!         ( rec(
+#!            ), cat_1, deduped_2_1, deduped_2_1, UnderlyingMatrix, 
+#!        morphism_attr_1_1 );
+#! end
+
+vec := MATRIX_CATEGORY( Q : no_precompiled_code );;
+
+StopCompilationAtPrimitivelyInstalledOperationsOfCategory( vec );
+
+Display( CapJitCompiledFunction( func, vec ) );
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! WARNING: Could not find declaration of ZeroObject (current input: \
+#! [ <Category "IsCapCategory"> ])
+#! function ( cat_1 )
+#!     local deduped_1_1;
+#!     deduped_1_1 := ZeroObject( cat_1 );
+#!     return ZeroMorphism( cat_1, deduped_1_1, deduped_1_1 );
+#! end
+
+ContinueCompilationAtPrimitivelyInstalledOperationsOfCategory( vec );
+
+Display( CapJitCompiledFunction( func, vec ) );
+#! function ( cat_1 )
+#!     local morphism_attr_1_1, deduped_2_1;
+#!     deduped_2_1 := ObjectifyObjectForCAPWithAttributes( rec(
+#!            ), cat_1, Dimension, 0 );
+#!     morphism_attr_1_1 
+#!      := HomalgZeroMatrix( 0, 0, UnderlyingRing( cat_1 ) );
+#!     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes
+#!         ( rec(
+#!            ), cat_1, deduped_2_1, deduped_2_1, UnderlyingMatrix, 
+#!        morphism_attr_1_1 );
+#! end
+
+#! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gd
+++ b/CompilerForCAP/gap/CompilerForCAP.gd
@@ -17,6 +17,17 @@ DeclareGlobalFunction( "StopCompilationAtCategory" );
 #! @Arguments category
 DeclareGlobalFunction( "ContinueCompilationAtCategory" );
 
+#! @Description
+#!   Stops the compiler from inlining and optimizing code of primitively installed operations of <A>category</A>.
+#!   Warning: Due to caching of compiled CAP operations, this has to be called before any compilation involving <A>category</A>.
+#! @Arguments category
+DeclareGlobalFunction( "StopCompilationAtPrimitivelyInstalledOperationsOfCategory" );
+
+#! @Description
+#!   Allows the compiler to inline and optimize code of primitively installed operations of <A>category</A> (this is the default).
+#! @Arguments category
+DeclareGlobalFunction( "ContinueCompilationAtPrimitivelyInstalledOperationsOfCategory" );
+
 #! @Section Getting information about the compilation process
 
 #! @Description

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -20,6 +20,22 @@ InstallGlobalFunction( ContinueCompilationAtCategory, function ( category )
     
 end );
 
+InstallGlobalFunction( StopCompilationAtPrimitivelyInstalledOperationsOfCategory, function ( category )
+    
+    Assert( 0, IsCapCategory( category ) );
+    
+    category!.stop_compilation_at_primitively_installed_operations := true;
+    
+end );
+
+InstallGlobalFunction( ContinueCompilationAtPrimitivelyInstalledOperationsOfCategory, function ( category )
+    
+    Assert( 0, IsCapCategory( category ) );
+    
+    category!.stop_compilation_at_primitively_installed_operations := false;
+    
+end );
+
 InstallGlobalFunction( CapJitCompiledFunction, function ( func, args... )
     
     if IsOperation( func ) or IsKernelFunction( func ) then

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -31,6 +31,12 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
                         
                     fi;
                     
+                    if IsBound( category!.stop_compilation_at_primitively_installed_operations ) and category!.stop_compilation_at_primitively_installed_operations = true and operation_name in ListPrimitivelyInstalledOperationsOfCategory( category ) then
+                        
+                        return tree;
+                        
+                    fi;
+                    
                     Info( InfoCapJit, 1, "####" );
                     Info( InfoCapJit, 1, Concatenation( "Resolve ", operation_name, "." ) );
                     


### PR DESCRIPTION
See commit messages for details.

Noticeable change: The second commit introduces a constructor for dummy categories, i.e. categories pretending to support certain CAP operations but without actual implementations. This is useful for testing or compiling against a certain set of CAP operations.