### PR TITLE
Make RingAsCategory of exterior algebra linear over the underlying field

### DIFF
--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -290,6 +290,17 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
     ## Homomorphism structure for homalg exterior rings over fields
     if IsHomalgRing( ring ) and HasIsExteriorRing( ring ) and IsExteriorRing( ring ) and IsField( BaseRing( ring ) ) then
         
+        SetIsLinearCategoryOverCommutativeRing( category, true );
+        
+        SetCommutativeRingOfLinearCategory( category, BaseRing( ring ) );
+        
+        AddMultiplyWithElementOfCommutativeRingForMorphisms( category,
+          function( cat, r, alpha )
+            
+            return RingAsCategoryMorphism( category, ( r / ring ) * UnderlyingRingElement( alpha ) );
+            
+        end );
+        
         field := BaseRing( ring );
         
         range_category := CategoryOfRows( field );


### PR DESCRIPTION
so that `BasisOfExternalHom` can be derived in `FreydCategory( CategoryOfRows( exterior algebra ) )`