### PR TITLE
Sort RecNames in OppositeCategory for stable results

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.08-09",
+Version := "2022.08-10",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/doc/AddFunctions.autodoc
+++ b/CAP/doc/AddFunctions.autodoc
@@ -72,12 +72,6 @@ Every Add method has the same structure. The steps in the Add method are as foll
 * Weight check: If the current weight of the operation is lower than the given weight of the new functions,
                 then the add function returns and installs nothing.
 
-* Option check: There are two possible options for every add method: `SetPrimitive` and `IsDerivation`.
-  * `SetPrimitive` should be a boolean, the default is true. If `SetPrimitive` is false, then the
-    current call of this add will not set the installed function to be primitive. This is used for derivations.
-  * `IsDerivation` should be a boolean, default is false. If it is true, the add method assumes that the given
-    function is a derivation and does not try to install a corresponding pair (See below).
-
 * Default weight: If the weight parameter is -1, the default weight is assumed, which is 100.
 
 * Checking for pairs: If the function is part of a with given pair, we check if the weight of the with given operation
@@ -86,8 +80,6 @@ Every Add method has the same structure. The steps in the Add method are as foll
 
 * Installation: Next, the method to install the functions is created. It creates the correct filter list, by merging the standard filters
                 for the operation with the particular filters for the given functions, then installs the method as described above.
-
-* SetPrimitive: If the set primitive flag is true, it is set as primitive in the weight list of the category.
 
 After calling an add method, the corresponding operation is available in the category. Also, some derivations, which are triggered by the setting
 of the primitive value, might be available.

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -144,7 +144,7 @@ function( d, weight, C )
       fi;
       
       add_method := ValueGlobal( add_name );
-      add_method( C, implementation_list, weight : SetPrimitive := false, IsDerivation := true );
+      add_method( C, implementation_list, weight : IsDerivation := true );
       
 #   fi;
   
@@ -1108,7 +1108,7 @@ InstallGlobalFunction( ListPrimitivelyInstalledOperationsOfCategory,
         Error( "input must be category or cell" );
     fi;
     
-    names := AsSortedList( RecNames( cat!.primitive_operations ) );
+    names := AsSortedList( Filtered( RecNames( cat!.primitive_operations ), x -> cat!.primitive_operations.(x) ) );
     
     if filter <> fail then
         names := Filtered( names, i -> PositionSublist( i, filter ) <> fail );

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -87,7 +87,7 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
         
     od;
     
-    recnames := RecNames( CAP_INTERNAL_METHOD_NAME_RECORD );
+    recnames := AsSortedList( RecNames( CAP_INTERNAL_METHOD_NAME_RECORD ) );
     
     for current_recname in recnames do
         


### PR DESCRIPTION
This also uncovered another issue: Previously, an operation was still marked as primitive even if the primitive installation had been overwritten by a derivation.