### PR TITLE
Make `/` a generic shorthand for `ObjectConstructor`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.08-07",
+Version := "2022.08-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -248,6 +248,13 @@ DeclareOperation( "ObjectConstructor",
                   [ IsCapCategory, IsObject ] );
 
 #! @Description
+#!   Shorthand for `ObjectConstructor( C, a )`.
+#! @Returns an object
+#! @Arguments a, C
+DeclareOperation( "\/",
+                  [ IsObject, IsCapCategory ] );
+
+#! @Description
 #! The argument is a CAP category object <A>obj</A>.
 #! The output is a datum which can be used to construct <A>obj</A>, that is,
 #! `IsEqualForObjects( `<A>obj</A>`, ObjectConstructor( CapCategory( `<A>obj</A>` ), ObjectDatum( `<A>obj</A>` ) ) )`.

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -192,6 +192,22 @@ InstallMethod( AddObject,
 end );
 
 ##
+InstallMethod( \/,
+               [ IsObject, IsCapCategory ],
+               
+  function( object_datum, cat )
+    
+    if not CanCompute( cat, "ObjectConstructor" ) then
+        
+        Error( "You are calling the generic \"/\" method, but <cat> does not have an object constructor. Please add one or install a special version of \"/\"." );
+        
+    fi;
+    
+    return ObjectConstructor( cat, object_datum );
+    
+end );
+
+##
 InstallMethod( IsWellDefined,
                [ IsCapCategoryObject ],
   IsWellDefinedForObjects

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -289,7 +289,7 @@ InstallMethod( ProductOp,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
           [ IsList, IsCapProductCategory ],
   function( list, category )
 

--- a/CAP/gap/WrapperCategory.gi
+++ b/CAP/gap/WrapperCategory.gi
@@ -89,7 +89,7 @@ InstallOtherMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
         "for a CAP category object and a wrapper CAP category",
          [ IsCapCategoryObject, IsWrapperCapCategory ],
         
@@ -104,7 +104,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
         "for a CAP category morphism and a wrapper CAP category",
         [ IsCapCategoryMorphism, IsWrapperCapCategory ],
         

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.08-08",
+Version := "2022.08-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -88,7 +88,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2022.06-01" ],
+                           [ "CAP", ">= 2022.08-08" ],
                            [ "MatricesForHomalg", ">= 2021.07-01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "LinearAlgebraForCAP", ">= 2020.05.16" ],

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -228,7 +228,7 @@ InstallMethod( AdditiveClosureMorphismListList,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsList, IsAdditiveClosureCategory ],
                
   function( listlist, category )
@@ -265,7 +265,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
           [ IsCapCategoryObject, IsAdditiveClosureCategory ],
   function( o, C )
     
@@ -280,7 +280,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
           [ IsCapCategoryMorphism, IsAdditiveClosureCategory ],
   function( alpha, C )
     

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -1489,7 +1489,7 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
               [ IsCapCategoryObject, IsAdelmanCategory ],
               
   function( object, adel )
@@ -1505,7 +1505,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsFreydCategoryObject, IsAdelmanCategory ],
   function( freyd_obj, adel )
     local underlying_category;
@@ -1523,7 +1523,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
               [ IsCapCategoryMorphism, IsAdelmanCategory ],
   function( morphism, adel )
     

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gd
@@ -58,10 +58,6 @@ DeclareOperation( "CategoryOfColumnsMorphism",
 DeclareOperation( "\/",
                   [ IsHomalgMatrix, IsCategoryOfColumns ] );
 
-DeclareOperation( "\/",
-                  [ IsInt, IsCategoryOfColumns ] );
-
-
 ####################################
 ##
 #! @Section Attributes

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gi
@@ -263,15 +263,10 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsHomalgMatrix, IsCategoryOfColumns ],
                AsCategoryOfColumnsMorphism
 );
-
-##
-InstallMethod( \/,
-               [ IsInt, IsCategoryOfColumns ],
-               CategoryOfColumnsObject );
 
 ####################################
 ##

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gd
@@ -50,9 +50,6 @@ DeclareOperation( "CategoryOfRowsMorphism",
 DeclareOperation( "\/",
                   [ IsHomalgMatrix, IsCategoryOfRows ] );
 
-DeclareOperation( "\/",
-                  [ IsInt, IsCategoryOfRows ] );
-
 KeyDependentOperation( "StandardRowMorphism",
                        IsCategoryOfRowsObject, IsInt, ReturnTrue );
 

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -1417,15 +1417,10 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsHomalgMatrix, IsCategoryOfRows ],
                AsCategoryOfRowsMorphism
 );
-
-##
-InstallMethod( \/,
-               [ IsInt, IsCategoryOfRows ],
-               CategoryOfRowsObject );
 
 ####################################
 ##

--- a/FreydCategoriesForCAP/gap/FreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gd
@@ -49,9 +49,6 @@ DeclareAttribute( "EmbeddingFunctorIntoFreydCategory",
                   IsCapCategory );
 
 DeclareOperation( "\/",
-                  [ IsCapCategoryObject, IsFreydCategory ] );
-
-DeclareOperation( "\/",
                   [ IsCapCategoryMorphism, IsFreydCategory ] );
 
 DeclareOperation( "\/",

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -2066,26 +2066,7 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
-              [ IsCapCategoryMorphism, IsFreydCategory ],
-              
-  function( mor, category )
-    local freyd_mor;
-    
-    freyd_mor := FreydCategoryObject( category, mor );
-    
-    if not IsIdenticalObj( CapCategory( freyd_mor ), category ) then
-        
-        Error( "The Freyd category of the given morphism is not identical to the provided Freyd category" );
-        
-    fi;
-    
-    return freyd_mor;
-    
-end );
-
-##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsHomalgMatrix, IsFreydCategory ],
                
   function( mat, freyd_category )
@@ -2095,7 +2076,7 @@ InstallMethod( \/,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsCapCategoryObject, IsFreydCategory ],
                
   function( obj, freyd_category )

--- a/FreydCategoriesForCAP/gap/GroupsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/GroupsAsCats.gi
@@ -387,7 +387,7 @@ InstallMethod( \=,
                [ IsGroupAsCategoryMorphism, IsGroupAsCategoryMorphism ],
                IsCongruentForMorphisms );
 
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsObject, IsGroupAsCategory ],
                GroupAsCategoryMorphism );
 

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -949,7 +949,7 @@ InstallMethod( \=,
                [ IsLinearClosureMorphism, IsLinearClosureMorphism ],
                IsCongruentForMorphisms );
 
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsCapCategoryMorphism, IsLinearClosure ],
                
     function( mor, cat )

--- a/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
@@ -386,16 +386,16 @@ InstallMethod( DownOnlyMorphismData,
 end );
 
 
-InstallMethod(\*,
-              [ IsProSetAsCategoryMorphism, IsProSetAsCategoryMorphism ],
+InstallMethod( \*,
+               [ IsProSetAsCategoryMorphism, IsProSetAsCategoryMorphism ],
   function( alpha , beta )
 
     return PreCompose( alpha , beta ) ;
 
 end );
 
-InstallMethod(\/,
-              [ IsInt, IsProSetAsCategory ],
+InstallOtherMethod( \/,
+               [ IsInt, IsProSetAsCategory ],
   function( n, C )
 
     return ProSetAsCategoryObject( n , C ) ;

--- a/FreydCategoriesForCAP/gap/QuiverRows.gi
+++ b/FreydCategoriesForCAP/gap/QuiverRows.gi
@@ -1618,18 +1618,18 @@ InstallMethod( \.,
 end );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsQuiverVertex, IsQuiverRowsCategory ],
                AsQuiverRowsObject
 );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsQuiverAlgebraElement, IsQuiverRowsCategory ],
                AsQuiverRowsMorphism );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsPath, IsQuiverRowsCategory ],
                {p, QRows} -> PathAsAlgebraElement( UnderlyingQuiverAlgebra( QRows ), p )/QRows
 );

--- a/FreydCategoriesForCAP/gap/Relations.gi
+++ b/FreydCategoriesForCAP/gap/Relations.gi
@@ -264,12 +264,12 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsCapCategoryObject, IsRelCategory ],
                RelCategoryObject );
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsCapCategoryMorphism, IsRelCategory ],
                
   function( mor, rel )

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -430,7 +430,7 @@ InstallMethod( \=,
                [ IsRingAsCategoryMorphism, IsRingAsCategoryMorphism ],
                IsCongruentForMorphisms );
 
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsRingElement, IsRingAsCategory ],
                RingAsCategoryMorphism );
 

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotients.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotients.gi
@@ -98,7 +98,7 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsCapCategoryObject, IsSerreQuotientCategory ],
                
   function( obj, serre_category )

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.08-03",
+Version := "2022.08-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -90,7 +90,7 @@ Dependencies := rec(
                            [ "ToolsForHomalg", ">=2015.09.18" ],
                            [ "MatricesForHomalg", ">= 2021.12-01" ],
                            [ "GaussForHomalg", ">= 2021.04-02" ],
-                           [ "CAP", ">= 2022.03-08" ],
+                           [ "CAP", ">= 2022.08-08" ],
                            [ "MonoidalCategories", ">= 2022.06-01" ],
                            ],
   SuggestedOtherPackages := [

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gd
@@ -44,9 +44,6 @@ DeclareAttribute( "AsVectorSpaceMorphism", IsHomalgMatrix );
 DeclareOperation( "\/",
                   [ IsHomalgMatrix, IsMatrixCategory ] );
 
-DeclareOperation( "\/",
-                  [ IsInt, IsMatrixCategory ] );
-
 ####################################
 ##
 #! @Section Attributes

--- a/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryMorphism.gi
@@ -168,7 +168,7 @@ end );
 ####################################
 
 ##
-InstallMethod( \/,
+InstallOtherMethod( \/,
                [ IsHomalgMatrix, IsMatrixCategory ],
   function( homalg_matrix, category )
     local field;

--- a/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
+++ b/LinearAlgebraForCAP/gap/MatrixCategoryObject.gi
@@ -110,18 +110,3 @@ InstallMethod( LaTeXOutput,
     return Concatenation( LaTeXOutput( UnderlyingRing( CapCategory( vector_space_object ) ) ), "^{1 \\times ", String( Dimension( vector_space_object ) ), "}" );
     
 end );
-
-####################################
-##
-## Convenience
-##
-####################################
-
-##
-InstallMethod( \/,
-               [ IsInt, IsMatrixCategory ],
-  function( dim, category )
-    
-    return MatrixCategoryObject( category, dim );
-    
-end );

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.08-03",
+Version := "2022.08-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -119,7 +119,7 @@ Dependencies := rec(
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
                    [ "ToolsForHomalg", ">= 2018.05.22" ],
-                   [ "CAP", ">= 2022.05-07" ],
+                   [ "CAP", ">= 2022.08-08" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/MonoidalCategories/gap/TerminalCategory.gd
+++ b/MonoidalCategories/gap/TerminalCategory.gd
@@ -57,10 +57,3 @@ DeclareGlobalFunction( "TerminalCategory" );
 #! @Arguments
 DeclareGlobalFunction( "TerminalCategoryWithMultipleObjects" );
 #! @InsertChunk TerminalCategoryWithMultipleObjects
-
-#! @Description
-#!  Create an object $a$ in the terminal category <A>T</A> with multiple objects
-#!  with <C>String</C>(<A>str</A>) = $a$.
-#! @Arguments T, str
-DeclareOperation( "/",
-        [ IsString, IsTerminalCategoryWithMultipleObjects ] );

--- a/MonoidalCategories/gap/TerminalCategory.gi
+++ b/MonoidalCategories/gap/TerminalCategory.gi
@@ -383,16 +383,6 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
     
 end );
 
-##
-InstallMethod( \/,
-        [ IsString, IsTerminalCategoryWithMultipleObjects ],
-        
-  function( string, T )
-    
-    return ObjectConstructor( T, string );
-    
-end );
-
 ##################################
 ##
 ## View & Display


### PR DESCRIPTION
@ all Do we want this?

Pros: Less code to write/think about. It should never cause problems because one can always install a method with more special filters if the generic method does not have the desired behavior.

Cons: Seeing a general installation of "/" for IsObject, IsCapCategory might be confusing.