### PR TITLE
Fix inconsistent final derivations in rigid monoidal categories

### DIFF
--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -317,7 +317,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 15766 : IsPrecompiledDerivation := true );
+    , 15772 : IsPrecompiledDerivation := true );
     
     ##
     AddCoDualityTensorProductCompatibilityMorphismWithGivenObjects( cat,
@@ -373,7 +373,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 15265 : IsPrecompiledDerivation := true );
+    , 15271 : IsPrecompiledDerivation := true );
     
     ##
     AddCoLambdaElimination( cat,
@@ -2799,7 +2799,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledDerivation := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromCoimageToCokernelOfKernel( cat,
@@ -2949,7 +2949,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledDerivation := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromFiberProductToKernelOfDiagonalDifference( cat,
@@ -3043,7 +3043,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledDerivation := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalCoHomToObject( cat,
@@ -3133,7 +3133,7 @@ function ( cat_1, a_1 )
 end
 ########
         
-    , 201 : IsPrecompiledDerivation := true );
+    , 203 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromInternalHomToObject( cat,
@@ -5550,7 +5550,7 @@ function ( cat_1, a_1, b_1 )
 end
 ########
         
-    , 15766 : IsPrecompiledDerivation := true );
+    , 15772 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductDualityCompatibilityMorphismWithGivenObjects( cat,
@@ -5608,7 +5608,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
 end
 ########
         
-    , 15265 : IsPrecompiledDerivation := true );
+    , 15271 : IsPrecompiledDerivation := true );
     
     ##
     AddTensorProductInternalHomCompatibilityMorphism( cat,
@@ -6509,7 +6509,7 @@ function ( cat_1, t_1, a_1, alpha_1 )
 end
 ########
         
-    , 5124 : IsPrecompiledDerivation := true );
+    , 5126 : IsPrecompiledDerivation := true );
     
     ##
     AddUniversalPropertyOfDual( cat,
@@ -6541,7 +6541,7 @@ function ( cat_1, t_1, a_1, alpha_1 )
 end
 ########
         
-    , 5124 : IsPrecompiledDerivation := true );
+    , 5126 : IsPrecompiledDerivation := true );
     
     ##
     AddZeroMorphism( cat,

--- a/MonoidalCategories/doc/Doc.autodoc
+++ b/MonoidalCategories/doc/Doc.autodoc
@@ -48,6 +48,8 @@ which has for each functor $- \otimes b: \mathbf{C} \rightarrow \mathbf{C}$
 a right adjoint (denoted by $\mathrm{\underline{Hom}}(b,-)$)
 is called a <Emph>closed monoidal category</Emph>.
 
+If no operations involving duals are installed manually, the dual objects will be derived as $a^\vee \coloneqq \mathrm{\underline{Hom}}(a,1)$.
+
 The corresponding GAP property is called
 <C>IsClosedMonoidalCategory</C>.
 
@@ -57,6 +59,8 @@ A monoidal category $\mathbf{C}$
 which has for each functor $- \otimes b: \mathbf{C} \rightarrow \mathbf{C}$
 a left adjoint (denoted by $\mathrm{\underline{coHom}}(-,b)$)
 is called a <Emph>coclosed monoidal category</Emph>.
+
+If no operations involving coduals are installed manually, the codual objects will be derived as $a_\vee \coloneqq \mathrm{\underline{coHom}}(1,a)$.
 
 The corresponding GAP property is called
 <C>IsCoclosedMonoidalCategory</C>.
@@ -72,12 +76,12 @@ The corresponding GAP property is given by
 
 @Section Symmetric Coclosed Monoidal Categories
 
-#! A monoidal category $\mathbf{C}$
-#! which is symmetric and coclosed
-#! is called a <Emph>symmetric coclosed monoidal category</Emph>.
+A monoidal category $\mathbf{C}$
+which is symmetric and coclosed
+is called a <Emph>symmetric coclosed monoidal category</Emph>.
 
-#! The corresponding GAP property is given by
-#! <C>IsSymmetricCoclosedMonoidalCategory</C>.
+The corresponding GAP property is given by
+<C>IsSymmetricCoclosedMonoidalCategory</C>.
 
 @Section Rigid Symmetric Closed Monoidal Categories
 
@@ -90,6 +94,12 @@ A symmetric closed monoidal category $\mathbf{C}$ satisfying
  is an isomorphism
 is called a <Emph>rigid symmetric closed monoidal category</Emph>.
 
+If no operations involving the closed structure are installed manually, the internal hom objects will be derived as
+$\mathrm{\underline{Hom}}(a,b) \coloneqq a^\vee \otimes b$ and, in particular, $\mathrm{\underline{Hom}}(a,1) \coloneqq a^\vee \otimes 1$.
+
+The corresponding GAP property is given by
+<C>IsRigidSymmetricClosedMonoidalCategory</C>.
+
 @Section Rigid Symmetric Coclosed Monoidal Categories
 
 A symmetric coclosed monoidal category $\mathbf{C}$ satisfying
@@ -100,6 +110,12 @@ A symmetric coclosed monoidal category $\mathbf{C}$ satisfying
  $\mathrm{\underline{coHom}}(1, \mathrm{\underline{coHom}}(1, a)) \rightarrow a$
  is an isomorphism
 is called a <Emph>rigid symmetric coclosed monoidal category</Emph>.
+
+If no operations involving the coclosed structure are installed manually, the internal cohom objects will be derived as
+$\mathrm{\underline{coHom}}(a,b) \coloneqq a \otimes b_\vee$ and, in particular, $\mathrm{\underline{coHom}}(1,a) \coloneqq 1 \otimes a_\vee$.
+
+The corresponding GAP property is given by
+<C>IsRigidSymmetricCoclosedMonoidalCategory</C>.
 
 @Section Convenience Methods
 

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -430,6 +430,8 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 AddFinalDerivation( IsomorphismFromTensorProductToInternalHom,
                     [ [ IdentityMorphism, 1 ],
                       [ DualOnObjects, 1 ],
+                      [ RightUnitor, 1 ],
+                      [ RightUnitorInverse, 1 ],
                       [ TensorProductOnObjects, 1 ] ],
                     [ InternalHomOnObjects,
                       InternalHomOnMorphismsWithGivenInternalHoms,
@@ -450,89 +452,30 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalHom,
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, a ), b ) );
     
-end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
-      Description := "IsomorphismFromTensorProductToInternalHom as the identity of (Dual(a) tensored b)" );
-
-##
-AddFinalDerivation( IsomorphismFromInternalHomToTensorProduct,
-                    [ [ IdentityMorphism, 1 ],
-                      [ DualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalHomOnObjects,
-                      InternalHomOnMorphismsWithGivenInternalHoms,
-                      EvaluationMorphismWithGivenSource,
-                      CoevaluationMorphismWithGivenRange,
-                      TensorProductToInternalHomAdjunctionMap,
-                      InternalHomToTensorProductAdjunctionMap,
-                      MonoidalPreComposeMorphismWithGivenObjects,
-                      MonoidalPostComposeMorphismWithGivenObjects,
-                      TensorProductInternalHomCompatibilityMorphismWithGivenObjects,
-                      TensorProductDualityCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalHomWithGivenObjects,
-                      MorphismFromInternalHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalHom,
-                      IsomorphismFromInternalHomToTensorProduct ],
-                    
+  end,
+[
+  IsomorphismFromInternalHomToTensorProduct,
   function( cat, a, b )
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, a ), b ) );
     
-end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
-      Description := "IsomorphismFromInternalHomToTensorProduct as the identity of (Dual(a) tensored b)" );
-
-## The next to derivations have the same conditions as IsomorphismFromInternalHomToTensorProduct,
-## because if the InternalHom is constructed via the final derivation, these
-## final derivation shall also be implemented
-##
-AddFinalDerivation( IsomorphismFromInternalHomToDual,
-                    [ [ IdentityMorphism, 1 ],
-                      [ DualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalHomOnObjects,
-                      InternalHomOnMorphismsWithGivenInternalHoms,
-                      EvaluationMorphismWithGivenSource,
-                      CoevaluationMorphismWithGivenRange,
-                      TensorProductToInternalHomAdjunctionMap,
-                      InternalHomToTensorProductAdjunctionMap,
-                      MonoidalPreComposeMorphismWithGivenObjects,
-                      MonoidalPostComposeMorphismWithGivenObjects,
-                      TensorProductInternalHomCompatibilityMorphismWithGivenObjects,
-                      TensorProductDualityCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalHomWithGivenObjects,
-                      MorphismFromInternalHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalHom,
-                      IsomorphismFromInternalHomToTensorProduct ],
-                    
+  end
+],
+[
+  IsomorphismFromInternalHomToDual,
   function( cat, object )
     
-    return IdentityMorphism( cat, DualOnObjects( cat, object ) );
+    return RightUnitor( cat, DualOnObjects( cat, object ) );
     
-end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
-      Description := "IsomorphismFromInternalHomToDual as the identity of the Dual" );
-
-##
-AddFinalDerivation( IsomorphismFromDualToInternalHom,
-                    [ [ IdentityMorphism, 1 ],
-                      [ DualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalHomOnObjects,
-                      InternalHomOnMorphismsWithGivenInternalHoms,
-                      EvaluationMorphismWithGivenSource,
-                      CoevaluationMorphismWithGivenRange,
-                      TensorProductToInternalHomAdjunctionMap,
-                      InternalHomToTensorProductAdjunctionMap,
-                      MonoidalPreComposeMorphismWithGivenObjects,
-                      MonoidalPostComposeMorphismWithGivenObjects,
-                      TensorProductInternalHomCompatibilityMorphismWithGivenObjects,
-                      TensorProductDualityCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalHomWithGivenObjects,
-                      MorphismFromInternalHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalHom,
-                      IsomorphismFromInternalHomToTensorProduct ],
-                    
+  end
+],
+[
+  IsomorphismFromDualToInternalHom,
   function( cat, object )
     
-    return IdentityMorphism( cat, DualOnObjects( cat, object ) );
+    return RightUnitorInverse( cat, DualOnObjects( cat, object ) );
     
-end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
-      Description := "IsomorphismFromDualToInternalHom as the identity of the Dual" );
+  end
+] : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
+    Description := "deriving the internal hom by tensoring with the dual object"
+);

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -428,6 +428,8 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 AddFinalDerivation( IsomorphismFromTensorProductToInternalCoHom,
                     [ [ IdentityMorphism, 1 ],
                       [ CoDualOnObjects, 1 ],
+                      [ LeftUnitor, 1 ],
+                      [ LeftUnitorInverse, 1 ],
                       [ TensorProductOnObjects, 1 ] ],
                     [ InternalCoHomOnObjects,
                       InternalCoHomOnMorphismsWithGivenInternalCoHoms,
@@ -448,89 +450,30 @@ AddFinalDerivation( IsomorphismFromTensorProductToInternalCoHom,
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) ) );
     
-end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
-      Description := "IsomorphismFromTensorProductToInternalCoHom as the identity of (a tensored CoDual(b))" );
-
-##
-AddFinalDerivation( IsomorphismFromInternalCoHomToTensorProduct,
-                    [ [ IdentityMorphism, 1 ],
-                      [ CoDualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalCoHomOnObjects,
-                      InternalCoHomOnMorphismsWithGivenInternalCoHoms,
-                      CoclosedEvaluationMorphismWithGivenRange,
-                      CoclosedCoevaluationMorphismWithGivenSource,
-                      TensorProductToInternalCoHomAdjunctionMap,
-                      InternalCoHomToTensorProductAdjunctionMap,
-                      MonoidalPreCoComposeMorphismWithGivenObjects,
-                      MonoidalPostCoComposeMorphismWithGivenObjects,
-                      InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects,
-                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalCoHomWithGivenObjects,
-                      MorphismFromInternalCoHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalCoHom,
-                      IsomorphismFromInternalCoHomToTensorProduct ],
-                    
+  end,
+[
+  IsomorphismFromInternalCoHomToTensorProduct,
   function( cat, a, b )
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) ) );
     
-end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
-      Description := "IsomorphismFromInternalCoHomToTensorProduct as the identity of (a tensored CoDual(b))" );
-
-## The next to derivations have the same conditions as IsomorphismFromInternalHomToTensorProduct,
-## because if the InternalHom is constructed via the final derivation, these
-## final derivation shall also be implemented
-##
-AddFinalDerivation( IsomorphismFromInternalCoHomToCoDual,
-                    [ [ IdentityMorphism, 1 ],
-                      [ CoDualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalCoHomOnObjects,
-                      InternalCoHomOnMorphismsWithGivenInternalCoHoms,
-                      CoclosedEvaluationMorphismWithGivenRange,
-                      CoclosedCoevaluationMorphismWithGivenSource,
-                      TensorProductToInternalCoHomAdjunctionMap,
-                      InternalCoHomToTensorProductAdjunctionMap,
-                      MonoidalPreCoComposeMorphismWithGivenObjects,
-                      MonoidalPostCoComposeMorphismWithGivenObjects,
-                      InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects,
-                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalCoHomWithGivenObjects,
-                      MorphismFromInternalCoHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalCoHom,
-                      IsomorphismFromInternalCoHomToTensorProduct ],
-                    
+  end
+],
+[
+  IsomorphismFromInternalCoHomToCoDual,
   function( cat, object )
     
-    return IdentityMorphism( cat, CoDualOnObjects( cat, object ) );
+    return LeftUnitor( cat, CoDualOnObjects( cat, object ) );
     
-end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
-      Description := "IsomorphismFromInternalCoHomToCoDual as the identity of the CoDual" );
-      
-##
-AddFinalDerivation( IsomorphismFromCoDualToInternalCoHom,
-                    [ [ IdentityMorphism, 1 ],
-                      [ CoDualOnObjects, 1 ],
-                      [ TensorProductOnObjects, 1 ] ],
-                    [ InternalCoHomOnObjects,
-                      InternalCoHomOnMorphismsWithGivenInternalCoHoms,
-                      CoclosedEvaluationMorphismWithGivenRange,
-                      CoclosedCoevaluationMorphismWithGivenSource,
-                      TensorProductToInternalCoHomAdjunctionMap,
-                      InternalCoHomToTensorProductAdjunctionMap,
-                      MonoidalPreCoComposeMorphismWithGivenObjects,
-                      MonoidalPostCoComposeMorphismWithGivenObjects,
-                      InternalCoHomTensorProductCompatibilityMorphismWithGivenObjects,
-                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
-                      MorphismFromTensorProductToInternalCoHomWithGivenObjects,
-                      MorphismFromInternalCoHomToTensorProductWithGivenObjects,
-                      IsomorphismFromTensorProductToInternalCoHom,
-                      IsomorphismFromInternalCoHomToTensorProduct ],
-                    
+  end
+],
+[
+  IsomorphismFromCoDualToInternalCoHom,
   function( cat, object )
     
-    return IdentityMorphism( cat, CoDualOnObjects( cat, object ) );
+    return LeftUnitorInverse( cat, CoDualOnObjects( cat, object ) );
     
-end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
-      Description := "IsomorphismFromCoDualToInternalCoHom as the identity of the CoDual" );
+  end
+] : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
+    Description := "deriving the internal cohom by tensoring with the codual object"
+);

--- a/MonoidalCategories/makedoc.g
+++ b/MonoidalCategories/makedoc.g
@@ -20,6 +20,7 @@ AutoDoc( rec(
     gapdoc := rec(
         LaTeXOptions := rec(
             LateExtraPreamble := """
+                \usepackage{mathtools}
             """,
         ),
     ),


### PR DESCRIPTION
Hopefully fixes #929.

I also added remarks about duals in the rigid case and documented the GAP property, which was somehow missing.