### PR TITLE
Revert two commits in ModulePresentationsForCAP

### DIFF
--- a/CAP/examples/ModulePresentationsMonoidalCategory.g
+++ b/CAP/examples/ModulePresentationsMonoidalCategory.g
@@ -31,22 +31,22 @@ Ul := TensorUnit( CapCategory( Ml ) );
 IntHoml := InternalHomOnObjects( DirectSum( Ml, Ul ), Nl );
 #! <An object in Category of left presentations of Z>
 Display( UnderlyingMatrix( IntHoml ) );
-#! [ [  -2,  -1 ],
-#!   [   1,  -1 ] ]
+#! [ [  1,  2 ],
+#!   [  0,  3 ] ]
 generator_l1 := StandardGeneratorMorphism( IntHoml, 1 );
 #! <A morphism in Category of left presentations of Z>
 morphism_l1 := LambdaElimination( DirectSum( Ml, Ul ), Nl, generator_l1 );
 #! <A morphism in Category of left presentations of Z>
 Display( UnderlyingMatrix( morphism_l1 ) );
-#! [ [  0 ],
-#!   [  2 ] ]
+#! [ [  -3 ],
+#!   [   2 ] ]
 generator_l2 := StandardGeneratorMorphism( IntHoml, 2 );
 #! <A morphism in Category of left presentations of Z>
 morphism_l2 := LambdaElimination( DirectSum( Ml, Ul ), Nl, generator_l2 );
 #! <A morphism in Category of left presentations of Z>
 Display( UnderlyingMatrix( morphism_l2 ) );
-#! [ [  0 ],
-#!   [  2 ] ]
+#! [ [   0 ],
+#!   [  -1 ] ]
 IsEqualForMorphisms( LambdaIntroduction( morphism_l1 ), generator_l1 );
 #! false
 IsCongruentForMorphisms( LambdaIntroduction( morphism_l1 ), generator_l1 );
@@ -79,21 +79,21 @@ Ur := TensorUnit( CapCategory( Mr ) );
 IntHomr := InternalHomOnObjects( DirectSum( Mr, Ur ), Nr );
 #! <An object in Category of right presentations of Z>
 Display( UnderlyingMatrix( IntHomr ) );
-#! [ [  -2,   1 ],
-#!   [  -1,  -1 ] ]
+#! [ [  1,  0 ],
+#!   [  2,  3 ] ]
 generator_r1 := StandardGeneratorMorphism( IntHomr, 1 );
 #! <A morphism in Category of right presentations of Z>
 morphism_r1 := LambdaElimination( DirectSum( Mr, Ur ), Nr, generator_r1 );
 #! <A morphism in Category of right presentations of Z>
 Display( UnderlyingMatrix( morphism_r1 ) );
-#! [ [  0,   2 ] ]
+#! [ [  -3,   2 ] ]
 generator_r2 := StandardGeneratorMorphism( IntHoml, 2 );
 #! <A morphism in Category of left presentations of Z>
 morphism_r2 := LambdaElimination( DirectSum( Ml, Ul ), Nl, generator_r2 );
 #! <A morphism in Category of left presentations of Z>
 Display( UnderlyingMatrix( morphism_r2 ) );
 #! [ [   0 ],
-#!   [   2 ] ]
+#!   [  -1 ] ]
 IsEqualForMorphisms( LambdaIntroduction( morphism_r1 ), generator_r1 );
 #! false
 IsCongruentForMorphisms( LambdaIntroduction( morphism_r1 ), generator_r1 );

--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ModulePresentationsForCAP",
 Subtitle := "Category R-pres for CAP",
-Version := "2022.09-02",
+Version := "2022.10-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ModulePresentationsForCAP/examples/MonoidalStructure.g
+++ b/ModulePresentationsForCAP/examples/MonoidalStructure.g
@@ -24,30 +24,21 @@ IsZero( T );
 H := InternalHomOnObjects( DirectSum( M, M ), DirectSum( M, N ) );
 #! <An object in Category of left presentations of Z>
 Display( H );
-#! [ [  -4,  -2 ],
-#!   [   2,   2 ] ]
+#! [ [   0,   0,   0,  -2 ],
+#!   [   1,   2,   0,   0 ],
+#!   [   0,   2,   2,   0 ],
+#!   [   2,   3,   0,   2 ] ]
 #! 
 #! An object in Category of left presentations of Z
-alpha := StandardGeneratorMorphism( H, 1 );
+alpha := StandardGeneratorMorphism( H, 3 );
 #! <A morphism in Category of left presentations of Z>
 l := LambdaElimination( DirectSum( M, M ), DirectSum( M, N ), alpha );
 #! <A morphism in Category of left presentations of Z>
 IsZero( l );
 #! false
 Display( l );
-#! [ [  0,   0 ],
-#!   [  1,  0 ] ]
-#!
-#! A morphism in Category of left presentations of Z
-alpha2 := StandardGeneratorMorphism( H, 2 );
-#! <A morphism in Category of left presentations of Z>
-l2 := LambdaElimination( DirectSum( M, M ), DirectSum( M, N ), alpha2 );
-#! <A morphism in Category of left presentations of Z>
-IsZero( l2 );
-#! false
-Display( l2 );
-#! [ [  1,   0 ],
-#!   [  0,  0 ] ]
+#! [ [  -2,   6 ],
+#!   [  -1,  -3 ] ]
 #!
 #! A morphism in Category of left presentations of Z
 #! @EndExample

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -411,35 +411,28 @@ InstallGlobalFunction( ADD_KERNEL_LEFT,
     AddKernelEmbedding( category,
       
       function( cat, morphism )
-        local kernel, embedding, source_matrix;
+        local kernel, embedding;
         
-        embedding := ReducedSyzygiesOfRows( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
+        embedding := SyzygiesOfRows( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
         
-        source_matrix := BasisOfRows( UnderlyingMatrix( Source( morphism ) ) );
-        
-        embedding := DecideZeroRows( embedding, source_matrix );
-        
-        embedding := CertainRows( embedding, NonZeroRows( embedding ) );
-        
-        kernel := SyzygiesOfRows( embedding, source_matrix );
+        kernel := SyzygiesOfRows( embedding, UnderlyingMatrix( Source( morphism ) ) );
         
         kernel := AsLeftPresentation( kernel );
         
         return PresentationMorphism( kernel, embedding, Source( morphism ) );
         
     end );
-#  TODO: Can we profit from such a function?
-#     
-#     AddKernelEmbeddingWithGivenKernelObject( category,
-#       
-#       function( cat, morphism, kernel )
-#         local embedding;
-#         
-#         embedding := SyzygiesOfRows( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
-#         
-#         return PresentationMorphism( kernel, embedding, Source( morphism ) );
-#         
-#     end );
+    
+    AddKernelEmbeddingWithGivenKernelObject( category,
+      
+      function( cat, morphism, kernel )
+        local embedding;
+        
+        embedding := SyzygiesOfRows( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
+        
+        return PresentationMorphism( kernel, embedding, Source( morphism ) );
+        
+    end );
     
     AddLiftAlongMonomorphism( category,
       
@@ -462,35 +455,28 @@ InstallGlobalFunction( ADD_KERNEL_RIGHT,
     AddKernelEmbedding( category,
       
       function( cat, morphism )
-        local kernel, embedding, source_matrix;
+        local kernel, embedding;
         
-        embedding := ReducedSyzygiesOfColumns( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
+        embedding := SyzygiesOfColumns( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
         
-        source_matrix := BasisOfColumns( UnderlyingMatrix( Source( morphism ) ) );
-        
-        embedding := DecideZeroColumns( embedding, source_matrix );
-        
-        embedding := CertainColumns( embedding, NonZeroColumns( embedding ) );
-        
-        kernel := SyzygiesOfColumns( embedding, source_matrix );
+        kernel := SyzygiesOfColumns( embedding, UnderlyingMatrix( Source( morphism ) ) );
         
         kernel := AsRightPresentation( kernel );
         
         return PresentationMorphism( kernel, embedding, Source( morphism ) );
         
     end );
-#  TODO: Can we profit from such a function?
-#     
-#     AddKernelEmbeddingWithGivenKernelObject( category,
-#       
-#       function( cat, morphism, kernel )
-#         local embedding;
-#         
-#         embedding := SyzygiesOfColumns( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
-#         
-#         return PresentationMorphism( kernel, embedding, Source( morphism ) );
-#         
-#     end );
+    
+    AddKernelEmbeddingWithGivenKernelObject( category,
+      
+      function( cat, morphism, kernel )
+        local embedding;
+        
+        embedding := SyzygiesOfColumns( UnderlyingMatrix( morphism ), UnderlyingMatrix( Range( morphism ) ) );
+        
+        return PresentationMorphism( kernel, embedding, Source( morphism ) );
+        
+    end );
     
     AddLiftAlongMonomorphism( category,
       

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -421,7 +421,7 @@ InstallGlobalFunction( ADD_KERNEL_LEFT,
         
         embedding := CertainRows( embedding, NonZeroRows( embedding ) );
         
-        kernel := LazySyzygiesOfRows( embedding, source_matrix );
+        kernel := SyzygiesOfRows( embedding, source_matrix );
         
         kernel := AsLeftPresentation( kernel );
         
@@ -472,7 +472,7 @@ InstallGlobalFunction( ADD_KERNEL_RIGHT,
         
         embedding := CertainColumns( embedding, NonZeroColumns( embedding ) );
         
-        kernel := LazySyzygiesOfColumns( embedding, source_matrix );
+        kernel := SyzygiesOfColumns( embedding, source_matrix );
         
         kernel := AsRightPresentation( kernel );
         


### PR DESCRIPTION
* Using `LazySyzygiesOfRows` is obsolete when compiling code because the kernel object will simply be dropped when not used (e.g. when computing homology objects).
* Simplifying the result by computing `ReducedSyzygiesOfRows` should better be done explicitly by applying `SimplifyMorphism*` where needed.

@sebastianpos Mohamed says he's the one who wanted those changes in the first place. Are you okay with reverting them for the reasons given above?