### PR TITLE
Allow to apply CanCompute to a CAP operation instead of its name

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.06-02",
+Version := "2022.06-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -378,21 +378,26 @@ DeclareGlobalFunction( "CapCategorySwitchLogicOff" );
 ##
 #############################################
 
-
+#! @BeginGroup
 #! @Description
-#! The argument is a category $C$ and a string $s$,
-#! which should be the name of a basic operation, e.g., PreCompose.
+#! The argument is a category <A>C</A> and a string <A>string</A>,
+#! which should be the name of a CAP operation, e.g., PreCompose.
 #! If applying this method is possible in $C$, the method returns <C>true</C>, <C>false</C> otherwise.
-#! If the string is not the name of a basic operation, an error is raised.
+#! If the string is not the name of a CAP operation, an error is raised.
+#! For debugging purposes one can also pass the CAP operation instead of its name.
 #! @Returns <C>true</C> or <C>false</C>
-#! @Arguments C,s
+#! @Arguments C, string
 DeclareOperation( "CanCompute",
                   [ IsCapCategory, IsString ] );
+#! @Arguments C, operation
+DeclareOperation( "CanCompute",
+                  [ IsCapCategory, IsFunction ] );
+#! @EndGroup
 
 #! @Description
 #! The arguments are a category $C$ and a string $s$.
 #! If $s$ is a categorical property (e.g. <C>"IsAbelianCategory"</C>),
-#! the output is a list of strings with basic operations
+#! the output is a list of strings with CAP operations
 #! which are missing in $C$ to have the categorical property
 #! constructively.
 #! If $s$ is not a categorical property, an error is raised.

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -529,6 +529,7 @@ InstallMethod( CreateCapCategory,
     
 end );
 
+##
 InstallMethod( CanCompute,
                [ IsCapCategory, IsString ],
                
@@ -537,13 +538,25 @@ InstallMethod( CanCompute,
     
     if not string in RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ) then
         
-        Error( "string is not the name of an operation" );
+        Error( string, " is not the name of a CAP operation" );
         
     fi;
     
     weight_list := category!.derivations_weight_list;
     
     return not CurrentOperationWeight( weight_list, string ) = infinity;
+    
+end );
+
+##
+InstallMethod( CanCompute,
+               [ IsCapCategory, IsFunction ],
+               
+  function( category, operation )
+    
+    Display( "WARNING: calling `CanCompute` with a CAP operation as the second argument should only be done for debugging purposes." );
+    
+    return CanCompute( category, NameFunction( operation ) );
     
 end );
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -948,7 +948,7 @@ InstallGlobalFunction( DerivationsOfMethodByCategory,
     elif IsString( name ) then
         string := name;
     else
-        Error( "Usage is <category>,<string>\n" );
+        Error( "Usage is <category>,<string> or <category>,<CAP operation>\n" );
         return;
     fi;
     


### PR DESCRIPTION
This should only be used for debugging purposes to keep the code portable
to other languages where functions do not have a name. To ensure this, a
suitable warning is displayed.