### PR TITLE
Do not persist credentials during checkout because it interferes with subsplits

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -26,6 +26,9 @@ jobs:
       - run: sudo chmod 1777 $RUNNER_TEMP
       - run: sudo chown gap:gap $GITHUB_WORKSPACE
       - uses: actions/checkout@v3
+        with:
+          # the persisted token interferes with the subsplit token used below
+          persist-credentials: false
       - run: cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/
       - run: |
           export HOME="/home/gap"


### PR DESCRIPTION
Sorry for the spam, these release problems in the CI are hard to debug.