### PR TITLE
Install final derivations sequentially

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.09-04",
+Version := "2022.09-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2987,22 +2987,9 @@ AddFinalDerivation( IsomorphismFromFiberProductToKernelOfDiagonalDifference,
     
     return IdentityMorphism( cat, kernel_of_diagonal_difference );
     
-end : Description := "IsomorphismFromFiberProductToKernelOfDiagonalDifference as the identity of the kernel of diagonal difference" );
-
-##
-AddFinalDerivation( IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct,
-                    [ [ DirectSumDiagonalDifference, 1 ], 
-                      [ KernelObject, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ FiberProduct,
-                      ProjectionInFactorOfFiberProduct,
-                      ProjectionInFactorOfFiberProductWithGivenFiberProduct,
-                      UniversalMorphismIntoFiberProduct,
-                      UniversalMorphismIntoFiberProductWithGivenFiberProduct,
-                      FiberProductEmbeddingInDirectSum,
-                      IsomorphismFromFiberProductToKernelOfDiagonalDifference,
-                      IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct ],
-                    
+  end,
+[
+  IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct,
   function( cat, diagram )
     local kernel_of_diagonal_difference;
     
@@ -3010,7 +2997,8 @@ AddFinalDerivation( IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct,
     
     return IdentityMorphism( cat, kernel_of_diagonal_difference );
     
-end : Description := "IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct as the identity of the kernel of diagonal difference" );
+  end
+] : Description := "IsomorphismFromFiberProductToKernelOfDiagonalDifference as the identity of the kernel of diagonal difference" );
 
 ##
 AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
@@ -3039,22 +3027,9 @@ AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram
     
     return IdentityMorphism( cat, equalizer_of_direct_product_diagram );
 
-end : Description := "IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram as the identity of the equalizer of direct product diagram" );
-
-##
-AddFinalDerivation( IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct,
-                    [ [ ProjectionInFactorOfDirectProduct, 2 ], ## Length( diagram ) would be the correct number
-                      [ PreCompose, 2 ], ## Length( diagram ) would be the correct number
-                      [ Equalizer, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ FiberProduct,
-                      ProjectionInFactorOfFiberProduct,
-                      ProjectionInFactorOfFiberProductWithGivenFiberProduct,
-                      UniversalMorphismIntoFiberProduct,
-                      UniversalMorphismIntoFiberProductWithGivenFiberProduct,
-                      IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
-                      IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct ],
-                    
+  end,
+[
+  IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct,
   function( cat, diagram )
     local D, diagram_of_equalizer, equalizer_of_direct_product_diagram;
     
@@ -3068,7 +3043,8 @@ AddFinalDerivation( IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct
     
     return IdentityMorphism( cat, equalizer_of_direct_product_diagram );
 
-end : Description := "IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct as the identity of the equalizer of direct product diagram" );
+  end
+] : Description := "IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram as the identity of the equalizer of direct product diagram" );
 
 ## Final methods for Pushout
 
@@ -3093,22 +3069,9 @@ AddFinalDerivation( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
     
     return IdentityMorphism( cat, cokernel_of_diagonal_difference );
     
-end : Description := "IsomorphismFromPushoutToCokernelOfDiagonalDifference as the identity of the cokernel of diagonal difference" );
-
-##
-AddFinalDerivation( IsomorphismFromCokernelOfDiagonalDifferenceToPushout,
-                    [ [ CokernelObject, 1 ],
-                      [ DirectSumCodiagonalDifference, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ Pushout,
-                      InjectionOfCofactorOfPushout,
-                      InjectionOfCofactorOfPushoutWithGivenPushout,
-                      UniversalMorphismFromPushout,
-                      UniversalMorphismFromPushoutWithGivenPushout,
-                      DirectSumProjectionInPushout,
-                      IsomorphismFromPushoutToCokernelOfDiagonalDifference,
-                      IsomorphismFromCokernelOfDiagonalDifferenceToPushout ],
-                    
+  end,
+[
+  IsomorphismFromCokernelOfDiagonalDifferenceToPushout,
   function( cat, diagram )
     local cokernel_of_diagonal_difference;
     
@@ -3116,7 +3079,8 @@ AddFinalDerivation( IsomorphismFromCokernelOfDiagonalDifferenceToPushout,
     
     return IdentityMorphism( cat, cokernel_of_diagonal_difference );
     
-end : Description := "IsomorphismFromCokernelOfDiagonalDifferenceToPushout as the identity of the cokernel of diagonal difference" );
+  end
+]: Description := "IsomorphismFromPushoutToCokernelOfDiagonalDifference as the identity of the cokernel of diagonal difference" );
 
 ##
 AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
@@ -3145,22 +3109,9 @@ AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
     
     return IdentityMorphism( cat, coequalizer_of_coproduct_diagram );
     
-end : Description := "IsomorphismFromPushoutToCoequalizerOfCoproductDiagram as the identity of the coequalizer of coproduct diagram" );
-
-##
-AddFinalDerivation( IsomorphismFromCoequalizerOfCoproductDiagramToPushout,
-                    [ [ InjectionOfCofactorOfCoproduct, 2 ], ## Length( diagram ) would be the correct number
-                      [ PreCompose, 2 ], ## Length( diagram ) would be the correct number
-                      [ Coequalizer, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ Pushout,
-                      InjectionOfCofactorOfPushout,
-                      InjectionOfCofactorOfPushoutWithGivenPushout,
-                      UniversalMorphismFromPushout,
-                      UniversalMorphismFromPushoutWithGivenPushout,
-                      IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
-                      IsomorphismFromCoequalizerOfCoproductDiagramToPushout ],
-                    
+  end,
+[
+  IsomorphismFromCoequalizerOfCoproductDiagramToPushout,
   function( cat, diagram )
     local D, diagram_of_coequalizer, coequalizer_of_coproduct_diagram;
     
@@ -3174,7 +3125,8 @@ AddFinalDerivation( IsomorphismFromCoequalizerOfCoproductDiagramToPushout,
     
     return IdentityMorphism( cat, coequalizer_of_coproduct_diagram );
     
-end : Description := "IsomorphismFromCoequalizerOfCoproductDiagramToPushout as the identity of the coequalizer of coproduct diagram" );
+  end
+]: Description := "IsomorphismFromPushoutToCoequalizerOfCoproductDiagram as the identity of the coequalizer of coproduct diagram" );
 
 ## Final methods for Image
 
@@ -3200,23 +3152,9 @@ AddFinalDerivation( IsomorphismFromImageObjectToKernelOfCokernel,
     
     return IdentityMorphism( cat, kernel_of_cokernel );
     
-end : Description := "IsomorphismFromImageObjectToKernelOfCokernel as the identity of the kernel of the cokernel" );
-
-##
-AddFinalDerivation( IsomorphismFromKernelOfCokernelToImageObject,
-                    [ [ KernelObject, 1 ],
-                      [ CokernelProjection, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ ImageObject,
-                      ImageEmbedding,
-                      ImageEmbeddingWithGivenImageObject,
-                      CoastrictionToImage,
-                      CoastrictionToImageWithGivenImageObject,
-                      UniversalMorphismFromImage,
-                      UniversalMorphismFromImageWithGivenImageObject,
-                      IsomorphismFromImageObjectToKernelOfCokernel,
-                      IsomorphismFromKernelOfCokernelToImageObject ],
-                    
+  end,
+[
+  IsomorphismFromKernelOfCokernelToImageObject,
   function( cat, mor )
     local kernel_of_cokernel;
     
@@ -3224,7 +3162,8 @@ AddFinalDerivation( IsomorphismFromKernelOfCokernelToImageObject,
     
     return IdentityMorphism( cat, kernel_of_cokernel );
     
-end : Description := "IsomorphismFromKernelOfCokernelToImageObject as the identity of the kernel of the cokernel" );
+  end
+]: Description := "IsomorphismFromImageObjectToKernelOfCokernel as the identity of the kernel of the cokernel" );
 
 ##
 AddDerivationToCAP( MorphismFromCoimageToImageWithGivenObjects,
@@ -3287,23 +3226,9 @@ AddFinalDerivation( IsomorphismFromCoimageToCokernelOfKernel,
     
     return IdentityMorphism( cat, cokernel_of_kernel );
     
-end : Description := "IsomorphismFromCoimageToCokernelOfKernel as the identity of the cokernel of the kernel" );
-
-##
-AddFinalDerivation( IsomorphismFromCokernelOfKernelToCoimage,
-                    [ [ CokernelObject, 1 ],
-                      [ KernelEmbedding, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ CoimageObject,
-                      CoimageProjection,
-                      CoimageProjectionWithGivenCoimageObject,
-                      AstrictionToCoimage,
-                      AstrictionToCoimageWithGivenCoimageObject,
-                      UniversalMorphismIntoCoimage,
-                      UniversalMorphismIntoCoimageWithGivenCoimageObject,
-                      IsomorphismFromCoimageToCokernelOfKernel,
-                      IsomorphismFromCokernelOfKernelToCoimage ],
-                    
+  end,
+[
+  IsomorphismFromCokernelOfKernelToCoimage,
   function( cat, mor )
     local cokernel_of_kernel;
     
@@ -3311,8 +3236,8 @@ AddFinalDerivation( IsomorphismFromCokernelOfKernelToCoimage,
     
     return IdentityMorphism( cat, cokernel_of_kernel );
     
-end : Description := "IsomorphismFromCokernelOfKernelToCoimage as the identity of the cokernel of the kernel" );
-
+  end
+] : Description := "IsomorphismFromCoimageToCokernelOfKernel as the identity of the cokernel of the kernel" );
 
 ## Final methods for initial object
 
@@ -3320,7 +3245,9 @@ end : Description := "IsomorphismFromCokernelOfKernelToCoimage as the identity o
 AddFinalDerivation( IsomorphismFromInitialObjectToZeroObject,
                     [ [ ZeroObject, 1 ],
                       [ IdentityMorphism, 1 ] ],
-                    [ InitialObject,
+                    [ IsomorphismFromInitialObjectToZeroObject,
+                      IsomorphismFromZeroObjectToInitialObject,
+                      InitialObject,
                       UniversalMorphismFromInitialObject
                       ## NOTE: the combination of AddZeroObject and AddUniversalMorphismFromInitialObjectWithGivenInitialObject
                       ## is okay because only having UniversalMorphismFromInitialObjectWithGivenInitialObject, you cannot
@@ -3332,25 +3259,15 @@ AddFinalDerivation( IsomorphismFromInitialObjectToZeroObject,
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-end : Description := "IsomorphismFromInitialObjectToZeroObject as the identity of the zero object" );
-
-##
-AddFinalDerivation( IsomorphismFromZeroObjectToInitialObject,
-                    [ [ ZeroObject, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ InitialObject,
-                      UniversalMorphismFromInitialObject
-                      ## NOTE: the combination of AddZeroObject and AddUniversalMorphismFromInitialObjectWithGivenInitialObject
-                      ## is okay because only having UniversalMorphismFromInitialObjectWithGivenInitialObject, you cannot
-                      ## deduce an InitialObject
-#                       UniversalMorphismFromInitialObjectWithGivenInitialObject
-                    ],
-                    
+  end,
+[
+  IsomorphismFromZeroObjectToInitialObject,
   function( cat )
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-end : Description := "IsomorphismFromZeroObjectToInitialObject as the identity of the zero object" );
+  end
+] : Description := "IsomorphismFromInitialObjectToZeroObject as the identity of the zero object" );
 
 ## Final methods for terminal object
 
@@ -3358,7 +3275,9 @@ end : Description := "IsomorphismFromZeroObjectToInitialObject as the identity o
 AddFinalDerivation( IsomorphismFromTerminalObjectToZeroObject,
                     [ [ ZeroObject, 1 ],
                       [ IdentityMorphism, 1 ] ],
-                    [ TerminalObject,
+                    [ IsomorphismFromTerminalObjectToZeroObject,
+                      IsomorphismFromZeroObjectToTerminalObject,
+                      TerminalObject,
                       UniversalMorphismIntoTerminalObject
                       ## NOTE: the combination of AddZeroObject and AddUniversalMorphismIntoTerminalObjectWithGivenTerminalObject
                       ## is okay because only having UniversalMorphismIntoTerminalObjectWithGivenTerminalObject, you cannot
@@ -3370,25 +3289,15 @@ AddFinalDerivation( IsomorphismFromTerminalObjectToZeroObject,
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-end : Description := "IsomorphismFromTerminalObjectToZeroObject as the identity of the zero object" );
-
-##
-AddFinalDerivation( IsomorphismFromZeroObjectToTerminalObject,
-                    [ [ ZeroObject, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ TerminalObject,
-                      UniversalMorphismIntoTerminalObject
-                      ## NOTE: the combination of AddZeroObject and AddUniversalMorphismIntoTerminalObjectWithGivenTerminalObject
-                      ## is okay because only having UniversalMorphismIntoTerminalObjectWithGivenTerminalObject, you cannot
-                      ## deduce a TerminalObject
-#                       UniversalMorphismIntoTerminalObjectWithGivenTerminalObject
-                    ],
-                    
+  end,
+[
+  IsomorphismFromZeroObjectToTerminalObject,
   function( cat )
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-end : Description := "IsomorphismFromZeroObjectToTerminalObject as the identity of the zero object" );
+  end
+] : Description := "IsomorphismFromTerminalObjectToZeroObject as the identity of the zero object" );
 
 ## Final methods for product
 
@@ -3396,7 +3305,9 @@ end : Description := "IsomorphismFromZeroObjectToTerminalObject as the identity 
 AddFinalDerivation( IsomorphismFromDirectSumToDirectProduct,
                     [ [ DirectSum, 1 ],
                       [ IdentityMorphism, 1 ] ],
-                    [ DirectProduct,
+                    [ IsomorphismFromDirectSumToDirectProduct,
+                      IsomorphismFromDirectProductToDirectSum,
+                      DirectProduct,
                       DirectProductFunctorialWithGivenDirectProducts,
                       ProjectionInFactorOfDirectProduct,
 #                       ProjectionInFactorOfDirectProductWithGivenDirectProduct,
@@ -3407,24 +3318,15 @@ AddFinalDerivation( IsomorphismFromDirectSumToDirectProduct,
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-end : Description := "IsomorphismFromDirectSumToDirectProduct as the identity of the direct sum" );
-
-##
-AddFinalDerivation( IsomorphismFromDirectProductToDirectSum,
-                    [ [ DirectSum, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ DirectProduct,
-                      DirectProductFunctorialWithGivenDirectProducts,
-                      ProjectionInFactorOfDirectProduct,
-#                       ProjectionInFactorOfDirectProductWithGivenDirectProduct,
-                      UniversalMorphismIntoDirectProduct ],
-#                       UniversalMorphismIntoDirectProductWithGivenDirectProduct ],
-                      
+  end,
+[
+  IsomorphismFromDirectProductToDirectSum,
   function( cat, diagram )
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-end : Description := "IsomorphismFromDirectProductToDirectSum as the identity of the direct sum" );
+  end
+] : Description := "IsomorphismFromDirectSumToDirectProduct as the identity of the direct sum" );
 
 ## Final methods for coproduct
 
@@ -3432,7 +3334,9 @@ end : Description := "IsomorphismFromDirectProductToDirectSum as the identity of
 AddFinalDerivation( IsomorphismFromCoproductToDirectSum,
                     [ [ DirectSum, 1 ],
                       [ IdentityMorphism, 1 ] ],
-                    [ Coproduct,
+                    [ IsomorphismFromCoproductToDirectSum,
+                      IsomorphismFromDirectSumToCoproduct,
+                      Coproduct,
                       CoproductFunctorialWithGivenCoproducts,
                       InjectionOfCofactorOfCoproduct,
 #                       InjectionOfCofactorOfCoproductWithGivenCoproduct,
@@ -3443,24 +3347,15 @@ AddFinalDerivation( IsomorphismFromCoproductToDirectSum,
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-end : Description := "IsomorphismFromCoproductToDirectSum as the identity of the direct sum" );
-
-##
-AddFinalDerivation( IsomorphismFromDirectSumToCoproduct,
-                    [ [ DirectSum, 1 ],
-                      [ IdentityMorphism, 1 ] ],
-                    [ Coproduct,
-                      CoproductFunctorialWithGivenCoproducts,
-                      InjectionOfCofactorOfCoproduct,
-#                       InjectionOfCofactorOfCoproductWithGivenCoproduct,
-                      UniversalMorphismFromCoproduct ],
-#                       UniversalMorphismFromCoproductWithGivenCoproduct ],
-                      
+  end,
+[
+  IsomorphismFromDirectSumToCoproduct,
   function( cat, diagram )
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-end : Description := "IsomorphismFromDirectSumToCoproduct as the identity of the direct sum" );
+  end
+]: Description := "IsomorphismFromCoproductToDirectSum as the identity of the direct sum" );
 
 ## Final methods for homology object
 
@@ -3469,8 +3364,12 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
                     [ [ ImageObject, 1 ],
                       [ PreCompose, 1 ],
                       [ KernelEmbedding, 1 ],
-                      [ CokernelProjection, 1 ] ],
-                    [ HomologyObject,
+                      [ CokernelProjection, 1 ],
+                      [ IdentityMorphism, 1 ],
+                    ],
+                    [ IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject,
+                      IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject,
+                      HomologyObject,
                       HomologyObjectFunctorialWithGivenHomologyObjects ],
                       
   function( cat, alpha, beta )
@@ -3480,7 +3379,18 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
     
     return IdentityMorphism( cat, homology_object );
     
-end : CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
+  end,
+[
+  IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject,
+  function( cat, alpha, beta )
+    local homology_object;
+    
+    homology_object := ImageObject( cat, PreCompose( cat, KernelEmbedding( cat, beta ), CokernelProjection( cat, alpha ) ) );
+    
+    return IdentityMorphism( cat, homology_object );
+    
+  end
+]: CategoryFilter := HasIsAbelianCategory and IsAbelianCategory,
       Description := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject as the identity of the homology object constructed as an image object" );
 
 

--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2022.08-03",
+Version := "2022.09-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/CartesianCategories/gap/CartesianClosedCategoriesDerivedMethods.gi
+++ b/CartesianCategories/gap/CartesianClosedCategoriesDerivedMethods.gi
@@ -30,26 +30,13 @@ AddFinalDerivation( IsomorphismFromCartesianDualObjectToExponentialIntoTerminalO
     
     return IdentityMorphism( cat, ExponentialOnObjects( cat, object, TerminalObject( cat ) ) );
     
-end : CategoryFilter := IsCartesianClosedCategory,
-      Description := "IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject as the identity of Exp(a,1)" );
-
-AddFinalDerivation( IsomorphismFromExponentialIntoTerminalObjectToCartesianDualObject,
-                    [ [ IdentityMorphism, 1 ],
-                      [ ExponentialOnObjects, 1 ],
-                      [ TerminalObject, 1 ] ],
-                    [ CartesianDualOnObjects,
-                      CartesianDualOnMorphismsWithGivenCartesianDuals,
-                      MorphismToCartesianBidualWithGivenCartesianBidual,
-                      IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject,
-                      IsomorphismFromExponentialIntoTerminalObjectToCartesianDualObject,
-                      UniversalPropertyOfCartesianDual,
-                      DirectProductCartesianDualityCompatibilityMorphismWithGivenObjects,
-                      CartesianEvaluationForCartesianDualWithGivenDirectProduct,
-                      MorphismFromDirectProductToExponentialWithGivenObjects ],
-                 
+  end,
+[
+  IsomorphismFromExponentialIntoTerminalObjectToCartesianDualObject,
   function( cat, object )
     
     return IdentityMorphism( cat, ExponentialOnObjects( cat, object, TerminalObject( cat ) ) );
     
-end : CategoryFilter := IsCartesianClosedCategory,
-      Description := "IsomorphismFromExponentialIntoTerminalObjectToCartesianDualObject as the identity of Exp(a,1)" );
+  end
+] : CategoryFilter := IsCartesianClosedCategory,
+      Description := "IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject and its inverse as the identity of Exp(a,1)" );

--- a/CartesianCategories/gap/CocartesianCoclosedCategoriesDerivedMethods.gi
+++ b/CartesianCategories/gap/CocartesianCoclosedCategoriesDerivedMethods.gi
@@ -30,27 +30,13 @@ AddFinalDerivation( IsomorphismFromCocartesianDualObjectToCoexponentialFromIniti
     
     return IdentityMorphism( cat, CoexponentialOnObjects( cat, InitialObject( cat ), object ) );
     
-end : CategoryFilter := IsCocartesianCoclosedCategory,
-      Description := "IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject as the identity of Coexp(1,a)" );
-
-AddFinalDerivation( IsomorphismFromCoexponentialFromInitialObjectToCocartesianDualObject,
-                    [ [ IdentityMorphism, 1 ],
-                      [ CoexponentialOnObjects, 1 ],
-                      [ InitialObject, 1 ] ],
-                    [ CocartesianDualOnObjects,
-                      CocartesianDualOnMorphismsWithGivenCocartesianDuals,
-                      MorphismFromCocartesianBidualWithGivenCocartesianBidual,
-                      IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject,
-                      IsomorphismFromCoexponentialFromInitialObjectToCocartesianDualObject,
-                      UniversalPropertyOfCocartesianDual,
-                      CocartesianDualityCoproductCompatibilityMorphismWithGivenObjects,
-                      CocartesianEvaluationForCocartesianDualWithGivenCoproduct,
-                      MorphismFromCoexponentialToCoproductWithGivenObjects
-                      ],
-
+  end,
+[
+  IsomorphismFromCoexponentialFromInitialObjectToCocartesianDualObject,
   function( cat, object )
     
     return IdentityMorphism( cat, CoexponentialOnObjects( cat, InitialObject( cat ), object ) );
     
-end : CategoryFilter := IsCocartesianCoclosedCategory,
-      Description := "IsomorphismFromCoexponentialFromInitialObjectToCocartesianDualObject as the identity of Coexp(1,a)" );
+  end
+] : CategoryFilter := IsCocartesianCoclosedCategory,
+      Description := "IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject as the identity of Coexp(1,a)" );

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -308,12 +308,14 @@ AddFinalDerivation( WeakKernelObject,
     return KernelLift( cat, morphism, test_mor );
     
   end
-]
-);
+] : Description := "weak kernel using kernel" );
 
 ##
 AddFinalDerivation( WeakCokernelObject,
-                    [ [ CokernelObject, 1 ] ],
+                    [ [ CokernelObject, 1 ],
+                      [ CokernelProjection, 1 ],
+                      [ CokernelColift, 1 ] ],
+                    
                     [ WeakCokernelObject,
                       WeakCokernelProjection,
                       WeakCokernelColift ],
@@ -322,33 +324,23 @@ AddFinalDerivation( WeakCokernelObject,
     
     return CokernelObject( cat, morphism );
     
-end : Description := "WeakCokernelObject as CokernelObject" );
-
-##
-AddFinalDerivation( WeakCokernelProjection,
-                    [ [ CokernelProjection, 1 ] ],
-                    [ WeakCokernelObject,
-                      WeakCokernelProjection,
-                      WeakCokernelColift ],
-                    
+  end,
+[
+  WeakCokernelProjection,
   function( cat, morphism )
     
     return CokernelProjection( cat, morphism );
     
-end : Description := "WeakCokernelProjection as CokernelProjection" );
-
-##
-AddFinalDerivation( WeakCokernelColift,
-                    [ [ CokernelColift, 1 ] ],
-                    [ WeakCokernelObject,
-                      WeakCokernelProjection,
-                      WeakCokernelColift ],
-                    
+  end
+],
+[
+  WeakCokernelColift,
   function( cat, morphism, test_mor )
     
     return CokernelColift( cat, morphism, test_mor );
     
-end : Description := "WeakCokernelColift as CokernelColift" );
+  end
+] : Description := "weak cokernel using cokernel" );
 
 ## Final derivation for weak fiber products and weak pushouts.
 ## Decision: we use a derivation from weak kernels and direct sums
@@ -356,8 +348,18 @@ end : Description := "WeakCokernelColift as CokernelColift" );
 ##
 AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
                     [ [ DirectSumDiagonalDifference, 1 ],
-                      [ WeakKernelEmbedding, 1 ] ],
-                    [ WeakBiFiberProduct ],
+                      [ WeakKernelEmbedding, 1 ],
+                      [ ProjectionInFactorOfDirectSum, 1 ],
+                      [ PreCompose, 1 ],
+                      [ UniversalMorphismIntoDirectSum, 1 ],
+                      [ WeakKernelLift, 1 ],
+                    ],
+                    [
+                      WeakBiFiberProduct,
+                      ProjectionInFirstFactorOfWeakBiFiberProduct,
+                      ProjectionInSecondFactorOfWeakBiFiberProduct,
+                      UniversalMorphismIntoWeakBiFiberProduct,
+                    ],
                       
   function( cat, alpha, beta )
     local diagonal_difference;
@@ -366,15 +368,9 @@ AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
     
     return WeakKernelEmbedding( cat, diagonal_difference );
     
-end : Description := "WeakBiFiberProductMorphismToDirectSum as WeakKernelEmbedding of DirectSumDiagonalDifference" );
-
-##
-AddFinalDerivation( ProjectionInFirstFactorOfWeakBiFiberProduct,
-                     [ [ WeakBiFiberProductMorphismToDirectSum, 1 ],
-                       [ PreCompose, 1 ],
-                       [ ProjectionInFactorOfDirectSum, 1 ] ],
-                     [ ProjectionInFirstFactorOfWeakBiFiberProduct ],
-                       
+  end,
+[
+  ProjectionInFirstFactorOfWeakBiFiberProduct,
   function( cat, alpha, beta )
     local morphism_to_direct_sum;
     
@@ -382,15 +378,10 @@ AddFinalDerivation( ProjectionInFirstFactorOfWeakBiFiberProduct,
     
     return PreCompose( cat, morphism_to_direct_sum, ProjectionInFactorOfDirectSum( cat, [ Source( alpha ), Source( beta ) ], 1 ) );
     
-end : Description := "ProjectionInFirstFactorOfWeakBiFiberProduct as composition of WeakBiFiberProductMorphismToDirectSum with the first direct sum projection" );
-
-##
-AddFinalDerivation( ProjectionInSecondFactorOfWeakBiFiberProduct,
-                     [ [ WeakBiFiberProductMorphismToDirectSum, 1 ],
-                       [ PreCompose, 1 ],
-                       [ ProjectionInFactorOfDirectSum, 1 ] ],
-                     [ ProjectionInSecondFactorOfWeakBiFiberProduct ],
-                       
+  end
+],
+[
+  ProjectionInSecondFactorOfWeakBiFiberProduct,
   function( cat, alpha, beta )
     local morphism_to_direct_sum;
     
@@ -398,15 +389,10 @@ AddFinalDerivation( ProjectionInSecondFactorOfWeakBiFiberProduct,
     
     return PreCompose( cat, morphism_to_direct_sum, ProjectionInFactorOfDirectSum( cat, [ Source( alpha ), Source( beta ) ], 2 ) );
     
-end : Description := "ProjectionInSecondFactorOfWeakBiFiberProduct as composition of WeakBiFiberProductMorphismToDirectSum with the second direct sum projection" );
-
-##
-AddFinalDerivation( UniversalMorphismIntoWeakBiFiberProduct,
-                    [ [ UniversalMorphismIntoDirectSum, 1 ],
-                      [ DirectSumDiagonalDifference, 1 ],
-                      [ WeakKernelLift, 1 ] ],
-                    [ WeakBiFiberProduct ],
-                    
+  end
+],
+[
+  UniversalMorphismIntoWeakBiFiberProduct,
   function( cat, alpha, beta, test_mor_1, test_mor_2 )
     local test_mor, diagonal_difference;
     
@@ -416,15 +402,25 @@ AddFinalDerivation( UniversalMorphismIntoWeakBiFiberProduct,
     
     return WeakKernelLift( cat, diagonal_difference, test_mor );
     
-end : Description := "UniversalMorphismIntoWeakBiFiberProduct using WeakKernelLift" );
-
+  end
+] : Description := "WeakBiFiberProductMorphismToDirectSum as WeakKernelEmbedding of DirectSumDiagonalDifference" );
 
 ## weak bi-pushout
 ##
 AddFinalDerivation( DirectSumMorphismToWeakBiPushout,
                     [ [ DirectSumCodiagonalDifference, 1 ],
-                      [ WeakCokernelProjection, 1 ] ],
-                    [ WeakBiPushout ],
+                      [ WeakCokernelProjection, 1 ],
+                      [ InjectionOfCofactorOfDirectSum, 1 ],
+                      [ PreCompose, 1 ],
+                      [ UniversalMorphismFromDirectSum, 1 ],
+                      [ WeakCokernelColift, 1 ],
+                    ],
+                    [
+                      WeakBiPushout,
+                      InjectionOfFirstCofactorOfWeakBiPushout,
+                      InjectionOfSecondCofactorOfWeakBiPushout,
+                      UniversalMorphismFromWeakBiPushout,
+                    ],
                       
   function( cat, alpha, beta )
     local co_diagonal_difference;
@@ -433,15 +429,9 @@ AddFinalDerivation( DirectSumMorphismToWeakBiPushout,
     
     return WeakCokernelProjection( cat, co_diagonal_difference );
     
-end : Description := "DirectSumMorphismToWeakBiPushout as WeakCokernelProjection of DirectSumCodiagonalDifference" );
-
-## InjectionOfSecondCofactorOfWeakBiPushout
-AddFinalDerivation( InjectionOfFirstCofactorOfWeakBiPushout,
-                     [ [ DirectSumMorphismToWeakBiPushout, 1 ],
-                       [ PreCompose, 1 ],
-                       [ InjectionOfCofactorOfDirectSum, 1 ] ],
-                     [ InjectionOfFirstCofactorOfWeakBiPushout ],
-                       
+end,
+[
+  InjectionOfFirstCofactorOfWeakBiPushout,
   function( cat, alpha, beta )
     local direct_sum_morphism;
     
@@ -449,15 +439,10 @@ AddFinalDerivation( InjectionOfFirstCofactorOfWeakBiPushout,
     
     return PreCompose( cat, InjectionOfCofactorOfDirectSum( cat, [ Range( alpha ), Range( beta ) ], 1 ), direct_sum_morphism );
     
-end : Description := "InjectionOfFirstCofactorOfWeakBiPushout as composition of first direct sum injection with DirectSumMorphismToWeakBiPushout" );
-
-##
-AddFinalDerivation( InjectionOfSecondCofactorOfWeakBiPushout,
-                     [ [ DirectSumMorphismToWeakBiPushout, 1 ],
-                       [ PreCompose, 1 ],
-                       [ InjectionOfCofactorOfDirectSum, 1 ] ],
-                     [ InjectionOfSecondCofactorOfWeakBiPushout ],
-                       
+  end
+],
+[
+  InjectionOfSecondCofactorOfWeakBiPushout,
   function( cat, alpha, beta )
     local direct_sum_morphism;
     
@@ -465,15 +450,10 @@ AddFinalDerivation( InjectionOfSecondCofactorOfWeakBiPushout,
     
     return PreCompose( cat, InjectionOfCofactorOfDirectSum( cat, [ Range( alpha ), Range( beta ) ], 2 ), direct_sum_morphism );
     
-end : Description := "InjectionOfSecondCofactorOfWeakBiPushout as composition of second direct sum injection with DirectSumMorphismToWeakBiPushout" );
-
-##
-AddFinalDerivation( UniversalMorphismFromWeakBiPushout,
-                    [ [ UniversalMorphismFromDirectSum, 1 ],
-                      [ DirectSumCodiagonalDifference, 1 ],
-                      [ WeakCokernelColift, 1 ] ],
-                    [ WeakBiPushout ],
-                    
+  end
+],
+[
+  UniversalMorphismFromWeakBiPushout,
   function( cat, alpha, beta, test_mor_1, test_mor_2 )
     local test_mor, co_diagonal_difference;
     
@@ -483,8 +463,8 @@ AddFinalDerivation( UniversalMorphismFromWeakBiPushout,
     
     return WeakCokernelColift( cat, co_diagonal_difference, test_mor );
     
-end : Description := "UniversalMorphismFromWeakBiPushout using WeakCokernelColift" );
-
+  end
+] : Description := "DirectSumMorphismToWeakBiPushout as WeakCokernelProjection of DirectSumCodiagonalDifference" );
 
 ## Final derivation for biased weak fiber products and biased weak pushouts.
 ## Decision: we use a derivation from weak fiber products and weak pushouts

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -1617,12 +1617,10 @@ end
         
 ########
 function ( cat_1, H_1_1, L_1, H_2_1 )
-    local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := SyzygiesOfColumns( UnderlyingMatrix( L_1[4] ) );
-    deduped_4_1 := SyzygiesOfColumns( UnderlyingMatrix( L_1[1] ) );
-    deduped_3_1 := SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( L_1[5] ) ) * deduped_5_1 );
-    deduped_2_1 := HomalgIdentityMatrix( NumberColumns( deduped_5_1 ) - RowRankOfMatrix( deduped_3_1 ), UnderlyingRing( cat_1 ) );
-    morphism_attr_1_1 := RightDivide( SyzygiesOfRows( SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( L_1[2] ) ) * deduped_4_1 ) ) * LeftDivide( deduped_4_1, (UnderlyingMatrix( L_1[3] ) * deduped_5_1) ), SyzygiesOfRows( deduped_3_1 ) ) * RightDivide( deduped_2_1, deduped_2_1 );
+    local morphism_attr_1_1, deduped_2_1, deduped_3_1;
+    deduped_3_1 := SyzygiesOfColumns( UnderlyingMatrix( L_1[4] ) );
+    deduped_2_1 := SyzygiesOfColumns( UnderlyingMatrix( L_1[1] ) );
+    morphism_attr_1_1 := RightDivide( SyzygiesOfRows( SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( L_1[2] ) ) * deduped_2_1 ) ) * LeftDivide( deduped_2_1, (UnderlyingMatrix( L_1[3] ) * deduped_3_1) ), SyzygiesOfRows( SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( L_1[5] ) ) * deduped_3_1 ) ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -1630,7 +1628,7 @@ function ( cat_1, H_1_1, L_1, H_2_1 )
 end
 ########
         
-    , 4421 : IsPrecompiledDerivation := true );
+    , 4218 : IsPrecompiledDerivation := true );
     
     ##
     AddHomomorphismStructureOnMorphisms( cat,
@@ -3179,10 +3177,9 @@ end
         
 ########
 function ( cat_1, alpha_1, beta_1 )
-    local morphism_attr_1_1, deduped_2_1, deduped_3_1;
-    deduped_3_1 := SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) );
-    deduped_2_1 := HomalgIdentityMatrix( NumberColumns( deduped_3_1 ) - RowRankOfMatrix( SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( beta_1 ) ) * deduped_3_1 ) ), UnderlyingRing( cat_1 ) );
-    morphism_attr_1_1 := RightDivide( deduped_2_1, deduped_2_1 );
+    local morphism_attr_1_1, deduped_2_1;
+    deduped_2_1 := SyzygiesOfColumns( UnderlyingMatrix( alpha_1 ) );
+    morphism_attr_1_1 := HomalgIdentityMatrix( NumberColumns( deduped_2_1 ) - RowRankOfMatrix( SyzygiesOfColumns( SyzygiesOfRows( UnderlyingMatrix( beta_1 ) ) * deduped_2_1 ) ), UnderlyingRing( cat_1 ) );
     return ObjectifyMorphismWithSourceAndRangeForCAPWithAttributes( rec(
            ), cat_1, ObjectifyObjectForCAPWithAttributes( rec(
              ), cat_1, Dimension, NumberRows( morphism_attr_1_1 ) ), ObjectifyObjectForCAPWithAttributes( rec(
@@ -3190,7 +3187,7 @@ function ( cat_1, alpha_1, beta_1 )
 end
 ########
         
-    , 906 : IsPrecompiledDerivation := true );
+    , 703 : IsPrecompiledDerivation := true );
     
     ##
     AddIsomorphismFromKernelOfCokernelToImageObject( cat,

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.08-04",
+Version := "2022.09-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
@@ -27,26 +27,13 @@ AddFinalDerivation( IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
     
     return IdentityMorphism( cat, InternalHomOnObjects( cat, object, TensorUnit( cat ) ) );
     
-end : CategoryFilter := IsClosedMonoidalCategory,
-      Description := "IsomorphismFromDualObjectToInternalHomIntoTensorUnit as the identity of Hom(a,1)" );
-
-AddFinalDerivation( IsomorphismFromInternalHomIntoTensorUnitToDualObject,
-                    [ [ IdentityMorphism, 1 ],
-                      [ InternalHomOnObjects, 1 ],
-                      [ TensorUnit, 1 ] ],
-                    [ DualOnObjects,
-                      DualOnMorphismsWithGivenDuals,
-                      MorphismToBidualWithGivenBidual,
-                      IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
-                      IsomorphismFromInternalHomIntoTensorUnitToDualObject,
-                      UniversalPropertyOfDual,
-                      TensorProductDualityCompatibilityMorphismWithGivenObjects,
-                      EvaluationForDualWithGivenTensorProduct,
-                      MorphismFromTensorProductToInternalHomWithGivenObjects ],
-                 
+  end,
+[
+  IsomorphismFromInternalHomIntoTensorUnitToDualObject,
   function( cat, object )
     
     return IdentityMorphism( cat, InternalHomOnObjects( cat, object, TensorUnit( cat ) ) );
     
-end : CategoryFilter := IsClosedMonoidalCategory,
-      Description := "IsomorphismFromInternalHomIntoTensorUnitToDualObject as the identity of Hom(a,1)" );
+  end
+] : CategoryFilter := IsClosedMonoidalCategory,
+      Description := "IsomorphismFromDualObjectToInternalHomIntoTensorUnit and its inverse as the identity of Hom(a,1)" );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
@@ -27,27 +27,13 @@ AddFinalDerivation( IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
     
     return IdentityMorphism( cat, InternalCoHomOnObjects( cat, TensorUnit( cat ), object ) );
     
-end : CategoryFilter := IsCoclosedMonoidalCategory,
-      Description := "IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit as the identity of coHom(1,a)" );
-
-AddFinalDerivation( IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject,
-                    [ [ IdentityMorphism, 1 ],
-                      [ InternalCoHomOnObjects, 1 ],
-                      [ TensorUnit, 1 ] ],
-                    [ CoDualOnObjects,
-                      CoDualOnMorphismsWithGivenCoDuals,
-                      MorphismFromCoBidualWithGivenCoBidual,
-                      IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
-                      IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject,
-                      UniversalPropertyOfCoDual,
-                      CoDualityTensorProductCompatibilityMorphismWithGivenObjects,
-                      CoclosedEvaluationForCoDualWithGivenTensorProduct,
-                      MorphismFromInternalCoHomToTensorProductWithGivenObjects
-                      ],
-
+  end,
+[
+  IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject,
   function( cat, object )
     
     return IdentityMorphism( cat, InternalCoHomOnObjects( cat, TensorUnit( cat ), object ) );
     
-end : CategoryFilter := IsCoclosedMonoidalCategory,
-      Description := "IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject as the identity of coHom(1,a)" );
+  end
+] : CategoryFilter := IsCoclosedMonoidalCategory,
+      Description := "IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit as the identity of coHom(1,a)" );


### PR DESCRIPTION
Otherwise two competing final derivations might both be installed. Probably
this has previously been a feature, but thanks to bundled derivations there
is no need for this anymore.
