### PR TITLE
Fix type signature of UnderlyingRingElement

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.07-01",
+Version := "2022.07-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
@@ -49,7 +49,19 @@ KeyDependentOperation( "RingAsCategoryMorphism", IsRingAsCategory, IsRingElement
 
 DeclareAttribute( "UnderlyingRingElement",
                   IsRingAsCategoryMorphism );
-CapJitAddTypeSignature( "UnderlyingRingElement", [ IsRingAsCategoryMorphism ], IsHomalgRingElement );
+CapJitAddTypeSignature( "UnderlyingRingElement", [ IsRingAsCategoryMorphism ], function ( input_types )
+    
+    if IsHomalgRing( UnderlyingRing( input_types[1].category ) ) then
+        
+        return rec( filter := IsHomalgRingElement );
+        
+    else
+        
+        return rec( filter := IsRingElement );
+        
+    fi;
+    
+end );
 
 DeclareAttribute( "UnderlyingRing",
                   IsRingAsCategory );


### PR DESCRIPTION
RingAsCategory can take an arbitrary ring.