### PR TITLE
Improve warnings and error messages

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.08-09",
+Version := "2022.08-10",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -77,11 +77,15 @@ InstallGlobalFunction( CapJitCompiledFunction, function ( func, args... )
     
 end );
 
+BindGlobal( "CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK", [ ] );
+
 InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( func, post_processing_enabled, args... )
   local debug, debug_idempotence, category_as_first_argument, category, type_signature, filter_list, arguments_data_types, return_type, return_data_type, tree, resolving_phase_functions, orig_tree, compiled_func, tmp, rule_phase_functions, f;
     
     Info( InfoCapJit, 1, "####" );
     Info( InfoCapJit, 1, "Start compilation." );
+    
+    Add( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK, func );
     
     if IsOperation( func ) or IsKernelFunction( func ) then
         
@@ -341,6 +345,8 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         # COVERAGE_IGNORE_BLOCK_END
         
     fi;
+    
+    Remove( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK );
     
     Info( InfoCapJit, 1, "####" );
     Info( InfoCapJit, 1, "Compilation finished." );

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -142,12 +142,12 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
             if tree.type = "STAT_EMPTY" then
                 
                 # COVERAGE_IGNORE_NEXT_LINE
-                ErrorWithFuncLocation( "Found an empty statement, probably there is a superfluous semicolon in the function mentioned above." );
+                ErrorWithFuncLocation( "Found an empty statement, probably there is a superfluous semicolon in the function mentioned above.\n" );
                 
             elif tree.type = "STAT_ASS_GVAR" then
                 
                 # COVERAGE_IGNORE_NEXT_LINE
-                ErrorWithFuncLocation( "Found an assignment to the global variable `", tree.gvar, "`. Maybe this should be a local variable of the function mentioned above?" );
+                ErrorWithFuncLocation( "Found an assignment to the global variable `", tree.gvar, "`. Maybe this should be a local variable of the function mentioned above?\n" );
                 
             fi;
             

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -186,7 +186,7 @@ InstallGlobalFunction( "CAP_JIT_INTERNAL_GET_DATA_TYPE_OF_VALUE", function ( val
     
     if Length( filters ) > 1 then
         
-        Error( "<value> matches more than one filter in CAP_JIT_INTERNAL_GLOBAL_VARIABLE_FILTERS: ", filters );
+        ErrorWithCurrentlyCompiledFunctionLocation( "<value> matches more than one filter in CAP_JIT_INTERNAL_GLOBAL_VARIABLE_FILTERS: ", filters );
         
     elif Length( filters ) = 1 then
         
@@ -260,7 +260,7 @@ InstallGlobalFunction( "CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_I
     
     if not IsBound( CAP_JIT_INTERNAL_TYPE_SIGNATURES.(gvar) ) then
         
-        Display( Concatenation( "WARNING: Could not find declaration of ", gvar, " (current input: ", String( input_filters ), ")" ) );
+        DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "WARNING: Could not find declaration of ", gvar, " (current input: ", String( input_filters ), ")" ) );
         return fail;
         
     fi;
@@ -278,13 +278,13 @@ InstallGlobalFunction( "CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_I
     
     if Length( type_signatures ) = 0 then
         
-        Display( Concatenation( "WARNING: Could not find matching declaration of ", gvar, " for input ", String( input_filters ) ) );
+        DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "WARNING: Could not find matching declaration of ", gvar, " for input ", String( input_filters ) ) );
         return fail;
         
     elif Length( type_signatures ) > 1 then
         
         # COVERAGE_IGNORE_NEXT_LINE
-        Error( "Found multiple matching declarations of ", gvar, " for input ", input_filters );
+        ErrorWithCurrentlyCompiledFunctionLocation( "Found multiple matching declarations of ", gvar, " for input ", input_filters );
         
     fi;
     
@@ -613,7 +613,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
             
             if not ForAll( tree.branches, branch -> branch.condition.data_type.filter = IsBool ) then
                 
-                Error( "a condition of the case expression is not a boolean" );
+                ErrorWithCurrentlyCompiledFunctionLocation( "a condition of the case expression is not a boolean" );
                 
             fi;
             
@@ -646,7 +646,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
             if not ForAll( tree.list, element -> element.data_type = tree.list.1.data_type ) then
                 
                 Display( "WARNING: list is not homogeneous, this is not supported. Use `NTuple` or its convenience aliases instead. The filters of the element types are:" );
-                Display( List( AsListMut( tree.list ), element -> element.data_type.filter ) );
+                DisplayWithCurrentlyCompiledFunctionLocation( List( AsListMut( tree.list ), element -> element.data_type.filter ) );
                 # there might already be a data type set, but we want to avoid partial typings -> unbind
                 Unbind( tree.data_type );
                 return tree;
@@ -664,7 +664,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
                 # "fail" explicitly has no type yet
                 if ValueGlobal( tree.gvar ) <> fail then
                     
-                    Display( Concatenation( "could not get type of gvar ", tree.gvar ) );
+                    DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "could not get type of gvar ", tree.gvar ) );
                     
                 fi;
                 
@@ -763,7 +763,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
             
         else
             
-            Display( Concatenation( "Cannot compute data type for syntax tree type ", tree.type, " yet." ) );
+            DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "Cannot compute data type for syntax tree type ", tree.type, " yet." ) );
             # there might already be a data type set, but we want to avoid partial typings -> unbind
             Unbind( tree.data_type );
             return tree;
@@ -1037,7 +1037,7 @@ CapJitAddTypeSignature( "[]", [ IsNTuple, IsInt ], function ( args, func_stack )
     if args.2.type <> "EXPR_INT" then
         
         # COVERAGE_IGNORE_NEXT_LINE
-        Error( "You should only access tuples via literal integers." );
+        ErrorWithCurrentlyCompiledFunctionLocation( "You should only access tuples via literal integers." );
         
     fi;
     

--- a/CompilerForCAP/gap/Tools.gd
+++ b/CompilerForCAP/gap/Tools.gd
@@ -141,3 +141,13 @@ DeclareOperation( "LastOp", [ IsRecord ] );
 DeclareOperation( "ForAllOp", [ IsRecord, IsFunction ] );
 DeclareOperation( "ForAnyOp", [ IsRecord, IsFunction ] );
 DeclareOperation( "Iterator", [ IsRecord ] );
+
+#! @Description
+#!   Displays <A>obj</A> followed by the location of the currently compiled function.
+#! @Arguments obj
+DeclareGlobalFunction( "DisplayWithCurrentlyCompiledFunctionLocation" );
+
+#! @Description
+#!   Prints <A>obj</A> as an error followed by the location of the currently compiled function.
+#! @Arguments obj
+DeclareGlobalFunction( "ErrorWithCurrentlyCompiledFunctionLocation" );

--- a/CompilerForCAP/gap/Tools.gi
+++ b/CompilerForCAP/gap/Tools.gi
@@ -819,3 +819,39 @@ InstallMethod( Iterator,
     return IteratorByFunctions( iter );
     
 end );
+
+InstallGlobalFunction( DisplayWithCurrentlyCompiledFunctionLocation, function ( obj )
+  local func;
+    
+    # COVERAGE_IGNORE_BLOCK_START
+    if IsEmpty( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK ) then
+        
+        Error( obj, "\nwhile not compiling a function. This should never happen.\n" );
+        
+    fi;
+    
+    func := Last( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK );
+    
+    Display( obj );
+    
+    Print( "while compiling function with name \"", NameFunction( func ), "\"\nlocated at ", FilenameFunc( func ), ":", StartlineFunc( func ), "\n\n" );
+    # COVERAGE_IGNORE_BLOCK_END
+    
+end );
+
+InstallGlobalFunction( ErrorWithCurrentlyCompiledFunctionLocation, function ( obj )
+  local func;
+    
+    # COVERAGE_IGNORE_BLOCK_START
+    if IsEmpty( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK ) then
+        
+        Error( obj, "\nwhile not compiling a function. This should never happen.\n" );
+        
+    fi;
+    
+    func := Last( CAP_JIT_INTERNAL_COMPILED_FUNCTIONS_STACK );
+    
+    Error( obj, "\nwhile compiling function with name \"", NameFunction( func ), "\"\nlocated at ", FilenameFunc( func ), ":", StartlineFunc( func ), "\n" );
+    # COVERAGE_IGNORE_BLOCK_END
+    
+end );


### PR DESCRIPTION
Print the name and location of the currently compiled function. Warning:
This does not mean that the error actually is in this function: It could
also be in a global function called in the currently compiled function.

@mohamed-barakat This is what I promised yesterday. Example:
```
WARNING: Could not find declaration of SyzygiesOfRows (current input: [ <Category "IsHomalgMatrix"> ])
while compiling function with name "Function added to FinSets for AstrictionToCoimage"
located at /home/fabian/.gap/pkg/CAP_project/CAP//gap/DerivedMethods.gi:627
```
Please also heed the warning above.