### PR TITLE
Use available type information to set data type of resolved global variables

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.09-13",
+Version := "2022.09-14",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/WrapperCategory.gd
+++ b/CAP/gap/WrapperCategory.gd
@@ -93,6 +93,16 @@ DeclareCategory( "IsWrapperCapCategoryMorphism",
 DeclareAttribute( "ModelingCategory",
         WasCreatedAsWrapperCapCategory );
 
+##
+CapJitAddTypeSignature( "ModelingCategory",
+        [ WasCreatedAsWrapperCapCategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( ModelingCategory( input_types[1].category ) );
+    
+end );
+
+
 DeclareAttribute( "UnderlyingCategory",
         IsWrapperCapCategory );
 

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.09-05",
+Version := "2022.09-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
+++ b/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
@@ -9,6 +9,8 @@ LoadPackage( "CompilerForCAP", false );
 
 # check that CapJitResolvedGlobalVariables is idempotent
 
+CapJitDisableDataTypeInference( );
+
 MY_GLOBAL_FUNCTION_1 := function ( x )
     #% CAP_JIT_RESOLVE_FUNCTION
     return x; end;;
@@ -62,5 +64,7 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 
 tree = tree2;
 #! true
+
+CapJitEnableDataTypeInference( );
 
 #! @EndExample

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -657,20 +657,42 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
             
         elif tree.type = "EXPR_REF_GVAR" then
             
-            data_type := CAP_JIT_INTERNAL_GET_DATA_TYPE_OF_VALUE( ValueGlobal( tree.gvar ) );
-            
-            if data_type = fail or data_type = "list_with_unknown_element_type" then
+            if IsBound( tree.data_type ) then
                 
-                # "fail" explicitly has no type yet
-                if ValueGlobal( tree.gvar ) <> fail then
+                data_type := CAP_JIT_INTERNAL_GET_DATA_TYPE_OF_VALUE( ValueGlobal( tree.gvar ) );
+                
+                if data_type <> fail then
                     
-                    DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "could not get type of gvar ", tree.gvar ) );
+                    if (data_type.filter = IsFunction and tree.data_type.filter <> IsFunction) or (data_type.filter <> IsFunction and data_type <> tree.data_type) then
+                        
+                        DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "the data type ", String( tree.data_type ), " of gvar ", tree.gvar, " differs from the automatically detected data type ", String( data_type ) ) );
+                        
+                    fi;
+                    
+                    data_type := tree.data_type;
                     
                 fi;
                 
-                # there might already be a data type set, but we want to avoid partial typings -> unbind
-                Unbind( tree.data_type );
-                return tree;
+                data_type := tree.data_type;
+                
+            else
+                
+                data_type := CAP_JIT_INTERNAL_GET_DATA_TYPE_OF_VALUE( ValueGlobal( tree.gvar ) );
+                
+                if data_type = fail or data_type = "list_with_unknown_element_type" then
+                    
+                    # "fail" explicitly has no type yet
+                    if ValueGlobal( tree.gvar ) <> fail then
+                        
+                        DisplayWithCurrentlyCompiledFunctionLocation( Concatenation( "could not get type of gvar ", tree.gvar ) );
+                        
+                    fi;
+                    
+                    # there might already be a data type set, but we want to avoid partial typings -> unbind
+                    Unbind( tree.data_type );
+                    return tree;
+                    
+                fi;
                 
             fi;
             
@@ -856,7 +878,13 @@ CapJitAddTypeSignature( "CreateCapCategoryMorphismWithAttributes", [ IsCapCatego
     
 end );
 
-# object and morphism attributes
+# category, object and morphism attributes
+CapJitAddTypeSignature( "RangeCategoryOfHomomorphismStructure", [ IsCapCategory ], function ( input_types )
+    
+    return CapJitDataTypeOfCategory( RangeCategoryOfHomomorphismStructure( input_types[1].category ) );
+    
+end );
+
 CapJitAddTypeSignature( "CapCategory", [ IsCapCategoryCell ], function ( input_types )
     
     return CapJitDataTypeOfCategory( input_types[1].category );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -19,7 +19,7 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
     
     # we have to use result_func instead of pre_func to correctly resolve `Attribute( UnderlyingCategory( cat ) )`
     result_func := function ( tree, result, keys, additional_arguments )
-      local key, value, resolved_tree, name, attr, cat, global_variable_name;
+      local value, global_variable_name, data_type, resolved_tree, name, key;
         
         tree := ShallowCopy( tree );
         
@@ -38,10 +38,26 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
                 
                 global_variable_name := CapJitGetOrCreateGlobalVariable( value );
                 
+                if CAP_JIT_DATA_TYPE_INFERENCE_ENABLED then
+                    
+                    data_type := CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_INPUT_TYPES( NameFunction( ValueGlobal( tree.funcref.gvar ) ), [ CapJitDataTypeOfCategory( ValueGlobal( tree.args.1.gvar ) ) ] );
+                    
+                else
+                    
+                    data_type := fail;
+                    
+                fi;
+                
                 tree := rec(
                     type := "EXPR_REF_GVAR",
                     gvar := global_variable_name,
                 );
+                
+                if data_type <> fail then
+                    
+                    tree.data_type := data_type;
+                    
+                fi;
                 
             fi;
             

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.09-03",
+Version := "2022.09-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -138,6 +138,12 @@ DeclareAttribute( "ExtendNaturalTransformationToAdditiveClosureOfSource",
 DeclareAttribute( "UnderlyingCategory",
                   IsAdditiveClosureCategory );
 
+CapJitAddTypeSignature( "UnderlyingCategory", [ IsAdditiveClosureCategory ], function ( input_types )
+    
+    return CapJitDataTypeOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );
+
 #! @Description
 #! The argument is a formal direct sum $A:=A_1\oplus\dots\oplus A_m$ in some additive closure category $C^\oplus$.
 #! The output is the list $[A_1,\dots,A_m]$.

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gd
@@ -61,6 +61,7 @@ KeyDependentOperation( "StandardRowMorphism",
 
 DeclareAttribute( "UnderlyingRing",
                   IsCategoryOfRows );
+CapJitAddTypeSignature( "UnderlyingRing", [ IsCategoryOfRows ], IsHomalgRing );
 
 DeclareAttribute( "GeneratingSystemOfRingAsModuleInRangeCategoryOfHomomorphismStructure",
                   IsCategoryOfRows );

--- a/FreydCategoriesForCAP/gap/FreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gd
@@ -63,6 +63,12 @@ DeclareOperation( "\/",
 DeclareAttribute( "UnderlyingCategory",
                   IsFreydCategory );
 
+CapJitAddTypeSignature( "UnderlyingCategory", [ IsFreydCategory ], function ( input_types )
+    
+    return CapJitDataTypeOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );
+
 DeclareAttribute( "RelationMorphism",
                   IsFreydCategoryObject );
 

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
@@ -35,6 +35,12 @@ DeclareAttribute( "RingAsCategory",
 DeclareAttribute( "RingAsCategoryUniqueObject",
                   IsRingAsCategory );
 
+CapJitAddTypeSignature( "RingAsCategoryUniqueObject", [ IsRingAsCategory ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 DeclareOperation( "RingAsCategoryMorphism",
                   [ IsRingElement, IsRingAsCategory ] );
 

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.09-06",
+Version := "2022.09-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gd
@@ -39,3 +39,4 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_MATRIX_CATEGORY" );
 
 DeclareAttribute( "UnderlyingRing",
                   IsMatrixCategory );
+CapJitAddTypeSignature( "UnderlyingRing", [ IsMatrixCategory ], IsHomalgRing );


### PR DESCRIPTION
@mohamed-barakat This will have an effect on FunctorCategories:
1. You have to remove the error here: https://github.com/mohamed-barakat/FunctorCategories/blob/0653f6a77f6d5dd5d1f3ae90d3b215f66f202464/gap/Tools.gd#L26
2. Due to more type information being available, the compiled code will change. In particular, `func( list[i] )` will now be converted to `List( list, func )[i]`, which might have a huge effect on the runtime (more things can cancel so the code might get faster, or due to `func` being applied to all elements of `list` things might get slower).