### PR TITLE
Do not outline entries of literal lists anymore

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.05-07",
+Version := "2022.05-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/OutlineWrappedArguments.gd
+++ b/CompilerForCAP/gap/OutlineWrappedArguments.gd
@@ -11,7 +11,7 @@
 #!   Outlines wrapped arguments to local variables. This includes:
 #!     * the attribute values in `ObjectifyObjectForCAPWithAttributes`
 #!     * the attribute values (including the arguments `source` and `range`) in `ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes`
-#!     * the entries of literal lists
+#!     * the arguments of `NTuple` (excluding the first argument)
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitOutlinedWrappedArguments" );

--- a/CompilerForCAP/gap/OutlineWrappedArguments.gi
+++ b/CompilerForCAP/gap/OutlineWrappedArguments.gi
@@ -7,13 +7,7 @@
 BindGlobal( "CAP_JIT_INTERNAL_GET_KEY_AND_POSITIONS_TO_OUTLINE", function ( tree, func_stack )
   local key, positions_to_outline, source, fvar, func, range;
     
-    if tree.type = "EXPR_LIST" then
-        
-        key := "list";
-        
-        positions_to_outline := [ 1 .. tree.list.length ];
-        
-    elif CapJitIsCallToGlobalFunction( tree, "NTuple" ) then
+    if CapJitIsCallToGlobalFunction( tree, "NTuple" ) then
         
         key := "args";
         


### PR DESCRIPTION
The cases where this was useful are now covered by `NTuple`.