### PR TITLE
Code EXPR_ELM_MAT in function call style

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2022.10-09",
+Version := "2022.10-10",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/MatElm.g
+++ b/CompilerForCAP/examples/MatElm.g
@@ -12,7 +12,7 @@ tree := ENHANCED_SYNTAX_TREE( func );;
 tree := CapJitResolvedGlobalVariables( tree );;
 Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 #! function ( x_1 )
-#!     return x_1[1, 1];
+#!     return \[\,\]( x_1, 1, 1 );
 #! end
 
 #! @EndExample

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -957,7 +957,8 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
         else
             
             # replace by native syntax if possible
-            if CapJitIsCallToGlobalFunction( tree, gvar -> IsBound( CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS.(gvar) ) ) then
+            # do not do this for "[,]" because of a difference between GAP 4.12 and GAP 4.13 regarding the indentation (https://github.com/gap-system/gap/pull/5167)
+            if CapJitIsCallToGlobalFunction( tree, gvar -> IsBound( CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS.(gvar) ) and gvar <> "[,]" ) then
                 
                 tree := CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS.(tree.funcref.gvar)( tree );
                 


### PR DESCRIPTION
To avoid a difference between GAP 4.12 and GAP 4.13 regarding the indentation.