### PR TITLE
Add CoFreydCategory(AsOppositeOfFreydCategoryOfOpposite)

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.08-07",
+Version := "2022.08-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/PrecompileCoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.g
+++ b/CompilerForCAP/examples/PrecompileCoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.g
@@ -1,0 +1,66 @@
+#! @Chapter Examples and tests
+
+#! @Section Tests
+
+#! @Example
+
+LoadPackage( "FreydCategoriesForCAP", false );
+#! true
+
+dummy := DummyCategory( rec(
+    list_of_operations_to_install := [
+        # general category
+        "PreCompose",
+        "IdentityMorphism",
+        "IsEqualForMorphisms",
+        "IsEqualForMorphismsOnMor",
+        "IsWellDefinedForMorphisms",
+        
+        # computable
+        "IsCongruentForMorphisms",
+        
+        # pre-additive
+        "AdditionForMorphisms",
+        "SubtractionForMorphisms",
+        "AdditiveInverseForMorphisms",
+        "ZeroMorphism",
+        
+        # with zero object
+        "ZeroObject",
+        "UniversalMorphismIntoZeroObject",
+        "UniversalMorphismFromZeroObject",
+        "ZeroObjectFunctorial",
+        
+        # additive
+        "DirectSum",
+        "DirectSumFunctorial",
+        "ProjectionInFactorOfDirectSum",
+        "UniversalMorphismIntoDirectSum",
+        "InjectionOfCofactorOfDirectSum",
+        "UniversalMorphismFromDirectSum",
+        
+        # colifts
+        "IsColiftable"
+    ],
+    properties := [
+        "IsAdditiveCategory",
+    ],
+) );;
+
+StopCompilationAtPrimitivelyInstalledOperationsOfCategory( dummy );
+
+CapJitPrecompileCategoryAndCompareResult(
+    underlying_category -> CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite(
+        underlying_category
+    ),
+    [ dummy ],
+    "FreydCategoriesForCAP",
+    "CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled" :
+    operations := "primitive",
+    number_of_objectified_objects_in_data_structure_of_object := 1,
+    number_of_objectified_morphisms_in_data_structure_of_object := 0,
+    number_of_objectified_objects_in_data_structure_of_morphism := 2,
+    number_of_objectified_morphisms_in_data_structure_of_morphism := 1
+);
+
+#! @EndExample

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.08-04",
+Version := "2022.08-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/examples/CoFreydCategory.g
+++ b/FreydCategoriesForCAP/examples/CoFreydCategory.g
@@ -1,0 +1,91 @@
+#! @Chapter Examples and Tests
+
+#! @Section CoFreyd category
+
+#! @Example
+
+LoadPackage( "FreydCategoriesForCAP", false );
+#! true
+
+ZZ := HomalgRingOfIntegers( );;
+rows := CategoryOfRows( ZZ );;
+co_freyd := CoFreydCategory( rows );
+#! CoFreyd( Rows( Z ) )
+rows_obj := CategoryOfRowsObject( rows, 1 );; # ZZ^1
+co_freyd_obj := AsCoFreydCategoryObject( rows_obj );; # ZZ^1 -> 0
+rows_mor := CategoryOfRowsMorphism( rows, rows_obj, HomalgMatrix( [ 2 ], 1, 1, ZZ ), rows_obj );; # ZZ^1 --2-> ZZ^1
+co_freyd_mor := CoFreydCategoryMorphism( co_freyd_obj, rows_mor, co_freyd_obj );;
+IsWellDefined( co_freyd_mor );
+#! true
+Display( KernelObject( co_freyd_mor ) );
+#! 
+#! --------------------------------
+#! CoRelation morphism:
+#! --------------------------------
+#! 
+#! Source: 
+#! A row module over Z of rank 1
+#! 
+#! Matrix: 
+#! [ [  2 ] ]
+#! 
+#! Range: 
+#! A row module over Z of rank 1
+#! 
+#! A morphism in Rows( Z )
+#! 
+#! 
+#! --------------------------------
+#! General description:
+#! --------------------------------
+#! 
+#! An object in CoFreyd( Rows( Z ) )
+#! 
+Display( UnderlyingMorphism( KernelEmbedding( co_freyd_mor ) ) );
+#! Source: 
+#! A row module over Z of rank 1
+#! 
+#! Matrix: 
+#! [ [  1 ] ]
+#! 
+#! Range: 
+#! A row module over Z of rank 1
+#! 
+#! An identity morphism in Rows( Z )
+Display( CokernelObject( co_freyd_mor ) );
+#! 
+#! --------------------------------
+#! CoRelation morphism:
+#! --------------------------------
+#! 
+#! Source: 
+#! A row module over Z of rank 0
+#! 
+#! Matrix: 
+#! (an empty 0 x 0 matrix)
+#! 
+#! Range: 
+#! A row module over Z of rank 0
+#! 
+#! A zero, split epi-, split monomorphism in Rows( Z )
+#! 
+#! 
+#! --------------------------------
+#! General description:
+#! --------------------------------
+#! 
+#! An object in CoFreyd( Rows( Z ) )
+#! 
+Display( UnderlyingMorphism( CokernelProjection( co_freyd_mor ) ) );
+#! Source: 
+#! A row module over Z of rank 1
+#! 
+#! Matrix: 
+#! (an empty 1 x 0 matrix)
+#! 
+#! Range: 
+#! A row module over Z of rank 0
+#! 
+#! A zero, split epimorphism in Rows( Z )
+
+#! @EndExample

--- a/FreydCategoriesForCAP/gap/CoFreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/CoFreydCategory.gd
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Declarations
+#
+#! @Chapter CoFreyd category
+
+####################################
+##
+#! @Section GAP Categories
+##
+####################################
+
+DeclareFilter( "IsCoFreydCategory",
+               IsCapCategory );
+
+DeclareFilter( "IsCoFreydCategoryObject",
+               IsCapCategoryObject );
+
+DeclareFilter( "IsCoFreydCategoryMorphism",
+               IsCapCategoryMorphism );
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareGlobalFunction( "CO_FREYD_CATEGORY" );
+
+DeclareAttribute( "CoFreydCategory",
+                  IsCapCategory );
+
+DeclareAttribute( "CoFreydCategoryObject",
+                  IsCapCategoryMorphism );
+
+DeclareOperation( "CoFreydCategoryMorphism",
+                  [ IsCoFreydCategoryObject, IsCapCategoryMorphism, IsCoFreydCategoryObject ] );
+
+DeclareAttribute( "AsCoFreydCategoryObject",
+                  IsCapCategoryObject );
+
+DeclareAttribute( "AsCoFreydCategoryMorphism",
+                  IsCapCategoryMorphism );
+
+####################################
+##
+#! @Section Attributes
+##
+####################################
+
+DeclareAttribute( "UnderlyingCategory",
+                  IsCoFreydCategory );
+
+DeclareAttribute( "CoRelationMorphism",
+                  IsCoFreydCategoryObject );
+
+CapJitAddTypeSignature( "CoRelationMorphism", [ IsCoFreydCategoryObject ], function ( input_types )
+    
+    Assert( 0, IsCoFreydCategory( input_types[1].category ) );
+    
+    return CapJitDataTypeOfMorphismOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );
+
+DeclareAttribute( "UnderlyingMorphism",
+                  IsCoFreydCategoryMorphism );
+
+CapJitAddTypeSignature( "UnderlyingMorphism", [ IsCoFreydCategoryMorphism ], function ( input_types )
+    
+    Assert( 0, IsCoFreydCategory( input_types[1].category ) );
+    
+    return CapJitDataTypeOfMorphismOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );

--- a/FreydCategoriesForCAP/gap/CoFreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/CoFreydCategory.gi
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Implementations
+#
+
+# read precompiled categories
+ReadPackage( "FreydCategoriesForCAP", "gap/precompiled_categories/CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled.gi" );
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallGlobalFunction( CO_FREYD_CATEGORY,
+  function( underlying_category )
+    local cat;
+    
+    cat := CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite( underlying_category : FinalizeCategory := false );
+    
+    if ValueOption( "no_precompiled_code" ) <> true then
+        
+        ADD_FUNCTIONS_FOR_CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled( cat );
+        
+    fi;
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );
+
+##
+InstallMethod( CoFreydCategory,
+               [ IsCapCategory ],
+    CO_FREYD_CATEGORY
+);
+
+##
+InstallMethod( AsCoFreydCategoryObject,
+               [ IsCapCategoryObject ],
+               
+  function( object )
+    
+    return AsCoFreydCategoryObject( CoFreydCategory( CapCategory( object ) ), object );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( AsCoFreydCategoryObject,
+                                     [ IsCoFreydCategory, IsCapCategoryObject ],
+                                     
+  function( cat, object )
+    local injective_object;
+    
+    injective_object := CoFreydCategoryObject( cat, UniversalMorphismIntoZeroObject( UnderlyingCategory( cat ), object ) );
+    
+    # CompilerForCAP cannot handle side effects
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    SetIsInjective( injective_object, true );
+    
+    return injective_object;
+    
+end );
+
+##
+InstallMethod( CoFreydCategoryObject,
+               [ IsCapCategoryMorphism ],
+               
+  function( co_relation_morphism )
+    
+    return CoFreydCategoryObject( CoFreydCategory( CapCategory( co_relation_morphism ) ), co_relation_morphism );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( CoFreydCategoryObject,
+                                     [ IsCoFreydCategory, IsCapCategoryMorphism ],
+                                     
+  function( cat, co_relation_morphism )
+    
+    return ObjectConstructor( cat, co_relation_morphism );
+    
+end );
+
+##
+InstallMethod( AsCoFreydCategoryMorphism,
+               [ IsCapCategoryMorphism ],
+               
+  function( morphism )
+    
+    return AsCoFreydCategoryMorphism( CoFreydCategory( CapCategory( morphism ) ), morphism );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( AsCoFreydCategoryMorphism,
+                                     [ IsCoFreydCategory, IsCapCategoryMorphism ],
+                                     
+  function( cat, morphism )
+    
+    return CoFreydCategoryMorphism( cat,
+             AsCoFreydCategoryObject( cat, Source( morphism ) ),
+             morphism,
+             AsCoFreydCategoryObject( cat, Range( morphism ) )
+           );
+    
+end );
+
+##
+InstallMethod( CoFreydCategoryMorphism,
+               [ IsCoFreydCategoryObject, IsCapCategoryMorphism, IsCoFreydCategoryObject ],
+               
+  function( source, morphism_datum, range )
+    
+    return CoFreydCategoryMorphism( CapCategory( source ), source, morphism_datum, range );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( CoFreydCategoryMorphism,
+                                     [ IsCoFreydCategory, IsCoFreydCategoryObject, IsCapCategoryMorphism, IsCoFreydCategoryObject ],
+                                     
+  function( cat, source, morphism_datum, range )
+    
+    return MorphismConstructor( cat, source, morphism_datum, range );
+    
+end );
+
+####################################
+##
+## View
+##
+####################################
+
+##
+InstallMethod( Display,
+               [ IsCoFreydCategoryObject ],
+               
+  function( co_freyd_category_object )
+    
+    Print( Concatenation( "\n", "--------------------------------\n" ) );
+    Print( "CoRelation morphism:\n" );
+    Print( "--------------------------------\n\n" );
+    Display( CoRelationMorphism( co_freyd_category_object ) );
+    Print( Concatenation( "\n\n", "--------------------------------", "\n" ) );
+    
+    Print( "General description:\n" );
+    Print( "--------------------------------\n\n" );
+    Print( Concatenation( StringMutable( co_freyd_category_object ), "\n\n" ) );
+    
+end );
+
+##
+InstallMethod( Display,
+               [ IsCoFreydCategoryMorphism ],
+               
+  function( co_freyd_category_morphism )
+    
+    Print( Concatenation( "\n", "--------------------------------\n" ) );
+    Print( "Source:\n" );
+    Print( "--------------------------------\n\n" );
+    Display( CoRelationMorphism( Source( co_freyd_category_morphism ) ) );
+    Print( Concatenation( "\n\n", "--------------------------------", "\n" ) );
+    
+    Print( "Morphism datum:\n" );
+    Print( "--------------------------------\n\n" );
+    Display( UnderlyingMorphism( co_freyd_category_morphism ) );
+    Print( Concatenation( "\n\n", "--------------------------------", "\n" ) );
+    
+    Print( "Range:\n" );
+    Print( "--------------------------------\n\n" );
+    Display( CoRelationMorphism( Range( co_freyd_category_morphism ) ) );
+    Print( Concatenation( "\n\n", "--------------------------------", "\n" ) );
+    
+    Print( "General description:\n" );
+    Print( "--------------------------------\n\n" );
+    Print( Concatenation( StringMutable( co_freyd_category_morphism ), "\n\n" ) );
+    
+end );

--- a/FreydCategoriesForCAP/gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gd
+++ b/FreydCategoriesForCAP/gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gd
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Declarations
+#
+#! @Chapter CoFreyd category
+
+####################################
+##
+#! @Section Constructors
+##
+####################################
+
+DeclareOperation( "CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite",
+                  [ IsCapCategory ] );

--- a/FreydCategoriesForCAP/gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gi
+++ b/FreydCategoriesForCAP/gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gi
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Implementations
+#
+
+####################################
+##
+## Constructors
+##
+####################################
+
+##
+InstallMethod( CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite,
+               [ IsCapCategory ],
+               
+  function ( underlying_category )
+    local op1, freyd, op2, object_constructor, modeling_tower_object_constructor, object_datum, modeling_tower_object_datum, morphism_constructor, modeling_tower_morphism_constructor, morphism_datum, modeling_tower_morphism_datum, wrapper;
+    
+    op1 := Opposite( underlying_category : only_primitive_operations := true, FinalizeCategory := true );
+    
+    freyd := FreydCategory( op1 : FinalizeCategory := true );
+    
+    op2 := Opposite( freyd : only_primitive_operations := true, FinalizeCategory := true );
+    
+    ##
+    object_constructor := function ( cat, co_relation_morphism )
+      local underlying_cat;
+        
+        underlying_cat := UnderlyingCategory( cat );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( co_relation_morphism, underlying_cat, {} -> "the object datum given to the object constructor of <cat>" );
+        
+        return ObjectifyObjectForCAPWithAttributes( rec( ), cat,
+                                                    CoRelationMorphism, co_relation_morphism );
+        
+    end;
+    
+    modeling_tower_object_constructor := function ( cat, co_relation_morphism )
+      local op2, freyd, op1, underlying_cat, op1_morphism, freyd_object;
+        
+        op2 := ModelingCategory( cat );
+        
+        freyd := Opposite( op2 );
+        
+        op1 := UnderlyingCategory( freyd );
+        
+        underlying_cat := OppositeCategory( op1 );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( co_relation_morphism, underlying_cat, {} -> "the object datum given to the modeling tower object constructor of <cat>" );
+        
+        op1_morphism := MorphismConstructor( op1,
+            ObjectConstructor( op1,
+                Range( co_relation_morphism )
+            ),
+            co_relation_morphism,
+            ObjectConstructor( op1,
+                Source( co_relation_morphism )
+            )
+        );
+        
+        freyd_object := ObjectConstructor( freyd,
+            op1_morphism
+        );
+        
+        return ObjectConstructor( op2,
+            freyd_object
+        );
+        
+    end;
+    
+    ##
+    object_datum := function ( cat, obj )
+        
+        return CoRelationMorphism( obj );
+        
+    end;
+    
+    modeling_tower_object_datum := function ( cat, obj )
+        
+        return Opposite( RelationMorphism( Opposite( obj ) ) );
+        
+    end;
+    
+    ##
+    morphism_constructor := function ( cat, source, underlying_morphism, range )
+      local underlying_cat;
+        
+        underlying_cat := UnderlyingCategory( cat );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( underlying_morphism, underlying_cat, {} -> "the morphism datum given to the morphism constructor of <cat>" );
+        
+        if IsEqualForObjects( underlying_cat, Source( underlying_morphism ), Source( CoRelationMorphism( source ) ) ) = false then
+            
+            Error( "the source of the morphism datum must be equal to the source of the co-relation morphism of the given source object" );
+            
+        fi;
+        
+        if IsEqualForObjects( underlying_cat, Range( underlying_morphism ), Source( CoRelationMorphism( range ) ) ) = false then
+            
+            Error( "the range of the morphism datum must be equal to the source of the co-relation morphism of the given range object" );
+            
+        fi;
+        
+        return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec( ), cat,
+                source,
+                range,
+                UnderlyingMorphism, underlying_morphism );
+        
+    end;
+    
+    modeling_tower_morphism_constructor := function ( cat, source, underlying_morphism, range )
+      local op2, freyd, op1, underlying_cat, op1_morphism, freyd_morphism;
+        
+        op2 := ModelingCategory( cat );
+        
+        freyd := Opposite( op2 );
+        
+        op1 := UnderlyingCategory( freyd );
+        
+        underlying_cat := OppositeCategory( op1 );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( underlying_morphism, underlying_cat, {} -> "the morphism datum given to the modeling tower morphism constructor of <cat>" );
+        
+        if IsEqualForObjects( underlying_cat, Source( underlying_morphism ), Source( Opposite( RelationMorphism( Opposite( source ) ) ) ) ) = false then
+            
+            Error( "the source of the morphism datum must be equal to the source of the co-relation morphism of the given source object" );
+            
+        fi;
+        
+        if IsEqualForObjects( underlying_cat, Range( underlying_morphism ), Source( Opposite( RelationMorphism( Opposite( range ) ) ) ) ) = false then
+            
+            Error( "the range of the morphism datum must be equal to the source of the co-relation morphism of the given range object" );
+            
+        fi;
+        
+        op1_morphism := MorphismConstructor( op1,
+            Range( RelationMorphism( Opposite( range ) ) ),
+            underlying_morphism,
+            Range( RelationMorphism( Opposite( source ) ) )
+        );
+        
+        freyd_morphism := MorphismConstructor( freyd,
+            Opposite( range ),
+            op1_morphism,
+            Opposite( source )
+        );
+        
+        return MorphismConstructor( op2,
+            source,
+            freyd_morphism,
+            range
+        );
+        
+    end;
+    
+    ##
+    morphism_datum := function ( op2, mor )
+        
+        return UnderlyingMorphism( mor );
+        
+    end;
+    
+    modeling_tower_morphism_datum := function ( cat, mor )
+        
+        return Opposite( UnderlyingMorphism( Opposite( mor ) ) );
+        
+    end;
+    
+    wrapper := WrapperCategory( op2, rec(
+        name := Concatenation( "CoFreyd( ", Name( underlying_category )," )" ),
+        category_filter := IsCoFreydCategory,
+        category_object_filter := IsCoFreydCategoryObject,
+        category_morphism_filter := IsCoFreydCategoryMorphism,
+        object_constructor := object_constructor,
+        object_datum := object_datum,
+        morphism_constructor := morphism_constructor,
+        morphism_datum := morphism_datum,
+        modeling_tower_morphism_constructor := modeling_tower_morphism_constructor,
+        modeling_tower_morphism_datum := modeling_tower_morphism_datum,
+        modeling_tower_object_constructor := modeling_tower_object_constructor,
+        modeling_tower_object_datum := modeling_tower_object_datum,
+        only_primitive_operations := true,
+    ) );
+    
+    SetUnderlyingCategory( wrapper, underlying_category );
+    
+    wrapper!.compiler_hints.category_attribute_names := [
+        "UnderlyingCategory",
+    ];
+    
+    return wrapper;
+    
+end );

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled.gi
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FreydCategoriesForCAP: Freyd categories - Formal (co)kernels for additive categories
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled", function ( cat )
+    
+    ##
+    AddAdditionForMorphisms( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMorphism, AdditionForMorphisms( UnderlyingCategory( cat_1 ), UnderlyingMorphism( a_1 ), UnderlyingMorphism( b_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddAdditiveInverseForMorphisms( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( a_1 ), Range( a_1 ), UnderlyingMorphism, AdditiveInverseForMorphisms( UnderlyingCategory( cat_1 ), UnderlyingMorphism( a_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, CoRelationMorphism, DirectSumFunctorial( UnderlyingCategory( cat_1 ), List( arg2_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ), List( arg2_1, function ( logic_new_func_x_2 )
+                return CoRelationMorphism( logic_new_func_x_2 );
+            end ), List( arg2_1, function ( logic_new_func_x_2 )
+                return Range( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddDirectSumFunctorialWithGivenDirectSums( cat,
+        
+########
+function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, Pp_1, UnderlyingMorphism, DirectSumFunctorial( UnderlyingCategory( cat_1 ), List( L_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( Source( logic_new_func_x_2 ) ) );
+            end ), List( L_1, function ( logic_new_func_x_2 )
+                return UnderlyingMorphism( logic_new_func_x_2 );
+            end ), List( L_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( Range( logic_new_func_x_2 ) ) );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, a_1, UnderlyingMorphism, IdentityMorphism( UnderlyingCategory( cat_1 ), Source( CoRelationMorphism( a_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, objects_1[k_1], P_1, UnderlyingMorphism, InjectionOfCofactorOfDirectSum( UnderlyingCategory( cat_1 ), List( objects_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ), k_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    local deduped_4_1;
+    deduped_4_1 := UnderlyingCategory( cat_1 );
+    return IsColiftable( deduped_4_1, CoRelationMorphism( Source( arg2_1 ) ), AdditionForMorphisms( deduped_4_1, UnderlyingMorphism( arg2_1 ), AdditiveInverseForMorphisms( deduped_4_1, UnderlyingMorphism( arg3_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsEqualForMorphisms( UnderlyingCategory( cat_1 ), UnderlyingMorphism( arg2_1 ), UnderlyingMorphism( arg3_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IsEqualForMorphismsOnMor( UnderlyingCategory( cat_1 ), CoRelationMorphism( arg2_1 ), CoRelationMorphism( arg3_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsWellDefinedForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    local deduped_3_1, deduped_4_1;
+    deduped_4_1 := UnderlyingMorphism( arg2_1 );
+    deduped_3_1 := UnderlyingCategory( cat_1 );
+    if not IsWellDefinedForMorphisms( deduped_3_1, deduped_4_1 ) then
+        return false;
+    elif not IsColiftable( deduped_3_1, CoRelationMorphism( Source( arg2_1 ) ), PreCompose( deduped_3_1, deduped_4_1, CoRelationMorphism( Range( arg2_1 ) ) ) ) then
+        return false;
+    else
+        return true;
+    fi;
+    return;
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsWellDefinedForObjects( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    if not IsWellDefinedForMorphisms( UnderlyingCategory( cat_1 ), CoRelationMorphism( arg2_1 ) ) then
+        return false;
+    else
+        return true;
+    fi;
+    return;
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsZeroForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return IsColiftable( UnderlyingCategory( cat_1 ), CoRelationMorphism( Source( arg2_1 ) ), UnderlyingMorphism( arg2_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddKernelEmbedding( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
+    deduped_4_1 := Source( alpha_1 );
+    deduped_3_1 := UnderlyingCategory( cat_1 );
+    deduped_2_1 := CoRelationMorphism( deduped_4_1 );
+    deduped_1_1 := Source( deduped_2_1 );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, CoRelationMorphism, UniversalMorphismIntoDirectSum( deduped_3_1, [ Range( deduped_2_1 ), Source( CoRelationMorphism( Range( alpha_1 ) ) ) ], deduped_1_1, [ deduped_2_1, UnderlyingMorphism( alpha_1 ) ] ) ), deduped_4_1, UnderlyingMorphism, IdentityMorphism( deduped_3_1, deduped_1_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddKernelLiftWithGivenKernelObject( cat,
+        
+########
+function ( cat_1, alpha_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMorphism, UnderlyingMorphism( tau_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMonomorphismIntoSomeInjectiveObject( cat,
+        
+########
+function ( cat_1, A_1 )
+    local deduped_1_1, deduped_2_1;
+    deduped_2_1 := UnderlyingCategory( cat_1 );
+    deduped_1_1 := Source( CoRelationMorphism( A_1 ) );
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, A_1, ObjectifyObjectForCAPWithAttributes( rec(
+             ), cat_1, CoRelationMorphism, UniversalMorphismIntoZeroObject( deduped_2_1, deduped_1_1 ) ), UnderlyingMorphism, IdentityMorphism( deduped_2_1, deduped_1_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismConstructor( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1, arg4_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, arg2_1, arg4_1, UnderlyingMorphism, arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismDatum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return UnderlyingMorphism( arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddObjectConstructor( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, CoRelationMorphism, arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddObjectDatum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return CoRelationMorphism( arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddPostCompose( cat,
+        
+########
+function ( cat_1, beta_1, alpha_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, Source( alpha_1 ), Range( beta_1 ), UnderlyingMorphism, PreCompose( UnderlyingCategory( cat_1 ), UnderlyingMorphism( alpha_1 ), UnderlyingMorphism( beta_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, objects_1[k_1], UnderlyingMorphism, ProjectionInFactorOfDirectSum( UnderlyingCategory( cat_1 ), List( objects_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ), k_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMorphism, UniversalMorphismFromDirectSum( UnderlyingCategory( cat_1 ), List( objects_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ), Source( CoRelationMorphism( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMorphism( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismFromZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, P_1, T_1, UnderlyingMorphism, UniversalMorphismFromZeroObject( UnderlyingCategory( cat_1 ), Source( CoRelationMorphism( T_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoDirectSumWithGivenDirectSum( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMorphism, UniversalMorphismIntoDirectSum( UnderlyingCategory( cat_1 ), List( objects_1, function ( logic_new_func_x_2 )
+                return Source( CoRelationMorphism( logic_new_func_x_2 ) );
+            end ), Source( CoRelationMorphism( T_1 ) ), List( tau_1, function ( logic_new_func_x_2 )
+                return UnderlyingMorphism( logic_new_func_x_2 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddUniversalMorphismIntoZeroObjectWithGivenZeroObject( cat,
+        
+########
+function ( cat_1, T_1, P_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, T_1, P_1, UnderlyingMorphism, UniversalMorphismIntoZeroObject( UnderlyingCategory( cat_1 ), Source( CoRelationMorphism( T_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroMorphism( cat,
+        
+########
+function ( cat_1, a_1, b_1 )
+    return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
+           ), cat_1, a_1, b_1, UnderlyingMorphism, ZeroMorphism( UnderlyingCategory( cat_1 ), Source( CoRelationMorphism( a_1 ) ), Source( CoRelationMorphism( b_1 ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddZeroObject( cat,
+        
+########
+function ( cat_1 )
+    return ObjectifyObjectForCAPWithAttributes( rec(
+           ), cat_1, CoRelationMorphism, ZeroObjectFunctorial( UnderlyingCategory( cat_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+end );
+
+BindGlobal( "CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled", function ( underlying_category )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function ( underlying_category )
+    return CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite( underlying_category );
+end;
+        
+        
+    
+    cat := category_constructor( underlying_category : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_CoFreydCategoryAsOppositeOfFreydCategoryOfOppositePrecompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/FreydCategoriesForCAP/init.g
+++ b/FreydCategoriesForCAP/init.g
@@ -20,6 +20,8 @@ ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfGradedRowsAndColumns/Catego
 ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfGradedRowsAndColumns/Tools.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategory.gd" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CoFreydCategory.gd" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gd" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gd" );
 

--- a/FreydCategoriesForCAP/read.g
+++ b/FreydCategoriesForCAP/read.g
@@ -21,6 +21,8 @@ ReadPackage( "FreydCategoriesForCAP", "gap/CategoryOfGradedRowsAndColumns/Tools.
 ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategoriesDerivedMethods.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/FreydCategory.gi" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CoFreydCategory.gi" );
+ReadPackage( "FreydCategoriesForCAP", "gap/CoFreydCategoryAsOppositeOfFreydCategoryOfOpposite.gi" );
 
 ReadPackage( "FreydCategoriesForCAP", "gap/AdditiveClosure.gi" );
 


### PR DESCRIPTION
This does not include all the convenience functions which FreydCategory has, and it only compiles the basic operations available regardless of the concrete input category (e.g. not the tensor structure which is installed conditionally only if the concrete input category has a tensor structure).

@sebastianpos The code should be clean and stable, so even if this is not used at the moment, I would still like to merge it as a demo for CompilerForCAP. Is that okay? The only thing we should make sure to get right are the names: are `CoFreydCategory`, `CoRelationMorphism` and `UnderlyingMorphism` the names we want for the constructor and the attributes?