### PR TITLE
Remove saturation of derivations

### DIFF
--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
-Version := "2022.08-02",
+Version := "2022.09-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ActionsForCAP/examples/IndirectionTest.g
+++ b/ActionsForCAP/examples/IndirectionTest.g
@@ -91,6 +91,7 @@ category_with_attributes_record := rec(
 triple := EnhancementWithAttributes( category_with_attributes_record );;
 indirection_category := triple[1];;
 SetIsAbelianCategory( indirection_category, true );;
+Reevaluate( indirection_category!.derivations_weight_list );
 AddIsEqualForCacheForObjects( indirection_category, IsIdenticalObj );;
 AddIsEqualForObjects( indirection_category, function( obj1, obj2 ) return UnderlyingCell( obj1 ) = UnderlyingCell( obj2 ); end );;
 AddIsEqualForCacheForMorphisms( indirection_category, IsIdenticalObj );;

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.09-07",
+Version := "2022.09-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryConstructor.gd
+++ b/CAP/gap/CategoryConstructor.gd
@@ -36,6 +36,7 @@ DeclareInfoClass( "InfoCategoryConstructor" );
 #!  * `morphism_constructor` (optional): function added as an installation of <Ref Oper="MorphismConstructor" Label="for IsCapCategoryObject, IsObject, IsCapCategoryObject" /> to the category
 #!  * `morphism_datum` (optional): function added as an installation of <Ref Oper="MorphismDatum" Label="for IsCapCategoryMorphism" /> to the category
 #!  * `list_of_operations_to_install` (mandatory): a list of names of &CAP; operations which should be installed for the category
+#!  * `supports_empty_limits` (optional): whether the category supports empty lists in inputs to operations of limits and colimits
 #!  * `underlying_category_getter_string` (optional): see below
 #!  * `underlying_object_getter_string` (optional): see below
 #!  * `underlying_morphism_getter_string` (optional): see below

--- a/CAP/gap/CategoryConstructor.gi
+++ b/CAP/gap/CategoryConstructor.gi
@@ -24,6 +24,7 @@ InstallMethod( CategoryConstructor,
         morphism_constructor := IsFunction,
         morphism_datum := IsFunction,
         list_of_operations_to_install := IsList,
+        supports_empty_limits := IsBool,
         underlying_category_getter_string := IsString,
         underlying_object_getter_string := IsString,
         underlying_morphism_getter_string := IsString,
@@ -72,6 +73,12 @@ InstallMethod( CategoryConstructor,
     fi;
     
     CC!.category_as_first_argument := true;
+    
+    if IsBound( options.supports_empty_limits ) then
+        
+        CC!.supports_empty_limits := options.supports_empty_limits;
+        
+    fi;
     
     CC!.compiler_hints := rec( );
     

--- a/CAP/gap/Derivations.gd
+++ b/CAP/gap/Derivations.gd
@@ -64,10 +64,12 @@ DeclareCategory( "IsDerivedMethod", IsObject );
 #!  filters.  If only one function is given, then <C>filters</C>
 #!  should be the empty list; in this case the argument's value
 #!  would be [[fun,[]]], where <C>fun</C> is the function.
-#!  The argument <A>category_filter</A> is a filter describing
+#!  The argument <A>category_filter</A> is a filter (or function) describing
 #!  which categories the derivation is valid for.  If it is valid
 #!  for all categories, then this argument should have the value
-#!  <C>IsCapCategory</C>.
+#!  <C>IsCapCategory</C>. The output of <A>category_filter</A> must not
+#!  change during the installation of operations. In particular, it must
+#!  not rely on `CanCompute` to check conditions.
 #! @Arguments name, target_op, used_ops_with_multiples, weight, implementations_with_extra_filters, category_filter
 DeclareOperation( "MakeDerivation",
                   [ IsString, IsFunction, IsDenseList,

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -38,6 +38,12 @@ InstallMethod( MakeDerivation,
                
 function( name, target_op, used_op_names_with_multiples_and_category_getters, weight, implementations_with_extra_filters, category_filter )
     
+    if PositionSublist( String( category_filter ), "CanCompute" ) <> fail then
+        
+        Print( "WARNING: The CategoryFilter of a derivation for ", NameFunction( target_op ), " uses `CanCompute`. Please register all preconditions explicitly.\n" );
+        
+    fi;
+    
     return ObjectifyWithAttributes(
         rec( ), NewType( TheFamilyOfDerivations, IsDerivedMethodRep ),
         DerivationName, name,

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -147,6 +147,10 @@ function( operations )
     G!.derivations_by_target.( op_name ) := [];
     G!.derivations_by_used_ops.( op_name ) := [];
   od;
+  
+  # derivations not using any operations
+  G!.derivations_by_used_ops.none := [];
+  
   return G;
 end );
 
@@ -230,6 +234,12 @@ function( G, d )
     # returns the category itself, this allows to recursively trigger derivations correctly.
     Add( G!.derivations_by_used_ops.( x[1] ), d );
   od;
+  
+  if IsEmpty( UsedOperationsWithMultiplesAndCategoryGetters( d ) ) then
+    
+    Add( G!.derivations_by_used_ops.none, d );
+    
+  fi;
   
 end );
 
@@ -599,13 +609,19 @@ end );
 InstallMethod( Reevaluate,
                [ IsOperationWeightList ],
 function( owl )
-    local op_name, d;
+  local new_weight, op_name, d;
     
     for op_name in Operations( DerivationGraph( owl ) ) do
         
         for d in DerivationsOfOperation( DerivationGraph( owl ), op_name ) do
             
-            TryToInstallDerivation( owl, d );
+            new_weight := TryToInstallDerivation( owl, d );
+            
+            if new_weight <> fail then
+                
+                InstallDerivationsUsingOperation( owl, TargetOperation( d ) );
+                
+            fi;
             
         od;
         

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1729,7 +1729,7 @@ AddDerivationToCAP( MorphismBetweenDirectSumsWithGivenDirectSums,
     return UniversalMorphismFromDirectSumWithGivenDirectSum( cat, diagram_S, T, test_diagram_coproduct, S );
     
 end : CategoryFilter := cat -> not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ),
-      Description := "MorphismBetweenDirectSumsWithGivenDirectSums using universal morphisms of direct sums" );
+      Description := "MorphismBetweenDirectSumsWithGivenDirectSums using universal morphisms of direct sums (without support for empty limits)" );
 
 ##
 AddDerivationToCAP( MorphismBetweenDirectSumsWithGivenDirectSums,
@@ -1744,7 +1744,7 @@ AddDerivationToCAP( MorphismBetweenDirectSumsWithGivenDirectSums,
     return UniversalMorphismFromDirectSumWithGivenDirectSum( cat, diagram_S, T, test_diagram_coproduct, S );
     
 end : CategoryFilter := cat -> IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true,
-      Description := "MorphismBetweenDirectSumsWithGivenDirectSums using universal morphisms of direct sums" );
+      Description := "MorphismBetweenDirectSumsWithGivenDirectSums using universal morphisms of direct sums (with support for empty limits)" );
 
 ##
 AddDerivationToCAP( HomologyObjectFunctorialWithGivenHomologyObjects,
@@ -1845,7 +1845,7 @@ AddDerivationToCAP( DirectSumDiagonalDifference,
     return SubtractionForMorphisms( cat, mor1, mor2 );
     
 end : CategoryFilter := cat -> not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ),
-      Description := "DirectSumDiagonalDifference using the operations defining this morphism" );
+      Description := "DirectSumDiagonalDifference using the operations defining this morphism (without support for empty limits)" );
 
 ##
 AddDerivationToCAP( DirectSumDiagonalDifference,
@@ -1876,7 +1876,7 @@ AddDerivationToCAP( DirectSumDiagonalDifference,
     return SubtractionForMorphisms( cat, mor1, mor2 );
     
 end : CategoryFilter := cat -> IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true,
-      Description := "DirectSumDiagonalDifference using the operations defining this morphism" );
+      Description := "DirectSumDiagonalDifference using the operations defining this morphism (with support for empty limits)" );
 
 ##
 AddDerivationToCAP( DirectSumCodiagonalDifference,
@@ -1914,7 +1914,7 @@ AddDerivationToCAP( DirectSumCodiagonalDifference,
     return SubtractionForMorphisms( cat, mor1, mor2 );
     
 end : CategoryFilter := cat -> not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ),
-      Description := "DirectSumCodiagonalDifference using the operations defining this morphism" );
+      Description := "DirectSumCodiagonalDifference using the operations defining this morphism (without support for empty limits)" );
 
 ##
 AddDerivationToCAP( DirectSumCodiagonalDifference,
@@ -1945,7 +1945,7 @@ AddDerivationToCAP( DirectSumCodiagonalDifference,
     return SubtractionForMorphisms( cat, mor1, mor2 );
     
 end : CategoryFilter := cat -> IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true,
-      Description := "DirectSumCodiagonalDifference using the operations defining this morphism" );
+      Description := "DirectSumCodiagonalDifference using the operations defining this morphism (with support for empty limits)" );
 
 
 ##

--- a/CAP/gap/DummyCategory.gi
+++ b/CAP/gap/DummyCategory.gi
@@ -16,6 +16,7 @@ InstallMethod( DummyCategory,
     category_constructor_options.category_filter := IsDummyCategory;
     category_constructor_options.category_object_filter := IsDummyCategoryObject;
     category_constructor_options.category_morphism_filter := IsDummyCategoryMorphism;
+    category_constructor_options.supports_empty_limits := true;
     
     dummy_function := { operation_name, dummy } -> """
         function( input_arguments )
@@ -32,8 +33,6 @@ InstallMethod( DummyCategory,
     category_constructor_options.create_func_morphism_or_fail := dummy_function;
     
     C := CategoryConstructor( category_constructor_options );
-    
-    C!.supports_empty_limits := true;
     
     Finalize( C );
     

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -212,7 +212,7 @@ InstallMethod( Finalize,
                [ IsCapCategory ],
   
   function( category )
-    local derivation_list, weight_list, current_install, current_final_derivation, filter, category_operation_weights, weight, operation_weights, operation_name, operation_weight, add_name, properties_with_logic, property, i, x, current_additional_func, property_name;
+    local derivation_list, weight_list, current_install, current_final_derivation, filter, category_operation_weights, weight, operation_weights, operation_name, operation_weight, add_name, old_weights, categorical_properties, diff, properties_with_logic, property, i, x, current_additional_func, property_name;
     
     if IsFinalized( category ) then
         
@@ -223,6 +223,15 @@ InstallMethod( Finalize,
     if ValueOption( "FinalizeCategory" ) = false then
         
         return false;
+        
+    fi;
+    
+    # prepare for the checks below (usually this is done when the first add function is called, but we support the case that no add function is called at all)
+    if not IsBound( category!.initially_known_categorical_properties ) then
+        
+        category!.initially_known_categorical_properties := ShallowCopy( ListKnownCategoricalProperties( category ) );
+        
+        InstallDerivationsUsingOperation( category!.derivations_weight_list, "none" );
         
     fi;
     
@@ -237,18 +246,6 @@ InstallMethod( Finalize,
     weight_list := category!.derivations_weight_list;
     
     while true do
-        
-        # Why is this saturation needed?
-        # Answer: https://github.com/homalg-project/CAP_project/issues/318
-        # Derivations are installed recursively by `InstallDerivationsUsingOperation`.
-        # If all dependencies of a derivation would be registered using the second argument of
-        # `AddDerivationToCAP` (or using the automated detection), this would suffice to consider
-        # all derivations which could ever be installed.
-        # However, derivations might have implicit dependencies in their CategoryFilter.
-        # This is used when checking for operations in other categories, e.g. the range category of the homomorphism structure.
-        # If the category and the other category coincide, it might thus happen that
-        # despite the recursive handling in `InstallDerivationsUsingOperation`, the derivations are not satured.
-        Saturate( weight_list );
         
         current_install := fail;
         
@@ -462,6 +459,48 @@ InstallMethod( Finalize,
         fi;
         
     od;
+    
+    if category!.overhead then
+        
+        # Check if reevaluation triggers new derivations. Derivations are installed recursively by `InstallDerivationsUsingOperation`, so this should never happen.
+        # See the WARNING below for possible causes why it still might happen.
+        old_weights := StructuralCopy( weight_list!.operation_weights );
+        
+        Info( DerivationInfo, 1, "Starting reevaluation of derivation weight list of the category name \"", Name( category ), "\"\n" );
+        
+        Reevaluate( weight_list );
+        
+        Info( DerivationInfo, 1, "Finished reevaluation of derivation weight list of the category name \"", Name( category ), "\"\n" );
+        
+        categorical_properties := ListKnownCategoricalProperties( category );
+        
+        if not IsSubset( categorical_properties, category!.initially_known_categorical_properties ) then
+            
+            Print( "WARNING: The category named \"", Name( category ), "\" has lost the following categorical properties since installation of the first function:\n" );
+            Display( Difference( category!.initially_known_categorical_properties, categorical_properties ) );
+            
+        fi;
+        
+        if weight_list!.operation_weights <> old_weights then
+            
+            Print( "WARNING: The installed derivations of the category named \"", Name( category ), "\" have changed by reevaluation, which is not expected at this point.\n" );
+            Print( "This might be due to one of the following reasons:\n" );
+            
+            diff := Difference( categorical_properties, category!.initially_known_categorical_properties );
+            
+            if not IsEmpty( diff ) then
+                
+                Print( "* The category has gained the following new categorical properties since adding the first function: ", diff, ". Properties should always be set before adding functions for operations which might trigger derivations involving the properties.\n" );
+                
+            fi;
+            
+            Print( "* The category has gained a new setting like `supports_empty_limits` since adding the first function. Such settings should always be set before adding functions.\n" );
+            Print( "* The category filter of some derivation does not fulfill the specification.\n" );
+            Print( "For debugging, call `ActivateDerivationInfo( )`, retry, and look at the derivations between \"Starting reevaluation of ...\" and \"Finished reevaluation of ...\".\n" );
+            
+        fi;
+        
+    fi;
     
     SetIsFinalized( category, true );
     

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -176,6 +176,15 @@ InstallGlobalFunction( CapInternalInstallAdd,
             Error( "you must pass at least one function to the add method" );
         fi;
         
+        # prepare for the checks in Finalize
+        if not IsBound( category!.initially_known_categorical_properties ) then
+            
+            category!.initially_known_categorical_properties := ShallowCopy( ListKnownCategoricalProperties( category ) );
+            
+            InstallDerivationsUsingOperation( category!.derivations_weight_list, "none" );
+            
+        fi;
+        
         if weight = -1 then
             weight := 100;
         fi;

--- a/CAP/gap/WrapperCategory.gi
+++ b/CAP/gap/WrapperCategory.gi
@@ -285,13 +285,13 @@ InstallMethod( WrapperCategory,
     
     category_constructor_options.list_of_operations_to_install := list_of_operations_to_install;
     
-    D := CategoryConstructor( category_constructor_options );
-    
     if IsBound( C!.supports_empty_limits ) then
         
-        D!.supports_empty_limits := C!.supports_empty_limits;
+        category_constructor_options.supports_empty_limits := C!.supports_empty_limits;
         
     fi;
+    
+    D := CategoryConstructor( category_constructor_options );
     
     D!.compiler_hints.category_attribute_names := [
         "ModelingCategory",


### PR DESCRIPTION
Background: After my recent changes, in principle we do not have to saturate/reevaluate derivations (two relatively expensive operations, responsible for >10% of the creation time of a category) in `Finalize` anymore. However, this requires that all categorical properties and settings like `supports_empty_limits` have to be set before calling any add function (or more precise: before calling an add function for a operation which might trigger derivations depending on those categorical properties). This PR by default still reevaluates and displays a warning if the conditions above are not fulfilled, but does not reevaluate anymore if `overhead` is set to false (i.e. `overhead` not only avoids run time overhead but also creation time overhead).

@ all Is this speedup something we would like to have? If yes, probably some category constructors will have to be adapted to fulfill the above conditions (or as a workaround to trigger a manual reevaluation before finalizing).