### PR TITLE
Derive DualOnMorphismsWithGivenDuals via coevaluation and evaluation for duals

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.06-04",
+Version := "2022.06-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -420,6 +420,59 @@ AddDerivationToCAP( TensorProductInternalHomCompatibilityMorphismInverseWithGive
 end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
       Description := "TensorProductInternalHomCompatibilityMorphismInverseWithGivenObjects as the inverse of TensorProductInternalHomCompatibilityMorphismWithGivenObjects" );
 
+##
+AddDerivationToCAP( DualOnMorphismsWithGivenDuals,
+                    
+  function( cat, source, alpha, range )
+    local a, b, av, bv;
+    
+    # α: a → b
+    # source = b^v
+    # range = a^v
+    
+    a := Source( alpha );
+    b := Range( alpha );
+    av := range;
+    bv := source;
+    
+    # b^v
+    #   |
+    #   | right unitor inverse of b^v
+    #   v
+    # b^v ⊗ 1
+    #   |
+    #   | id_{b^v} ⊗ coev_a
+    #   v
+    # b^v ⊗ (a ⊗ a^v)
+    #   |
+    #   | id_{b^v} ⊗ (α ⊗ id_{a^v})
+    #   v
+    # b^v ⊗ (b ⊗ a^v)
+    #   |
+    #   | associator
+    #   v
+    # (b^v ⊗ b) ⊗ a^v
+    #   |
+    #   | ev_b ⊗ id_{a^v}
+    #   v
+    # 1 ⊗ a^v
+    #   |
+    #   | left unitor of a^v
+    #   v
+    # a^v
+    
+    return PreComposeList( cat, [
+        RightUnitorInverse( cat, bv ),
+        TensorProductOnMorphisms( cat, IdentityMorphism( cat, bv ), CoevaluationForDual( cat, a ) ),
+        TensorProductOnMorphisms( cat, IdentityMorphism( cat, bv ), TensorProductOnMorphisms( cat, alpha, IdentityMorphism( cat, av ) ) ),
+        AssociatorRightToLeft( cat, bv, b, av ),
+        TensorProductOnMorphisms( cat, EvaluationForDual( cat, b ), IdentityMorphism( cat, av ) ),
+        LeftUnitor( cat, av )
+    ] );
+    
+end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
+      Description := "DualOnMorphismsWithGivenDuals via coevaluation and evaluation for duals" );
+
 ####################################
 ## Final derived methods
 ####################################


### PR DESCRIPTION
@sebastianpos This is the construction in Remark 3.29 of your thesis. Is there a reason why you did not add it as a derivation, or did you simply not need it?

Note: I think to make sure things are consistent, I have to show that if we set `DualOnObjects( a ) := InternalHomOnObjects( a, 1 )` the above derivation will be congruent to `InternalHomOnMorphisms( -, 1 )`. I hope this is true and not too hard :D