### PR TITLE
Normalize MatElm to [,] again

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.10-07",
+Version := "2022.10-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/MatElm.g
+++ b/CompilerForCAP/examples/MatElm.g
@@ -2,16 +2,17 @@
 
 #! @Section Tests
 
-LoadPackage( "CompilerForCAP", false );
-
 #! @Example
 
-func := x -> x[1,1];;
+LoadPackage( "CompilerForCAP", false );
+#! true
+
+func := x -> MatElm( x, 1, 1 );;
 tree := ENHANCED_SYNTAX_TREE( func );;
 tree := CapJitResolvedGlobalVariables( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function ( x_1 )
-#!     return MatElm( x_1, 1, 1 );
+#!     return x_1[1, 1];
 #! end
 
 #! @EndExample

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -13,7 +13,7 @@ end );
 BindGlobal( "CAP_JIT_INTERNAL_SYNTAX_TREE_TO_OPERATION_TRANSLATIONS", rec(
     EXPR_ELM_LIST := tree -> rec( operation_name := "[]", args := [ tree.list, tree.pos ] ),
     EXPR_ELMS_LIST := tree -> rec( operation_name := "{}", args := [ tree.list, tree.poss ] ),
-    EXPR_ELM_MAT := tree -> rec( operation_name := "MatElm", args := [ tree.list, tree.row, tree.col ] ),
+    EXPR_ELM_MAT := tree -> rec( operation_name := "[,]", args := [ tree.list, tree.row, tree.col ] ),
     EXPR_SUM := tree -> rec( operation_name := "+", args := [ tree.left, tree.right ] ),
     EXPR_DIFF := tree -> rec( operation_name := "-", args := [ tree.left, tree.right ] ),
     EXPR_PROD := tree -> rec( operation_name := "*", args := [ tree.left, tree.right ] ),
@@ -25,7 +25,7 @@ BindGlobal( "CAP_JIT_INTERNAL_SYNTAX_TREE_TO_OPERATION_TRANSLATIONS", rec(
 BindGlobal( "CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS", rec(
     \[\] := tree -> rec( type := "EXPR_ELM_LIST", list := tree.args.1, pos := tree.args.2 ),
     \{\} := tree -> rec( type := "EXPR_ELMS_LIST", list := tree.args.1, poss := tree.args.2 ),
-    MatELm := tree -> rec( type := "EXPR_ELM_MAT", list := tree.args.1, row := tree.args.2, col := tree.args.3 ),
+    \[\,\] := tree -> rec( type := "EXPR_ELM_MAT", list := tree.args.1, row := tree.args.2, col := tree.args.3 ),
     \+ := tree -> rec( type := "EXPR_SUM", left := tree.args.1, right := tree.args.2 ),
     \- := tree -> rec( type := "EXPR_DIFF", left := tree.args.1, right := tree.args.2 ),
     \* := tree -> rec( type := "EXPR_PROD", left := tree.args.1, right := tree.args.2 ),

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -1131,7 +1131,7 @@ CapJitAddTypeSignature( "*", [ IsInt, IsList ], function ( input_types )
     
 end );
 
-CapJitAddTypeSignature( "MatElm", [ IsList, IsInt, IsInt ], function ( input_types )
+CapJitAddTypeSignature( "[,]", [ IsList, IsInt, IsInt ], function ( input_types )
     
     Assert( 0, input_types[1].element_type.filter = IsList );
     
@@ -1324,7 +1324,7 @@ CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgIdentityMatrix", [ "
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgZeroMatrix", [ "IsInt", "IsInt", "IsHomalgRing" ], "IsHomalgMatrix" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "RandomMatrix", [ "IsInt", "IsInt", "IsHomalgRing" ], "IsHomalgMatrix" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "IsZero", [ "IsHomalgMatrix" ], "IsBool" );
-CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "MatElm", [ "IsHomalgMatrix", "IsInt", "IsInt" ], "IsHomalgRingElement" );
+CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "[,]", [ "IsHomalgMatrix", "IsInt", "IsInt" ], "IsHomalgRingElement" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "ConvertRowToMatrix", [ "IsHomalgMatrix", "IsInt", "IsInt" ], "IsHomalgMatrix" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "ConvertColumnToMatrix", [ "IsHomalgMatrix", "IsInt", "IsInt" ], "IsHomalgMatrix" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "ConvertMatrixToRow", [ "IsHomalgMatrix" ], "IsHomalgMatrix" );

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -90,17 +90,19 @@ InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )
                     # normalize to the "official" name
                     name := NameFunction( value );
                     
-                    # in GAP 4.11, "MatElm" points to "[,]", in GAP 4.12 it's the other way round
-                    if name = "[,]" then
+                    # in GAP 4.11 and GAP 4.13, "MatElm" points to "[,]", in GAP 4.12 it's the other way round
+                    if name = "MatElm" then
                         
-                        # this code is only executed with GAP 4.11, but coverage information is only uploaded for GAP master
+                        # this code is only executed with GAP 4.12, but coverage information is only uploaded for GAP master
                         Assert( 0, IsIdenticalObj( \[\,\], MatElm ) );
                         
-                        name := "MatElm";
+                        name := "[,]";
                         
                     fi;
                     
-                    if name <> tree.gvar and IsBoundGlobal( name ) and IsIdenticalObj( value, ValueGlobal( name ) ) then
+                    # `IsBoundGlobal` calls `CheckGlobalName`, which warns about names containing characters not in `IdentifierLetters`.
+                    # This is expected for operations in CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS, so we avoid IsBoundGlobal in this case.
+                    if name <> tree.gvar and (IsBound( CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS.(name) ) or IsBoundGlobal( name )) and IsIdenticalObj( value, ValueGlobal( name ) ) then
                         
                         tree := ShallowCopy( tree );
                         

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.10-10",
+Version := "2022.10-11",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -226,10 +226,10 @@ end );
 #! The output is the $(i,j)$'th entry in <C>MorphismMatrix</C>($\alpha$).
 #! @Arguments alpha, i, j
 #! @Returns a morphism $C$
-DeclareOperation( "MatElm",
+DeclareOperation( "[,]",
                   [ IsAdditiveClosureMorphism, IsInt, IsInt ] );
 
-CapJitAddTypeSignature( "MatElm", [ IsAdditiveClosureMorphism, IsInt, IsInt ], function ( input_types )
+CapJitAddTypeSignature( "[,]", [ IsAdditiveClosureMorphism, IsInt, IsInt ], function ( input_types )
     
     Assert( 0, IsAdditiveClosureCategory( input_types[1].category ) );
     


### PR DESCRIPTION
Following GAP commit 3d4c228d1a26afc4f641a3e7885cf4e626a34fb0.

Also, the old code contained a typo (`MatELm` instead of `MatElm`) which prevented MatElm from being coded as EXPR_ELM_MAT although it should have been.