### PR TITLE
Add better error messages for some unsupported types of statements

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.08-06",
+Version := "2022.08-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2155,7 +2155,7 @@ AddDerivationToCAP( IsomorphismFromDirectSumToDirectProduct,
                     [ [ InverseForMorphisms, 1 ],
                       [ IsomorphismFromDirectProductToDirectSum, 1 ] ],
                       
-  function( cat, diagram );
+  function( cat, diagram )
     
     return InverseForMorphisms( cat, IsomorphismFromDirectProductToDirectSum( cat, diagram ) );
     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.08-08",
+Version := "2022.08-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -43,7 +43,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
         
         # using LocationFunc causes a segfault (https://github.com/gap-system/gap/issues/4507)
         # COVERAGE_IGNORE_NEXT_LINE
-        CallFuncList( Error, Concatenation( [ "for function at ", FilenameFunc( func ), ":", StartlineFunc( func ), ":\n" ], args ) );
+        CallFuncList( Error, Concatenation( [ "for function at ", TextAttr.b1, FilenameFunc( func ), ":", StartlineFunc( func ), TextAttr.reset, ":\n" ], args ) );
         
     end;
     
@@ -137,6 +137,19 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
         elif IsRecord( tree ) then
             
             Assert( 0, IsBound( tree.type ) );
+            
+            # check for unsupported stuff
+            if tree.type = "STAT_EMPTY" then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                ErrorWithFuncLocation( "Found an empty statement, probably there is a superfluous semicolon in the function mentioned above." );
+                
+            elif tree.type = "STAT_ASS_GVAR" then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                ErrorWithFuncLocation( "Found an assignment to the global variable `", tree.gvar, "`. Maybe this should be a local variable of the function mentioned above?" );
+                
+            fi;
             
             # replace verbose types by short types
             if StartsWith( tree.type, "STAT_SEQ_STAT" ) then


### PR DESCRIPTION
Example outputs:
```
Error, for function at .gap/pkg/CAP_project/LinearAlgebraForCAP//gap/LinearAlgebraForCAP.gi:185:
Found an empty statement, probably there is a superfluous semicolon in the function mentioned above. at .gap/pkg/CAP_project/CompilerForCAP//gap/EnhancedSyntaxTree.gi:46 called from
ErrorWithFuncLocation( "Found an empty statement, probably there is a superfluous semicolon in the function mentioned above." ); at .gap/pkg/CAP_project/CompilerForCAP//gap/EnhancedSyntaxTree.gi:145 called from
```
and
```
Error, for function at .gap/pkg/CAP_project/LinearAlgebraForCAP//gap/LinearAlgebraForCAP.gi:185:
Found an assignment to the global variable `test`. Maybe this should be a local variable of the function mentioned above? at .gap/pkg/CAP_project/CompilerForCAP//gap/EnhancedSyntaxTree.gi:46 called from
ErrorWithFuncLocation( "Found an assignment to the global variable `", tree.gvar, "`. Maybe this should be a local variable of the function mentioned above?" 
 ); at .gap/pkg/CAP_project/CompilerForCAP//gap/EnhancedSyntaxTree.gi:150 called from
```