### PR TITLE
Replace Display by Print

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.10-05",
+Version := "2022.10-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/LinearAlgebraForCAP.g
+++ b/CompilerForCAP/examples/LinearAlgebraForCAP.g
@@ -18,8 +18,9 @@ W := DirectSum( V, V );;
 morphism_matrix := [ [ alpha, beta ], [ beta, alpha ] ];;
 
 # compile the derivation of MorphismBetweenDirectSumsWithGivenDirectSums
-Display(
-    vec!.added_functions.MorphismBetweenDirectSumsWithGivenDirectSums[1][1]
+Print(
+    vec!.added_functions.MorphismBetweenDirectSumsWithGivenDirectSums[1][1],
+    "\n"
 );
 #! function ( cat, S, diagram_S, morphism_matrix, diagram_T, T )
 #!     local test_diagram_product, test_diagram_coproduct;


### PR DESCRIPTION
GAP master now prints the function location when using Display.
