### PR TITLE
Introduce compiler hint category_attribute_resolving_functions

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.10-08",
+Version := "2022.10-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
+++ b/CompilerForCAP/examples/CapJitResolvedGlobalVariables.g
@@ -65,6 +65,32 @@ Display( ENHANCED_SYNTAX_TREE_CODE( tree2 ) );
 tree = tree2;
 #! true
 
+# test category_attribute_resolving_functions
+MY_CAP_CATEGORY_3 := CreateCapCategory( );;
+SetMyAttribute( MY_CAP_CATEGORY_3, 1 );
+MY_CAP_CATEGORY_3!.compiler_hints := rec(
+    category_attribute_names := [
+        "MyAttribute"
+    ],
+);;
+
+func := cat -> MyAttribute( cat );;
+
+Display( CapJitCompiledFunction( func, MY_CAP_CATEGORY_3 ) );
+#! function ( cat_1 )
+#!     return MyAttribute( cat_1 );
+#! end
+
+MY_CAP_CATEGORY_3!.compiler_hints.category_attribute_resolving_functions :=
+  rec(
+    MyAttribute := { } -> rec( type := "EXPR_INT", value := 1 ),
+);;
+
+Display( CapJitCompiledFunction( func, MY_CAP_CATEGORY_3 ) );
+#! function ( cat_1 )
+#!     return 1;
+#! end
+
 CapJitEnableDataTypeInference( );
 
 #! @EndExample


### PR DESCRIPTION
This is experimental and will be improved in the future once we have more examples using it. Current limitations include:

1. The resolving function is not applied if the attribute is obtained from the function context instead of by applying the attribute getter to the category.
2. The resolving function must be attached to the category to which the attribute getter is applied in the original code. This might be a different category than the one to which the attribute getter is applied in the compiled code (see FAQ question "Where do the category attributes in the compiled code come from?").

In the future this might be extended by a convenience which automatically resolves literal data types (integers, literal lists, etc.).

Fixes #1098.