### PR TITLE
Introduce CapJitEnableStepByStepCompilation

### DIFF
--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -111,6 +111,8 @@ You can revert this decision using `ContinueCompilationAtCategory`.
 
 @Section Disabling the automatic inference of data types
 
+@Section Compiling step-by-step
+
 @Section Proof assistant mode
 
 @Section Getting information about the compilation process

--- a/CompilerForCAP/examples/CapJitEnableStepByStepCompilation.g
+++ b/CompilerForCAP/examples/CapJitEnableStepByStepCompilation.g
@@ -1,0 +1,72 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "CompilerForCAP", false );
+#! true
+
+CapJitDisableDataTypeInference( );
+
+CapJitEnableStepByStepCompilation( );
+
+dummy := DummyCategory( rec(
+    list_of_operations_to_install := [
+        "ZeroObject",
+        "ZeroMorphism",
+    ],
+) );;
+
+StopCompilationAtPrimitivelyInstalledOperationsOfCategory( dummy );
+
+func := cat -> ZeroObjectFunctorialWithGivenZeroObjects( cat,
+    ZeroObject( cat ),
+    ZeroObject( cat )
+);;
+
+compiled_func := CapJitCompiledFunction( func, dummy );;
+Display( compiled_func );
+#! function ( cat_1 )
+#!     return ZeroObjectFunctorial( cat_1 );
+#! end
+
+compiled_func := CapJitCompiledFunction( compiled_func, dummy );;
+Display( compiled_func );
+#! function ( cat_1 )
+#!     local deduped_1_1;
+#!     deduped_1_1 := ZeroObject( cat_1 );
+#!     return ZeroMorphism( cat_1, deduped_1_1, deduped_1_1 );
+#! end
+
+
+
+CapJitDisableStepByStepCompilation( );
+
+dummy := DummyCategory( rec(
+    list_of_operations_to_install := [
+        "ZeroObject",
+        "ZeroMorphism",
+    ],
+) );;
+
+StopCompilationAtPrimitivelyInstalledOperationsOfCategory( dummy );
+
+func := cat -> ZeroObjectFunctorialWithGivenZeroObjects( cat,
+    ZeroObject( cat ),
+    ZeroObject( cat )
+);;
+
+compiled_func := CapJitCompiledFunction( func, dummy );;
+Display( compiled_func );
+#! function ( cat_1 )
+#!     local deduped_1_1;
+#!     deduped_1_1 := ZeroObject( cat_1 );
+#!     return ZeroMorphism( cat_1, deduped_1_1, deduped_1_1 );
+#! end
+
+
+CapJitEnableDataTypeInference( );
+
+
+#! @EndExample

--- a/CompilerForCAP/gap/CompilerForCAP.gd
+++ b/CompilerForCAP/gap/CompilerForCAP.gd
@@ -39,6 +39,21 @@ DeclareGlobalFunction( "CapJitDisableDataTypeInference" );
 DeclareGlobalFunction( "CapJitEnableDataTypeInference" );
 #! @EndGroup
 
+#! @Section Compiling step-by-step
+
+#! @BeginGroup
+#! @Description
+#!   Enables or disables step-by-step compilation for demonstration or debugging purposes.
+#!   If enabled, only the first level of CAP operations and known methods is resolved (instead of resolving recursively).
+#!   Caveats:
+#!     * This does not work if fully compiled operations are already cached, so this should be used before starting any compilation.
+#!     * This does not work if the CAP category is not immediately available from the input (e.g. because it is a range category of a homomorphism structure of the input category).
+#! @Arguments
+DeclareGlobalFunction( "CapJitEnableStepByStepCompilation" );
+#! @Arguments
+DeclareGlobalFunction( "CapJitDisableStepByStepCompilation" );
+#! @EndGroup
+
 #! @Section Proof assistant mode
 
 #! @BeginGroup

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -50,6 +50,20 @@ InstallGlobalFunction( CapJitEnableDataTypeInference, function ( )
     
 end );
 
+CAP_JIT_RESOLVE_ONE_LEVEL_ONLY := false;
+
+InstallGlobalFunction( CapJitEnableStepByStepCompilation, function ( )
+    
+    CAP_JIT_RESOLVE_ONE_LEVEL_ONLY := true;
+    
+end );
+
+InstallGlobalFunction( CapJitDisableStepByStepCompilation, function ( )
+    
+    CAP_JIT_RESOLVE_ONE_LEVEL_ONLY := false;
+    
+end );
+
 CAP_JIT_PROOF_ASSISTANT_MODE_ENABLED := false;
 
 InstallGlobalFunction( CapJitEnableProofAssistantMode, function ( )
@@ -76,6 +90,8 @@ InstallGlobalFunction( CapJitCompiledFunction, function ( func, args... )
     return ENHANCED_SYNTAX_TREE_CODE( CallFuncList( CapJitCompiledFunctionAsEnhancedSyntaxTree, Concatenation( [ func, true ], args ) ) );
     
 end );
+
+CAP_JIT_INTERNAL_COMPILATION_IN_PROGRESS := false;
 
 BindGlobal( "CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK", [ ] );
 
@@ -187,6 +203,20 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         
     fi;
     
+    if CAP_JIT_RESOLVE_ONE_LEVEL_ONLY then
+        
+        if CAP_JIT_INTERNAL_COMPILATION_IN_PROGRESS then
+            
+            return tree;
+            
+        else
+            
+            CAP_JIT_INTERNAL_COMPILATION_IN_PROGRESS := true;
+            
+        fi;
+        
+    fi;
+    
     # resolving phase
     resolving_phase_functions := [
         CapJitResolvedOperations,
@@ -242,6 +272,12 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
             fi;
             
         od;
+        
+        if CAP_JIT_RESOLVE_ONE_LEVEL_ONLY then
+            
+            break;
+            
+        fi;
         
     od;
     
@@ -350,6 +386,12 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     
     Info( InfoCapJit, 1, "####" );
     Info( InfoCapJit, 1, "Compilation finished." );
+    
+    if CAP_JIT_RESOLVE_ONE_LEVEL_ONLY then
+        
+        CAP_JIT_INTERNAL_COMPILATION_IN_PROGRESS := false;
+        
+    fi;
     
     return tree;
     


### PR DESCRIPTION
@mohamed-barakat Please check if this works for your applications in #918. The interface you suggest there is not feasible, but you can call `CapJitEnableStepByStepCompilation` and than iteratively compile a function. Also see the caveats in the documentation.