### PR TITLE
Do not use filters of the range category of homomorphism structure when installing operations

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.08-01",
+Version := "2022.08-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -424,7 +424,11 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRING_WITH_FILTER,
             fi;
             
             if category <> false and HasRangeCategoryOfHomomorphismStructure( category ) then
-                return ObjectFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryObject;
+                # FIXME: We would like to include the object filter of the range category here, but this does not allow to change the range category later on:
+                # When changing the range category, primitive operations are correctly installed using the new range category,
+                # but derivations which have already been triggered will not be re-installed and thus still use the old range category.
+                #return ObjectFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryObject;
+                return IsCapCategoryObject;
             else
                 return IsCapCategoryObject;
             fi;
@@ -437,7 +441,9 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACE_STRING_WITH_FILTER,
             fi;
             
             if category <> false and HasRangeCategoryOfHomomorphismStructure( category ) then
-                return MorphismFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryMorphism;
+                # FIXME: see above
+                #return MorphismFilter( RangeCategoryOfHomomorphismStructure( category ) ) and IsCapCategoryMorphism;
+                return IsCapCategoryMorphism;
             else
                 return IsCapCategoryMorphism;
             fi;


### PR DESCRIPTION
Using the filter prevents changing the range category later on. This broke
InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects
in CategoryOfColumns.
