### PR TITLE
Remove wrong properties from TerminalCategoryWithMultipleObjects

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.09-04",
+Version := "2022.09-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/TerminalCategory.gi
+++ b/MonoidalCategories/gap/TerminalCategory.gi
@@ -263,7 +263,7 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
     local name, category_filter, category_object_filter, category_morphism_filter,
           create_func_object, create_func_morphism,
           object_constructor, object_datum, morphism_constructor, morphism_datum,
-          properties, excluded_properties, T;
+          properties, excluded_properties, excluded_skeletal_properties, excluded_strict_properties, T;
     
     name := "TerminalCategoryWithMultipleObjects( )";
     
@@ -326,8 +326,11 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
     
     ## prevent skeletality and strictness
     properties := Set( List( CAP_INTERNAL_CATEGORICAL_PROPERTIES_LIST, a -> a[1] ) );
-    excluded_properties := Filtered( properties, p -> IsInt( PositionSublist( p, "Strict" ) ) );
-    Add( excluded_properties, "IsSkeletalCategory" );
+    excluded_strict_properties := Filtered( properties, p -> IsInt( PositionSublist( p, "Strict" ) ) );
+    excluded_skeletal_properties := Filtered( properties, p -> "IsSkeletalCategory" in ListImpliedFilters( FilterByName( p ) ) );
+    Add( excluded_skeletal_properties, "IsSkeletalCategory" );
+    
+    excluded_properties := Concatenation( excluded_strict_properties, excluded_skeletal_properties );
     
     T := CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY( rec(
                  name := name,


### PR DESCRIPTION
Since Locales v2022.09-06, the tests in `CategoryConstructor` and `LazyCategories` fail. This is because the newly added properties in `Locales` imply, that the terminal category with multiple objects is skeletal and strict, which triggers wrong derivations.

This is only temporary until #1009 is ready.

Note, that the operations coming from this line:
 https://github.com/TKuh/CAP_project/blob/14559af33be47076edc0d52ceb286319bb9c2394/MonoidalCategories/gap/TerminalCategory.gi#L46 
should also not be installed for the terminal category with multiple objects. But I thought it might turn out to be unnecessary to rework it now, because of this discussion: https://github.com/homalg-project/CAP_project/pull/1009#discussion_r970700630.