### PR TITLE
Disable post processing for syntax trees which are cached and later reused

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.08-03",
+Version := "2022.08-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -92,7 +92,11 @@ Display( compiled_func2 );
 #! end
 
 Display( ENHANCED_SYNTAX_TREE_CODE(
-    CapJitCompiledCAPOperationAsEnhancedSyntaxTree( vec, "KernelEmbedding" )
+  CAP_JIT_INTERNAL_POST_PROCESSED_SYNTAX_TREE(
+    CapJitCompiledCAPOperationAsEnhancedSyntaxTree( vec, "KernelEmbedding" ),
+    vec,
+    false
+  )
 ) );
 #! function ( cat_1, morphism_1 )
 #!     local morphism_attr_1_1;

--- a/CompilerForCAP/gap/CompileCAPOperation.gd
+++ b/CompilerForCAP/gap/CompileCAPOperation.gd
@@ -9,6 +9,6 @@
 
 #! @Description
 #!   A special version of <Ref Func="CapJitCompiledFunctionAsEnhancedSyntaxTree" /> compiling the operation
-#!   given by <A>operation_name</A> in <A>cat</A>.
+#!   given by <A>operation_name</A> in <A>cat</A> (with post-processing disabled).
 #! @Arguments cat, operation_name
 DeclareGlobalFunction( "CapJitCompiledCAPOperationAsEnhancedSyntaxTree" );

--- a/CompilerForCAP/gap/CompileCAPOperation.gi
+++ b/CompilerForCAP/gap/CompileCAPOperation.gi
@@ -60,7 +60,7 @@ InstallGlobalFunction( "CapJitCompiledCAPOperationAsEnhancedSyntaxTree", functio
             
         fi;
         
-        cat!.compiled_functions_trees.(operation_name)[index] := CapJitCompiledFunctionAsEnhancedSyntaxTree( function_to_compile, cat, info.filter_list, return_type );
+        cat!.compiled_functions_trees.(operation_name)[index] := CapJitCompiledFunctionAsEnhancedSyntaxTree( function_to_compile, false, cat, info.filter_list, return_type );
         
     fi;
     

--- a/CompilerForCAP/gap/CompilerForCAP.gd
+++ b/CompilerForCAP/gap/CompilerForCAP.gd
@@ -75,6 +75,10 @@ DeclareGlobalFunction( "CapJitCompiledFunction" );
 #! @Description
 #!   Like <Ref Func="CapJitCompiledFunction" />, but returns an enhanced syntax tree of the compiled function.
 #!   <A>func</A> must not be an operation or a kernel function because those cannot properly be represented as a syntax tree.
+#!   The second argument can be used to disable post-processing, e.g. the application of compiler hints.
 #! @Returns a record
-#! @Arguments func[, type_signature]
+#! @Arguments func, post_processing_enabled[, type_signature]
 DeclareGlobalFunction( "CapJitCompiledFunctionAsEnhancedSyntaxTree" );
+
+# helper
+DeclareGlobalFunction( "CAP_JIT_INTERNAL_POST_PROCESSED_SYNTAX_TREE" );

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -73,11 +73,11 @@ InstallGlobalFunction( CapJitCompiledFunction, function ( func, args... )
         
     fi;
     
-    return ENHANCED_SYNTAX_TREE_CODE( CallFuncList( CapJitCompiledFunctionAsEnhancedSyntaxTree, Concatenation( [ func ], args ) ) );
+    return ENHANCED_SYNTAX_TREE_CODE( CallFuncList( CapJitCompiledFunctionAsEnhancedSyntaxTree, Concatenation( [ func, true ], args ) ) );
     
 end );
 
-InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( func, args... )
+InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( func, post_processing_enabled, args... )
   local debug, debug_idempotence, category_as_first_argument, category, type_signature, filter_list, arguments_data_types, return_type, return_data_type, tree, resolving_phase_functions, orig_tree, compiled_func, tmp, rule_phase_functions, f;
     
     Info( InfoCapJit, 1, "####" );
@@ -324,6 +324,34 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     
     # post-processing
     
+    if post_processing_enabled then
+        
+        tree := CAP_JIT_INTERNAL_POST_PROCESSED_SYNTAX_TREE( tree, category, debug );
+        
+    fi;
+    
+    if debug then
+        
+        # COVERAGE_IGNORE_BLOCK_START
+        compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
+        
+        Display( compiled_func );
+        
+        Error( "compilation finished" );
+        # COVERAGE_IGNORE_BLOCK_END
+        
+    fi;
+    
+    Info( InfoCapJit, 1, "####" );
+    Info( InfoCapJit, 1, "Compilation finished." );
+    
+    return tree;
+    
+end );
+
+InstallGlobalFunction( CAP_JIT_INTERNAL_POST_PROCESSED_SYNTAX_TREE, function ( tree, category, debug )
+  local compiled_func;
+    
     if debug then
         # COVERAGE_IGNORE_BLOCK_START
         compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
@@ -334,7 +362,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     
     tree := CapJitInlinedBindingsFully( tree );
     
-    if category_as_first_argument then
+    if category <> fail then
         
         if debug then
             # COVERAGE_IGNORE_BLOCK_START
@@ -372,21 +400,6 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         tree := CapJitDeduplicatedExpressions( tree );
         
     fi;
-    
-    if debug then
-        
-        # COVERAGE_IGNORE_BLOCK_START
-        compiled_func := ENHANCED_SYNTAX_TREE_CODE( tree );
-        
-        Display( compiled_func );
-        
-        Error( "compilation finished" );
-        # COVERAGE_IGNORE_BLOCK_END
-        
-    fi;
-    
-    Info( InfoCapJit, 1, "####" );
-    Info( InfoCapJit, 1, "Compilation finished." );
     
     return tree;
     

--- a/CompilerForCAP/gap/PrecompileCategory.gi
+++ b/CompilerForCAP/gap/PrecompileCategory.gi
@@ -137,6 +137,8 @@ InstallGlobalFunction( "CapJitPrecompileCategory", function ( category_construct
         
         compiled_tree := CapJitCompiledCAPOperationAsEnhancedSyntaxTree( cat, function_name );
         
+        compiled_tree := CAP_JIT_INTERNAL_POST_PROCESSED_SYNTAX_TREE( compiled_tree, cat, false );
+        
         # change names of arguments
         compiled_tree := CAP_JIT_INTERNAL_REPLACED_FVARS_FUNC_ID(
             compiled_tree,

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -127,7 +127,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
                         
                         if not IsBound( category!.compiled_known_methods_trees.(operation_name)[tree.args.length] ) then
                             
-                            category!.compiled_known_methods_trees.(operation_name)[tree.args.length] := CapJitCompiledFunctionAsEnhancedSyntaxTree( known_method.method, category );
+                            category!.compiled_known_methods_trees.(operation_name)[tree.args.length] := CapJitCompiledFunctionAsEnhancedSyntaxTree( known_method.method, false, category );
                             
                         fi;
                         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -179,16 +179,14 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
-    deduped_6_1 := UnderlyingMatrix( arg2_1 );
-    deduped_5_1 := NumberColumns( deduped_6_1 );
-    deduped_4_1 := NumberRows( deduped_6_1 );
+    local deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
     deduped_3_1 := OppositeCategory( ModelingCategory( cat_1 ) );
     if not IS_IDENTICAL_OBJ( deduped_3_1, deduped_3_1 ) then
         return false;
-    elif deduped_4_1 <> deduped_4_1 then
+    elif NumberRows( deduped_4_1 ) <> RankOfObject( Range( arg2_1 ) ) then
         return false;
-    elif deduped_5_1 <> deduped_5_1 then
+    elif NumberColumns( deduped_4_1 ) <> RankOfObject( Source( arg2_1 ) ) then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -419,16 +419,14 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
-    deduped_6_1 := UnderlyingMatrix( arg2_1 );
-    deduped_5_1 := NumberColumns( deduped_6_1 );
-    deduped_4_1 := NumberRows( deduped_6_1 );
+    local deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
     deduped_3_1 := OppositeCategory( ModelingCategory( cat_1 ) );
     if not IS_IDENTICAL_OBJ( deduped_3_1, deduped_3_1 ) then
         return false;
-    elif deduped_4_1 <> deduped_4_1 then
+    elif NumberRows( deduped_4_1 ) <> RankOfObject( Range( arg2_1 ) ) then
         return false;
-    elif deduped_5_1 <> deduped_5_1 then
+    elif NumberColumns( deduped_4_1 ) <> RankOfObject( Source( arg2_1 ) ) then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -480,16 +480,14 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
-    deduped_6_1 := UnderlyingMatrix( arg2_1 );
-    deduped_5_1 := NumberColumns( deduped_6_1 );
-    deduped_4_1 := NumberRows( deduped_6_1 );
+    local deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingMatrix( arg2_1 );
     deduped_3_1 := OppositeCategory( ModelingCategory( cat_1 ) );
     if not IS_IDENTICAL_OBJ( deduped_3_1, deduped_3_1 ) then
         return false;
-    elif deduped_4_1 <> deduped_4_1 then
+    elif NumberRows( deduped_4_1 ) <> RankOfObject( Range( arg2_1 ) ) then
         return false;
-    elif deduped_5_1 <> deduped_5_1 then
+    elif NumberColumns( deduped_4_1 ) <> RankOfObject( Source( arg2_1 ) ) then
         return false;
     else
         return true;

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1448,24 +1448,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := UnderlyingRing( cat_1 );
-    deduped_7_1 := List( arg2_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := List( arg2_1, function ( logic_new_func_x_2 )
             return Dimension( Source( logic_new_func_x_2 ) );
         end );
-    deduped_6_1 := Sum( deduped_7_1 );
+    deduped_7_1 := Sum( deduped_8_1 );
     hoisted_4_1 := List( arg2_1, UnderlyingMatrix );
-    hoisted_3_1 := deduped_9_1;
-    hoisted_2_1 := deduped_8_1;
-    hoisted_1_1 := deduped_7_1;
-    deduped_5_1 := List( [ 1 .. deduped_9_1 ], function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_10_1;
+    hoisted_2_1 := deduped_9_1;
+    hoisted_1_1 := deduped_8_1;
+    deduped_6_1 := List( [ 1 .. deduped_10_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_1_1[logic_new_func_x_2];
             return UnionOfRows( HomalgZeroMatrix( Sum( hoisted_1_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_1_2, hoisted_2_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_2_1 ), HomalgZeroMatrix( Sum( hoisted_1_1{[ (logic_new_func_x_2 + 1) .. hoisted_3_1 ]} ), deduped_1_2, hoisted_2_1 ) ) * hoisted_4_1[logic_new_func_x_2];
         end );
+    deduped_5_1 := UnionOfColumns( deduped_9_1, deduped_7_1, deduped_6_1{[ 1 .. deduped_10_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_9_1, deduped_7_1, deduped_6_1{[ 2 .. deduped_10_1 ]} );
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, NumberRows( SyzygiesOfRows( UnionOfColumns( deduped_8_1, deduped_6_1, deduped_5_1{[ 1 .. deduped_9_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_8_1, deduped_6_1, deduped_5_1{[ 2 .. deduped_9_1 ]} ) ) ) );
+           ), cat_1, Dimension, NumberRows( deduped_5_1 ) - RowRankOfMatrix( deduped_5_1 ) );
 end
 ########
         
@@ -1536,10 +1537,10 @@ function ( cat_1, morphisms_1, L_1, morphismsp_1 )
             deduped_1_2 := hoisted_2_1[logic_new_func_x_2];
             return UnionOfRows( HomalgZeroMatrix( Sum( hoisted_2_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_1_2, hoisted_3_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_3_1 ), HomalgZeroMatrix( Sum( hoisted_2_1{[ (logic_new_func_x_2 + 1) .. hoisted_4_1 ]} ), deduped_1_2, hoisted_3_1 ) ) * hoisted_5_1[logic_new_func_x_2];
         end );
-    deduped_11_1 := SyzygiesOfRows( UnionOfColumns( deduped_18_1, deduped_14_1, deduped_12_1{[ 1 .. deduped_19_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_18_1, deduped_14_1, deduped_12_1{[ 2 .. deduped_19_1 ]} ) );
+    deduped_11_1 := UnionOfColumns( deduped_18_1, deduped_14_1, deduped_12_1{[ 1 .. deduped_19_1 - 1 ]} ) + -1 * UnionOfColumns( deduped_18_1, deduped_14_1, deduped_12_1{[ 2 .. deduped_19_1 ]} );
     hoisted_7_1 := List( L_1, UnderlyingMatrix );
-    hoisted_6_1 := deduped_11_1;
-    morphism_attr_1_1 := RightDivide( UnionOfColumns( deduped_18_1, NumberRows( deduped_11_1 ), List( [ 1 .. Length( L_1 ) ], function ( logic_new_func_x_2 )
+    hoisted_6_1 := SyzygiesOfRows( deduped_11_1 );
+    morphism_attr_1_1 := RightDivide( UnionOfColumns( deduped_18_1, NumberRows( deduped_11_1 ) - RowRankOfMatrix( deduped_11_1 ), List( [ 1 .. Length( L_1 ) ], function ( logic_new_func_x_2 )
                 local deduped_1_2;
                 deduped_1_2 := Sum( hoisted_2_1{[ 1 .. logic_new_func_x_2 - 1 ]} ) + 1;
                 return CertainColumns( hoisted_6_1, [ deduped_1_2 .. (deduped_1_2 - 1 + hoisted_2_1[logic_new_func_x_2]) ] ) * hoisted_7_1[logic_new_func_x_2];
@@ -2037,51 +2038,51 @@ function ( cat_1, list_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1;
     deduped_27_1 := UnderlyingRing( cat_1 );
     deduped_26_1 := List( list_1, Dimension );
-    deduped_25_1 := deduped_26_1[1];
-    deduped_24_1 := deduped_26_1[3];
-    deduped_23_1 := deduped_26_1[2];
-    deduped_22_1 := deduped_26_1[4];
-    deduped_21_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
-    deduped_20_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
-    deduped_19_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
-    deduped_18_1 := deduped_25_1 * deduped_24_1;
+    deduped_25_1 := deduped_26_1[2];
+    deduped_24_1 := deduped_26_1[1];
+    deduped_23_1 := deduped_26_1[4];
+    deduped_22_1 := deduped_26_1[3];
+    deduped_21_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
+    deduped_20_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
+    deduped_19_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
+    deduped_18_1 := deduped_25_1 * deduped_23_1;
     deduped_17_1 := deduped_24_1 * deduped_22_1;
-    deduped_16_1 := deduped_23_1 * deduped_22_1;
-    deduped_15_1 := deduped_17_1 * deduped_17_1;
-    deduped_14_1 := deduped_24_1 * deduped_16_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
-    deduped_12_1 := deduped_18_1 * deduped_16_1;
+    deduped_16_1 := deduped_22_1 * deduped_23_1;
+    deduped_15_1 := deduped_22_1 * deduped_18_1;
+    deduped_14_1 := deduped_16_1 * deduped_16_1;
+    deduped_13_1 := HomalgIdentityMatrix( deduped_16_1, deduped_27_1 );
+    deduped_12_1 := deduped_17_1 * deduped_18_1;
     deduped_11_1 := HomalgIdentityMatrix( deduped_12_1, deduped_27_1 );
-    deduped_10_1 := deduped_12_1 * deduped_17_1;
-    hoisted_8_1 := deduped_12_1;
-    hoisted_7_1 := deduped_17_1;
-    hoisted_6_1 := deduped_16_1;
+    deduped_10_1 := deduped_12_1 * deduped_16_1;
+    hoisted_3_1 := deduped_12_1;
+    hoisted_2_1 := deduped_16_1;
+    deduped_9_1 := KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
+                        local deduped_1_2;
+                        deduped_1_2 := (i_2 - 1);
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                        local deduped_1_2;
+                        deduped_1_2 := (i_2 - 1);
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_27_1 ), deduped_11_1 ) * KroneckerMat( ConvertMatrixToColumn( deduped_13_1 ), deduped_11_1 );
+    hoisted_8_1 := deduped_18_1;
+    hoisted_7_1 := deduped_24_1;
+    hoisted_6_1 := deduped_22_1;
     hoisted_5_1 := deduped_25_1;
-    hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_23_1;
-    hoisted_2_1 := deduped_22_1;
-    deduped_9_1 := KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( deduped_19_1, KroneckerMat( HomalgIdentityMatrix( deduped_23_1, deduped_27_1 ), ConvertMatrixToRow( deduped_20_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
-                                  local deduped_1_2;
-                                  deduped_1_2 := (i_2 - 1);
-                                  return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                              end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_22_1 * deduped_23_1), deduped_27_1 ), deduped_20_1 ) ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_19_1, ConvertMatrixToRow( deduped_21_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+    hoisted_4_1 := deduped_23_1;
+    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_27_1 ), KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( deduped_19_1, KroneckerMat( HomalgIdentityMatrix( deduped_25_1, deduped_27_1 ), ConvertMatrixToRow( deduped_20_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_24_1 * deduped_25_1), deduped_27_1 ), deduped_21_1 )), HomalgIdentityMatrix( deduped_16_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_27_1 ), HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
-                            local deduped_1_2;
-                            deduped_1_2 := (i_2 - 1);
-                            return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                        end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_27_1 ) ), deduped_20_1 ) ) * (KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                      end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ), deduped_11_1 ) * KroneckerMat( ConvertMatrixToColumn( deduped_13_1 ), deduped_11_1 ));
-    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_27_1 ), deduped_9_1 );
+                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_23_1 * deduped_25_1), deduped_27_1 ), deduped_20_1 ) ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_19_1, ConvertMatrixToRow( deduped_21_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                                      local deduped_1_2;
+                                      deduped_1_2 := (i_2 - 1);
+                                      return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
+                                  end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_22_1 * deduped_24_1), deduped_27_1 ), deduped_21_1 )), HomalgIdentityMatrix( deduped_18_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( HomalgIdentityMatrix( deduped_17_1, deduped_27_1 ), HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                              local deduped_1_2;
+                              deduped_1_2 := (i_2 - 1);
+                              return (REM_INT( deduped_1_2, hoisted_8_1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, hoisted_8_1 ) + 1);
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ) ), deduped_20_1 ) ) * deduped_9_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -2099,51 +2100,51 @@ function ( cat_1, source_1, list_1, range_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1;
     deduped_27_1 := UnderlyingRing( cat_1 );
     deduped_26_1 := List( list_1, Dimension );
-    deduped_25_1 := deduped_26_1[1];
-    deduped_24_1 := deduped_26_1[3];
-    deduped_23_1 := deduped_26_1[2];
-    deduped_22_1 := deduped_26_1[4];
-    deduped_21_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
-    deduped_20_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
-    deduped_19_1 := HomalgIdentityMatrix( deduped_25_1, deduped_27_1 );
-    deduped_18_1 := deduped_25_1 * deduped_24_1;
+    deduped_25_1 := deduped_26_1[2];
+    deduped_24_1 := deduped_26_1[1];
+    deduped_23_1 := deduped_26_1[4];
+    deduped_22_1 := deduped_26_1[3];
+    deduped_21_1 := HomalgIdentityMatrix( deduped_22_1, deduped_27_1 );
+    deduped_20_1 := HomalgIdentityMatrix( deduped_23_1, deduped_27_1 );
+    deduped_19_1 := HomalgIdentityMatrix( deduped_24_1, deduped_27_1 );
+    deduped_18_1 := deduped_25_1 * deduped_23_1;
     deduped_17_1 := deduped_24_1 * deduped_22_1;
-    deduped_16_1 := deduped_23_1 * deduped_22_1;
-    deduped_15_1 := deduped_17_1 * deduped_17_1;
-    deduped_14_1 := deduped_24_1 * deduped_16_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_17_1, deduped_27_1 );
-    deduped_12_1 := deduped_18_1 * deduped_16_1;
+    deduped_16_1 := deduped_22_1 * deduped_23_1;
+    deduped_15_1 := deduped_22_1 * deduped_18_1;
+    deduped_14_1 := deduped_16_1 * deduped_16_1;
+    deduped_13_1 := HomalgIdentityMatrix( deduped_16_1, deduped_27_1 );
+    deduped_12_1 := deduped_17_1 * deduped_18_1;
     deduped_11_1 := HomalgIdentityMatrix( deduped_12_1, deduped_27_1 );
-    deduped_10_1 := deduped_12_1 * deduped_17_1;
-    hoisted_8_1 := deduped_12_1;
-    hoisted_7_1 := deduped_17_1;
-    hoisted_6_1 := deduped_16_1;
+    deduped_10_1 := deduped_12_1 * deduped_16_1;
+    hoisted_3_1 := deduped_12_1;
+    hoisted_2_1 := deduped_16_1;
+    deduped_9_1 := KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
+                        local deduped_1_2;
+                        deduped_1_2 := (i_2 - 1);
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
+                        local deduped_1_2;
+                        deduped_1_2 := (i_2 - 1);
+                        return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                    end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_27_1 ), deduped_11_1 ) * KroneckerMat( ConvertMatrixToColumn( deduped_13_1 ), deduped_11_1 );
+    hoisted_8_1 := deduped_18_1;
+    hoisted_7_1 := deduped_24_1;
+    hoisted_6_1 := deduped_22_1;
     hoisted_5_1 := deduped_25_1;
-    hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_23_1;
-    hoisted_2_1 := deduped_22_1;
-    deduped_9_1 := KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( deduped_19_1, KroneckerMat( HomalgIdentityMatrix( deduped_23_1, deduped_27_1 ), ConvertMatrixToRow( deduped_20_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
-                                  local deduped_1_2;
-                                  deduped_1_2 := (i_2 - 1);
-                                  return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                              end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_22_1 * deduped_23_1), deduped_27_1 ), deduped_20_1 ) ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_19_1, ConvertMatrixToRow( deduped_21_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
+    hoisted_4_1 := deduped_23_1;
+    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_27_1 ), KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( deduped_19_1, KroneckerMat( HomalgIdentityMatrix( deduped_25_1, deduped_27_1 ), ConvertMatrixToRow( deduped_20_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                                     local deduped_1_2;
                                     deduped_1_2 := (i_2 - 1);
                                     return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_24_1 * deduped_25_1), deduped_27_1 ), deduped_21_1 )), HomalgIdentityMatrix( deduped_16_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( HomalgIdentityMatrix( deduped_18_1, deduped_27_1 ), HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
-                            local deduped_1_2;
-                            deduped_1_2 := (i_2 - 1);
-                            return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                        end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_27_1 ) ), deduped_20_1 ) ) * (KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_10_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                      end ) ), deduped_10_1 ), deduped_10_1, deduped_10_1, deduped_27_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                      end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ), deduped_11_1 ) * KroneckerMat( ConvertMatrixToColumn( deduped_13_1 ), deduped_11_1 ));
-    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_27_1 ), deduped_9_1 );
+                                end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_27_1 ), deduped_20_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_23_1 * deduped_25_1), deduped_27_1 ), deduped_20_1 ) ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_19_1, ConvertMatrixToRow( deduped_21_1 ) ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                                      local deduped_1_2;
+                                      deduped_1_2 := (i_2 - 1);
+                                      return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
+                                  end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_27_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( (deduped_22_1 * deduped_24_1), deduped_27_1 ), deduped_21_1 )), HomalgIdentityMatrix( deduped_18_1, deduped_27_1 ) ), deduped_20_1 ) * KroneckerMat( KroneckerMat( HomalgIdentityMatrix( deduped_17_1, deduped_27_1 ), HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                              local deduped_1_2;
+                              deduped_1_2 := (i_2 - 1);
+                              return (REM_INT( deduped_1_2, hoisted_8_1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, hoisted_8_1 ) + 1);
+                          end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_27_1 ) ), deduped_20_1 ) ) * deduped_9_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -2377,8 +2378,8 @@ end
 function ( cat_1, C_1, alpha_1, I_1 )
     local morphism_attr_1_1, deduped_2_1, deduped_3_1;
     deduped_3_1 := UnderlyingMatrix( alpha_1 );
-    deduped_2_1 := RightDivide( LeftDivide( SyzygiesOfColumns( SyzygiesOfRows( deduped_3_1 ) ), deduped_3_1 ), SyzygiesOfRows( SyzygiesOfColumns( deduped_3_1 ) ) );
-    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_2_1 ), UnderlyingRing( cat_1 ) ), deduped_2_1 );
+    deduped_2_1 := SyzygiesOfColumns( deduped_3_1 );
+    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberRows( deduped_2_1 ) - RowRankOfMatrix( deduped_2_1 ), UnderlyingRing( cat_1 ) ), RightDivide( LeftDivide( SyzygiesOfColumns( SyzygiesOfRows( deduped_3_1 ) ), deduped_3_1 ), SyzygiesOfRows( deduped_2_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -5053,24 +5054,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := UnderlyingRing( cat_1 );
-    deduped_7_1 := List( arg2_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := List( arg2_1, function ( logic_new_func_x_2 )
             return Dimension( Range( logic_new_func_x_2 ) );
         end );
-    deduped_6_1 := Sum( deduped_7_1 );
-    hoisted_4_1 := deduped_9_1;
-    hoisted_3_1 := deduped_8_1;
-    hoisted_2_1 := deduped_7_1;
+    deduped_7_1 := Sum( deduped_8_1 );
+    hoisted_4_1 := deduped_10_1;
+    hoisted_3_1 := deduped_9_1;
+    hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := List( arg2_1, UnderlyingMatrix );
-    deduped_5_1 := List( [ 1 .. deduped_9_1 ], function ( logic_new_func_x_2 )
+    deduped_6_1 := List( [ 1 .. deduped_10_1 ], function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := hoisted_2_1[logic_new_func_x_2];
             return hoisted_1_1[logic_new_func_x_2] * UnionOfColumns( HomalgZeroMatrix( deduped_1_2, Sum( hoisted_2_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), hoisted_3_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_3_1 ), HomalgZeroMatrix( deduped_1_2, Sum( hoisted_2_1{[ (logic_new_func_x_2 + 1) .. hoisted_4_1 ]} ), hoisted_3_1 ) );
         end );
+    deduped_5_1 := UnionOfRows( deduped_9_1, deduped_7_1, deduped_6_1{[ 1 .. deduped_10_1 - 1 ]} ) + -1 * UnionOfRows( deduped_9_1, deduped_7_1, deduped_6_1{[ 2 .. deduped_10_1 ]} );
     return ObjectifyObjectForCAPWithAttributes( rec(
-           ), cat_1, Dimension, NumberColumns( SyzygiesOfColumns( UnionOfRows( deduped_8_1, deduped_6_1, deduped_5_1{[ 1 .. deduped_9_1 - 1 ]} ) + -1 * UnionOfRows( deduped_8_1, deduped_6_1, deduped_5_1{[ 2 .. deduped_9_1 ]} ) ) ) );
+           ), cat_1, Dimension, NumberColumns( deduped_5_1 ) - RowRankOfMatrix( deduped_5_1 ) );
 end
 ########
         
@@ -5110,10 +5112,10 @@ function ( cat_1, morphisms_1, L_1, morphismsp_1 )
             deduped_1_2 := hoisted_7_1[logic_new_func_x_2];
             return hoisted_6_1[logic_new_func_x_2] * UnionOfColumns( HomalgZeroMatrix( deduped_1_2, Sum( hoisted_7_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), hoisted_4_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_4_1 ), HomalgZeroMatrix( deduped_1_2, Sum( hoisted_7_1{[ (logic_new_func_x_2 + 1) .. hoisted_8_1 ]} ), hoisted_4_1 ) );
         end );
-    deduped_11_1 := SyzygiesOfColumns( UnionOfRows( deduped_18_1, deduped_14_1, deduped_12_1{[ 1 .. deduped_19_1 - 1 ]} ) + -1 * UnionOfRows( deduped_18_1, deduped_14_1, deduped_12_1{[ 2 .. deduped_19_1 ]} ) );
-    hoisted_10_1 := deduped_11_1;
+    deduped_11_1 := UnionOfRows( deduped_18_1, deduped_14_1, deduped_12_1{[ 1 .. deduped_19_1 - 1 ]} ) + -1 * UnionOfRows( deduped_18_1, deduped_14_1, deduped_12_1{[ 2 .. deduped_19_1 ]} );
+    hoisted_10_1 := SyzygiesOfColumns( deduped_11_1 );
     hoisted_9_1 := List( L_1, UnderlyingMatrix );
-    morphism_attr_1_1 := LeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_18_1, deduped_15_1, deduped_13_1{[ 1 .. deduped_20_1 - 1 ]} ) + -1 * UnionOfRows( deduped_18_1, deduped_15_1, deduped_13_1{[ 2 .. deduped_20_1 ]} ) ), UnionOfRows( deduped_18_1, NumberColumns( deduped_11_1 ), List( [ 1 .. Length( L_1 ) ], function ( logic_new_func_x_2 )
+    morphism_attr_1_1 := LeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_18_1, deduped_15_1, deduped_13_1{[ 1 .. deduped_20_1 - 1 ]} ) + -1 * UnionOfRows( deduped_18_1, deduped_15_1, deduped_13_1{[ 2 .. deduped_20_1 ]} ) ), UnionOfRows( deduped_18_1, NumberColumns( deduped_11_1 ) - RowRankOfMatrix( deduped_11_1 ), List( [ 1 .. Length( L_1 ) ], function ( logic_new_func_x_2 )
                 local deduped_1_2;
                 deduped_1_2 := Sum( hoisted_7_1{[ 1 .. logic_new_func_x_2 - 1 ]} ) + 1;
                 return hoisted_9_1[logic_new_func_x_2] * CertainRows( hoisted_10_1, [ deduped_1_2 .. (deduped_1_2 - 1 + hoisted_7_1[logic_new_func_x_2]) ] );
@@ -5681,53 +5683,53 @@ function ( cat_1, list_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1;
     deduped_29_1 := UnderlyingRing( cat_1 );
     deduped_28_1 := List( list_1, Dimension );
-    deduped_27_1 := deduped_28_1[4];
-    deduped_26_1 := deduped_28_1[2];
+    deduped_27_1 := deduped_28_1[2];
+    deduped_26_1 := deduped_28_1[4];
     deduped_25_1 := deduped_28_1[3];
     deduped_24_1 := deduped_28_1[1];
-    deduped_23_1 := HomalgIdentityMatrix( deduped_26_1, deduped_29_1 );
+    deduped_23_1 := HomalgIdentityMatrix( deduped_27_1, deduped_29_1 );
     deduped_22_1 := HomalgIdentityMatrix( deduped_24_1, deduped_29_1 );
     deduped_21_1 := HomalgIdentityMatrix( deduped_25_1, deduped_29_1 );
-    deduped_20_1 := deduped_25_1 * deduped_27_1;
-    deduped_19_1 := deduped_24_1 * deduped_26_1;
-    deduped_18_1 := deduped_24_1 * deduped_25_1;
-    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_29_1 );
-    deduped_16_1 := deduped_20_1 * deduped_24_1;
-    deduped_15_1 := HomalgIdentityMatrix( deduped_19_1, deduped_29_1 );
-    deduped_14_1 := deduped_18_1 * deduped_18_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_18_1, deduped_29_1 );
-    deduped_12_1 := deduped_19_1 * deduped_20_1;
-    deduped_11_1 := deduped_18_1 * deduped_12_1;
+    deduped_20_1 := deduped_24_1 * deduped_27_1;
+    deduped_19_1 := deduped_24_1 * deduped_25_1;
+    deduped_18_1 := deduped_25_1 * deduped_26_1;
+    deduped_17_1 := deduped_19_1 * deduped_19_1;
+    deduped_16_1 := HomalgIdentityMatrix( deduped_18_1, deduped_29_1 );
+    deduped_15_1 := deduped_18_1 * deduped_24_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_20_1, deduped_29_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_19_1, deduped_29_1 );
+    deduped_12_1 := deduped_20_1 * deduped_18_1;
+    deduped_11_1 := deduped_19_1 * deduped_12_1;
     deduped_10_1 := HomalgIdentityMatrix( deduped_12_1, deduped_29_1 );
-    hoisted_8_1 := deduped_25_1;
-    hoisted_7_1 := deduped_27_1;
-    hoisted_6_1 := deduped_26_1;
-    hoisted_5_1 := deduped_20_1;
-    hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_12_1;
-    hoisted_2_1 := deduped_18_1;
-    deduped_9_1 := KroneckerMat( ConvertMatrixToRow( deduped_13_1 ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_29_1 ), deduped_10_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
-                        local deduped_1_2;
-                        deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_29_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( KroneckerMat( deduped_15_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
+    hoisted_6_1 := deduped_25_1;
+    hoisted_5_1 := deduped_26_1;
+    hoisted_4_1 := deduped_27_1;
+    hoisted_3_1 := deduped_18_1;
+    hoisted_2_1 := deduped_24_1;
+    deduped_9_1 := KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                            local deduped_1_2;
+                            deduped_1_2 := (i_2 - 1);
+                            return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                        end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_29_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_14_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                                  local deduped_1_2;
+                                  deduped_1_2 := (i_2 - 1);
+                                  return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
+                              end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_29_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, ConvertMatrixToColumn( deduped_22_1 ) )), deduped_16_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_16_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
-                              return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_29_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_15_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
-                                    local deduped_1_2;
-                                    deduped_1_2 := (i_2 - 1);
-                                    return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_29_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, ConvertMatrixToColumn( deduped_22_1 ) )), deduped_17_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_17_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
-                                local deduped_1_2;
-                                deduped_1_2 := (i_2 - 1);
-                                return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_29_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_29_1 ), ConvertMatrixToColumn( deduped_21_1 ) )) )) );
-    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_29_1 ), deduped_9_1 );
+                              return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
+                          end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_29_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_29_1 ), ConvertMatrixToColumn( deduped_21_1 ) )) ) );
+    hoisted_8_1 := deduped_12_1;
+    hoisted_7_1 := deduped_19_1;
+    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_29_1 ), KroneckerMat( ConvertMatrixToRow( deduped_13_1 ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                            local deduped_1_2;
+                            deduped_1_2 := (i_2 - 1);
+                            return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
+                        end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_29_1 ), deduped_10_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
+                          local deduped_1_2;
+                          deduped_1_2 := (i_2 - 1);
+                          return (REM_INT( deduped_1_2, hoisted_8_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_8_1 ) + 1);
+                      end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_29_1 ) ) * deduped_9_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -5745,53 +5747,53 @@ function ( cat_1, source_1, list_1, range_1 )
     local morphism_attr_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1;
     deduped_29_1 := UnderlyingRing( cat_1 );
     deduped_28_1 := List( list_1, Dimension );
-    deduped_27_1 := deduped_28_1[4];
-    deduped_26_1 := deduped_28_1[2];
+    deduped_27_1 := deduped_28_1[2];
+    deduped_26_1 := deduped_28_1[4];
     deduped_25_1 := deduped_28_1[3];
     deduped_24_1 := deduped_28_1[1];
-    deduped_23_1 := HomalgIdentityMatrix( deduped_26_1, deduped_29_1 );
+    deduped_23_1 := HomalgIdentityMatrix( deduped_27_1, deduped_29_1 );
     deduped_22_1 := HomalgIdentityMatrix( deduped_24_1, deduped_29_1 );
     deduped_21_1 := HomalgIdentityMatrix( deduped_25_1, deduped_29_1 );
-    deduped_20_1 := deduped_25_1 * deduped_27_1;
-    deduped_19_1 := deduped_24_1 * deduped_26_1;
-    deduped_18_1 := deduped_24_1 * deduped_25_1;
-    deduped_17_1 := HomalgIdentityMatrix( deduped_20_1, deduped_29_1 );
-    deduped_16_1 := deduped_20_1 * deduped_24_1;
-    deduped_15_1 := HomalgIdentityMatrix( deduped_19_1, deduped_29_1 );
-    deduped_14_1 := deduped_18_1 * deduped_18_1;
-    deduped_13_1 := HomalgIdentityMatrix( deduped_18_1, deduped_29_1 );
-    deduped_12_1 := deduped_19_1 * deduped_20_1;
-    deduped_11_1 := deduped_18_1 * deduped_12_1;
+    deduped_20_1 := deduped_24_1 * deduped_27_1;
+    deduped_19_1 := deduped_24_1 * deduped_25_1;
+    deduped_18_1 := deduped_25_1 * deduped_26_1;
+    deduped_17_1 := deduped_19_1 * deduped_19_1;
+    deduped_16_1 := HomalgIdentityMatrix( deduped_18_1, deduped_29_1 );
+    deduped_15_1 := deduped_18_1 * deduped_24_1;
+    deduped_14_1 := HomalgIdentityMatrix( deduped_20_1, deduped_29_1 );
+    deduped_13_1 := HomalgIdentityMatrix( deduped_19_1, deduped_29_1 );
+    deduped_12_1 := deduped_20_1 * deduped_18_1;
+    deduped_11_1 := deduped_19_1 * deduped_12_1;
     deduped_10_1 := HomalgIdentityMatrix( deduped_12_1, deduped_29_1 );
-    hoisted_8_1 := deduped_25_1;
-    hoisted_7_1 := deduped_27_1;
-    hoisted_6_1 := deduped_26_1;
-    hoisted_5_1 := deduped_20_1;
-    hoisted_4_1 := deduped_24_1;
-    hoisted_3_1 := deduped_12_1;
-    hoisted_2_1 := deduped_18_1;
-    deduped_9_1 := KroneckerMat( ConvertMatrixToRow( deduped_13_1 ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_14_1 ], function ( i_2 )
-                          local deduped_1_2;
-                          deduped_1_2 := (i_2 - 1);
-                          return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
-                      end ) ), deduped_14_1 ), deduped_14_1, deduped_14_1, deduped_29_1 ), deduped_10_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
-                        local deduped_1_2;
-                        deduped_1_2 := (i_2 - 1);
-                        return (REM_INT( deduped_1_2, hoisted_3_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_3_1 ) + 1);
-                    end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_29_1 ) ) * KroneckerMat( TransposedMatrix( deduped_13_1 ), (KroneckerMat( KroneckerMat( deduped_15_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_16_1 ], function ( i_2 )
+    hoisted_6_1 := deduped_25_1;
+    hoisted_5_1 := deduped_26_1;
+    hoisted_4_1 := deduped_27_1;
+    hoisted_3_1 := deduped_18_1;
+    hoisted_2_1 := deduped_24_1;
+    deduped_9_1 := KroneckerMat( TransposedMatrix( deduped_13_1 ), KroneckerMat( KroneckerMat( deduped_14_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_15_1 ], function ( i_2 )
+                            local deduped_1_2;
+                            deduped_1_2 := (i_2 - 1);
+                            return (REM_INT( deduped_1_2, hoisted_2_1 ) * hoisted_3_1 + QUO_INT( deduped_1_2, hoisted_2_1 ) + 1);
+                        end ) ), deduped_15_1 ), deduped_15_1, deduped_15_1, deduped_29_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_14_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
+                                  local deduped_1_2;
+                                  deduped_1_2 := (i_2 - 1);
+                                  return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_2_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
+                              end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_29_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, ConvertMatrixToColumn( deduped_22_1 ) )), deduped_16_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_16_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_18_1 ], function ( i_2 )
                               local deduped_1_2;
                               deduped_1_2 := (i_2 - 1);
-                              return (REM_INT( deduped_1_2, hoisted_4_1 ) * hoisted_5_1 + QUO_INT( deduped_1_2, hoisted_4_1 ) + 1);
-                          end ) ), deduped_16_1 ), deduped_16_1, deduped_16_1, deduped_29_1 ) ), deduped_21_1 ) * KroneckerMat( KroneckerMat( (KroneckerMat( deduped_15_1, deduped_22_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_19_1 ], function ( i_2 )
-                                    local deduped_1_2;
-                                    deduped_1_2 := (i_2 - 1);
-                                    return (REM_INT( deduped_1_2, hoisted_6_1 ) * hoisted_4_1 + QUO_INT( deduped_1_2, hoisted_6_1 ) + 1);
-                                end ) ), deduped_19_1 ), deduped_19_1, deduped_19_1, deduped_29_1 ), deduped_22_1 ) * KroneckerMat( deduped_23_1, ConvertMatrixToColumn( deduped_22_1 ) )), deduped_17_1 ), deduped_21_1 ) * KroneckerMat( deduped_23_1, (KroneckerMat( deduped_17_1, deduped_21_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_20_1 ], function ( i_2 )
-                                local deduped_1_2;
-                                deduped_1_2 := (i_2 - 1);
-                                return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_8_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
-                            end ) ), deduped_20_1 ), deduped_20_1, deduped_20_1, deduped_29_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_27_1, deduped_29_1 ), ConvertMatrixToColumn( deduped_21_1 ) )) )) );
-    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_29_1 ), deduped_9_1 );
+                              return (REM_INT( deduped_1_2, hoisted_5_1 ) * hoisted_6_1 + QUO_INT( deduped_1_2, hoisted_5_1 ) + 1);
+                          end ) ), deduped_18_1 ), deduped_18_1, deduped_18_1, deduped_29_1 ), deduped_21_1 ) * KroneckerMat( HomalgIdentityMatrix( deduped_26_1, deduped_29_1 ), ConvertMatrixToColumn( deduped_21_1 ) )) ) );
+    hoisted_8_1 := deduped_12_1;
+    hoisted_7_1 := deduped_19_1;
+    morphism_attr_1_1 := RightDivide( HomalgIdentityMatrix( NumberColumns( deduped_9_1 ), deduped_29_1 ), KroneckerMat( ConvertMatrixToRow( deduped_13_1 ), deduped_10_1 ) * KroneckerMat( HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_17_1 ], function ( i_2 )
+                            local deduped_1_2;
+                            deduped_1_2 := (i_2 - 1);
+                            return (REM_INT( deduped_1_2, hoisted_7_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_7_1 ) + 1);
+                        end ) ), deduped_17_1 ), deduped_17_1, deduped_17_1, deduped_29_1 ), deduped_10_1 ) * KroneckerMat( deduped_13_1, HomalgMatrix( PermutationMat( PermList( List( [ 1 .. deduped_11_1 ], function ( i_2 )
+                          local deduped_1_2;
+                          deduped_1_2 := (i_2 - 1);
+                          return (REM_INT( deduped_1_2, hoisted_8_1 ) * hoisted_7_1 + QUO_INT( deduped_1_2, hoisted_8_1 ) + 1);
+                      end ) ), deduped_11_1 ), deduped_11_1, deduped_11_1, deduped_29_1 ) ) * deduped_9_1 );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(


### PR DESCRIPTION
This PR has an interesting side-effect:

We have the equality (Rank-nullity theorem)
```
NumberRows( matrix ) - RowRankOfMatrix( matrix ) = NumberRows( SyzygiesOfRows( matrix ) )
```
which manifests itself in
```
KernelObject( mor ) = Source( KernelEmbedding( mor ) )
```
in the implementation of MatrixCategory. Previously, always the right-hand side of the equation was used, which in general is slower than the left-hand side. With this PR, the left-hand side is used. In cases where `SyzygiesOfRows` is computed anyway (e.g. `FiberProductFunctorial`) this is a performance regression. In cases where `SyzygiesOfRows` is not computed (e.g. `FiberProduct`) this is a performance improvement.

There are two further changes to compiled code in this PR:

1. `IsWellDefinedForMorphisms` for CategoryOfColumns is now correct (in particular, we don't actually need #964 for this).
2. Many derivations of `...Inverse` are now even less efficient than before. I have opened #977 to fix this on a different level.