### PR TITLE
InfoStringOfInstalledOperationsOfCategory now shows further mathematical properties

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.09-16",
+Version := "2022.09-17",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -6,35 +6,58 @@
 InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
   
   function( category )
-    local list_of_properties, property, string;
+    local list_of_mathematical_properties, list_of_potential_algorithmic_properties,
+          list_of_algorithmic_properties, list_of_maximal_algorithmic_properties, property, string;
     
     if not IsCapCategory( category ) then
         Error( "first argument must be a category" );
         return;
     fi;
     
-    list_of_properties := Intersection( ListKnownCategoricalProperties( category ), RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ) );
+    list_of_mathematical_properties := ListKnownCategoricalProperties( category );
+
+    list_of_potential_algorithmic_properties := RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD );
     
-    list_of_properties := Filtered( list_of_properties, p -> CheckConstructivenessOfCategory( category, p ) = [ ] );
+    list_of_algorithmic_properties := Intersection( list_of_mathematical_properties, list_of_potential_algorithmic_properties );
     
-    list_of_properties := MaximalObjects( list_of_properties,
-                                  { p1, p2 } ->
-                                  IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p2 ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p1 ) ) or
-                                  p1 in ListImpliedFilters( ValueGlobal( p2 ) )
-                          );
+    list_of_algorithmic_properties := Filtered( list_of_algorithmic_properties, p -> IsEmpty( CheckConstructivenessOfCategory( category, p ) ) );
     
-    StableSortBy( list_of_properties, p -> Length( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p ) ) );
+    list_of_maximal_algorithmic_properties := MaximalObjects( list_of_algorithmic_properties, { p1, p2 } ->
+                                               IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p2 ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p1 ) ) or
+                                               p1 in ListImpliedFilters( ValueGlobal( p2 ) ) );
+    
+    StableSortBy( list_of_maximal_algorithmic_properties, p -> Length( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p ) ) );
     
     string := ShallowCopy( String( Length( ListPrimitivelyInstalledOperationsOfCategory( category ) ) ) );
     Append( string, " primitive operations were used to derive " );
     Append( string, String( Length( ListInstalledOperationsOfCategory( category ) ) ) );
     Append( string, " operations for this category" );
-    if not IsEmpty( list_of_properties ) then
-        Append( string, " which constructively" );
+    if not IsEmpty( list_of_maximal_algorithmic_properties ) then
+        Append( string, " which algorithmically" );
     fi;
-    for property in list_of_properties do
+    for property in list_of_maximal_algorithmic_properties do
         Append( string, "\n* " );
         Append( string, property );
+    od;
+    
+    list_of_mathematical_properties := Difference( list_of_mathematical_properties, list_of_algorithmic_properties );
+    
+    list_of_mathematical_properties := MaximalObjects( list_of_mathematical_properties, { p1, p2 } -> p1 in ListImpliedFilters( ValueGlobal( p2 ) ) );
+    
+    if not IsEmpty( list_of_mathematical_properties ) then
+        if not IsEmpty( list_of_algorithmic_properties ) then
+            Append( string, "\nand furthermore" );
+        else
+            Append( string, " which" );
+        fi;
+        Append( string, " mathematically" );
+    fi;
+    for property in list_of_mathematical_properties do
+        Append( string, "\n* " );
+        Append( string, property );
+        if property in Difference( list_of_potential_algorithmic_properties, list_of_algorithmic_properties ) then
+            Append( string, " (but not yet algorithmically)" );
+        fi;
     od;
     
     return string;

--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2022.09-06",
+Version := "2022.09-07",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
@@ -99,7 +99,7 @@ Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [
                 [ "GAPDoc", ">= 1.5" ],
-                [ "CAP", ">= 2022.03-06" ],
+                [ "CAP", ">= 2022.09-17" ],
                 ],
   SuggestedOtherPackages := [
                 [ "MonoidalCategories", ">= 2022.09-03" ],

--- a/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
+++ b/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
@@ -1,0 +1,26 @@
+#! @Chapter Examples and Tests
+
+#! @Section InfoOfInstalledOperationsOfCategory
+
+#! @Example
+
+LoadPackage( "CartesianCategories", false );
+#! true
+
+distributive := DummyCategory( rec(
+  list_of_operations_to_install :=
+    Concatenation(
+      CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCartesianClosedCategory,
+      CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCocartesianCategory  ),
+  properties := [ "IsCartesianClosedCategory", "IsCocartesianCategory",
+                  "IsSkeletalCategory" ] ) );;
+
+InfoOfInstalledOperationsOfCategory( distributive );
+#! 19 primitive operations were used to derive 103 operations for this category
+#! which algorithmically
+#! * IsBicartesianClosedCategory
+#! and furthermore mathematically
+#! * IsDistributiveCategory (but not yet algorithmically)
+#! * IsSkeletalCategory
+
+#! @EndExample

--- a/CartesianCategories/examples/InitialCategory.g
+++ b/CartesianCategories/examples/InitialCategory.g
@@ -8,11 +8,13 @@ I := InitialCategory( );
 IsInitialCategory( I );
 #! true
 InfoOfInstalledOperationsOfCategory( I );
-#! 5 primitive operations were used to derive 13 operations for this category
+#! 5 primitive operations were used to derive 13 operations for this category which mathematically
+#! * IsInitialCategory
 OI := Opposite( I );
 #! Opposite of InitialCategory( )
 IsInitialCategory( OI );
 #! true
 InfoOfInstalledOperationsOfCategory( OI );
-#! 17 primitive operations were used to derive 17 operations for this category
+#! 17 primitive operations were used to derive 17 operations for this category which mathematically
+#! * IsInitialCategory
 #! @EndExample

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2022.05-02",
+Version := "2022.09-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -71,7 +71,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2022.04-03" ],
+                           [ "CAP", ">= 2022.09-17" ],
                            [ "ModulePresentationsForCAP", ">=2019.08.07" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "ComplexesAndFilteredObjectsForCAP", ">=2016.09.19" ],

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -16,9 +16,11 @@ Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
 #! 40 primitive operations were used to derive 198 operations for this category
-#! which constructively
+#! which algorithmically
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
+#! and furthermore mathematically
+#! * IsSymmetricClosedMonoidalCategory (but not yet algorithmically)
 #ListPrimitivelyInstalledOperationsOfCategory( Sgrmod );
 M := GradedFreeLeftPresentation( 2, S, [ 1, 1 ] );
 #! <An object in The category of graded left f.p. modules over Q[x,y]
@@ -72,7 +74,7 @@ CohP1 := Sgrmod / C;
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian
 InfoOfInstalledOperationsOfCategory( CohP1 );
 #! 21 primitive operations were used to derive 157 operations for this category
-#! which constructively
+#! which algorithmically
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );
 #! Localization functor of The Serre quotient category of The category of graded left

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.09-07",
+Version := "2022.09-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -119,7 +119,7 @@ Dependencies := rec(
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
                    [ "ToolsForHomalg", ">= 2018.05.22" ],
-                   [ "CAP", ">= 2022.08-08" ],
+                   [ "CAP", ">= 2022.09-17" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/MonoidalCategories/examples/TerminalCategory.g
+++ b/MonoidalCategories/examples/TerminalCategory.g
@@ -7,13 +7,19 @@ T := TerminalCategory( );
 #! TerminalCategory( )
 InfoOfInstalledOperationsOfCategory( T );
 #! 68 primitive operations were used to derive 317 operations for this category
-#! which constructively
+#! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
+#! and furthermore mathematically
+#! * IsLocallyOfFiniteInjectiveDimension
+#! * IsLocallyOfFiniteProjectiveDimension
+#! * IsSkeletalCategory
+#! * IsStrictMonoidalCategory
+#! * IsTerminalCategory
 i := InitialObject( T );
 #! <A zero object in TerminalCategory( )>
 t := TerminalObject( T );

--- a/MonoidalCategories/examples/TerminalCategoryWithMultipleObjects.g
+++ b/MonoidalCategories/examples/TerminalCategoryWithMultipleObjects.g
@@ -7,13 +7,17 @@ T := TerminalCategoryWithMultipleObjects( );
 #! TerminalCategoryWithMultipleObjects( )
 InfoOfInstalledOperationsOfCategory( T );
 #! 68 primitive operations were used to derive 317 operations for this category
-#! which constructively
+#! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
+#! and furthermore mathematically
+#! * IsLocallyOfFiniteInjectiveDimension
+#! * IsLocallyOfFiniteProjectiveDimension
+#! * IsTerminalCategory
 i := InitialObject( T );
 #! <A zero object in TerminalCategoryWithMultipleObjects( )>
 t := TerminalObject( T );


### PR DESCRIPTION
the motivation behind this is two-fold:
1. To see the categorical properties which are not linked to CAP operations
2. To see which constructive categorical properties are mathematically valid but not yet constructive
