### PR TITLE
Introduce AddFinalDerivationBundle

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.10-08",
+Version := "2022.10-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2987,7 +2987,7 @@ AddDerivationToCAP( MereExistenceOfSolutionOfLinearSystemInAbCategory,
 ## Final methods for FiberProduct
 
 ##
-AddFinalDerivation( IsomorphismFromFiberProductToKernelOfDiagonalDifference,
+AddFinalDerivationBundle( # IsomorphismFromFiberProductToKernelOfDiagonalDifference
                     [ [ DirectSumDiagonalDifference, 1 ], 
                       [ KernelObject, 1 ],
                       [ IdentityMorphism, 1 ] ],
@@ -2999,7 +2999,8 @@ AddFinalDerivation( IsomorphismFromFiberProductToKernelOfDiagonalDifference,
                       FiberProductEmbeddingInDirectSum,
                       IsomorphismFromFiberProductToKernelOfDiagonalDifference,
                       IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct ],
-                    
+[
+  IsomorphismFromFiberProductToKernelOfDiagonalDifference,
   function( cat, diagram )
     local kernel_of_diagonal_difference;
     
@@ -3007,7 +3008,8 @@ AddFinalDerivation( IsomorphismFromFiberProductToKernelOfDiagonalDifference,
     
     return IdentityMorphism( cat, kernel_of_diagonal_difference );
     
-  end,
+  end
+],
 [
   IsomorphismFromKernelOfDiagonalDifferenceToFiberProduct,
   function( cat, diagram )
@@ -3021,7 +3023,7 @@ AddFinalDerivation( IsomorphismFromFiberProductToKernelOfDiagonalDifference,
 ] : Description := "IsomorphismFromFiberProductToKernelOfDiagonalDifference as the identity of the kernel of diagonal difference" );
 
 ##
-AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
+AddFinalDerivationBundle( # IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
                     [ [ ProjectionInFactorOfDirectProduct, 2 ], ## Length( diagram ) would be the correct number
                       [ PreCompose, 2 ], ## Length( diagram ) would be the correct number
                       [ DirectProduct, 1 ],
@@ -3034,7 +3036,8 @@ AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram
                       UniversalMorphismIntoFiberProductWithGivenFiberProduct,
                       IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
                       IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct ],
-                    
+[
+  IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram,
   function( cat, diagram )
     local D, diagram_of_equalizer, equalizer_of_direct_product_diagram;
     
@@ -3048,7 +3051,8 @@ AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram
     
     return IdentityMorphism( cat, equalizer_of_direct_product_diagram );
 
-  end,
+  end
+],
 [
   IsomorphismFromEqualizerOfDirectProductDiagramToFiberProduct,
   function( cat, diagram )
@@ -3070,7 +3074,7 @@ AddFinalDerivation( IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram
 ## Final methods for Pushout
 
 ##
-AddFinalDerivation( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
+AddFinalDerivationBundle( # IsomorphismFromPushoutToCokernelOfDiagonalDifference,
                     [ [ CokernelObject, 1 ],
                       [ DirectSumCodiagonalDifference, 1 ],
                       [ IdentityMorphism, 1 ] ],
@@ -3082,7 +3086,8 @@ AddFinalDerivation( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
                       DirectSumProjectionInPushout,
                       IsomorphismFromPushoutToCokernelOfDiagonalDifference,
                       IsomorphismFromCokernelOfDiagonalDifferenceToPushout ],
-                    
+[
+  IsomorphismFromPushoutToCokernelOfDiagonalDifference,
   function( cat, diagram )
     local cokernel_of_diagonal_difference;
     
@@ -3090,7 +3095,8 @@ AddFinalDerivation( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
     
     return IdentityMorphism( cat, cokernel_of_diagonal_difference );
     
-  end,
+  end
+],
 [
   IsomorphismFromCokernelOfDiagonalDifferenceToPushout,
   function( cat, diagram )
@@ -3104,7 +3110,7 @@ AddFinalDerivation( IsomorphismFromPushoutToCokernelOfDiagonalDifference,
 ]: Description := "IsomorphismFromPushoutToCokernelOfDiagonalDifference as the identity of the cokernel of diagonal difference" );
 
 ##
-AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
+AddFinalDerivationBundle( # IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
                     [ [ InjectionOfCofactorOfCoproduct, 2 ], ## Length( diagram ) would be the correct number
                       [ PreCompose, 2 ], ## Length( diagram ) would be the correct number
                       [ Coproduct, 1 ],
@@ -3117,7 +3123,8 @@ AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
                       UniversalMorphismFromPushoutWithGivenPushout,
                       IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
                       IsomorphismFromCoequalizerOfCoproductDiagramToPushout ],
-                    
+[
+  IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
   function( cat, diagram )
     local D, diagram_of_coequalizer, coequalizer_of_coproduct_diagram;
     
@@ -3131,7 +3138,8 @@ AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
     
     return IdentityMorphism( cat, coequalizer_of_coproduct_diagram );
     
-  end,
+  end
+],
 [
   IsomorphismFromCoequalizerOfCoproductDiagramToPushout,
   function( cat, diagram )
@@ -3153,7 +3161,7 @@ AddFinalDerivation( IsomorphismFromPushoutToCoequalizerOfCoproductDiagram,
 ## Final methods for Image
 
 ##
-AddFinalDerivation( IsomorphismFromImageObjectToKernelOfCokernel,
+AddFinalDerivationBundle( # IsomorphismFromImageObjectToKernelOfCokernel,
                     [ [ KernelObject, 1 ],
                       [ CokernelProjection, 1 ],
                       [ IdentityMorphism, 1 ] ],
@@ -3166,7 +3174,8 @@ AddFinalDerivation( IsomorphismFromImageObjectToKernelOfCokernel,
                       UniversalMorphismFromImageWithGivenImageObject,
                       IsomorphismFromImageObjectToKernelOfCokernel,
                       IsomorphismFromKernelOfCokernelToImageObject ],
-                    
+[
+  IsomorphismFromImageObjectToKernelOfCokernel,
   function( cat, mor )
     local kernel_of_cokernel;
     
@@ -3174,7 +3183,8 @@ AddFinalDerivation( IsomorphismFromImageObjectToKernelOfCokernel,
     
     return IdentityMorphism( cat, kernel_of_cokernel );
     
-  end,
+  end
+],
 [
   IsomorphismFromKernelOfCokernelToImageObject,
   function( cat, mor )
@@ -3227,7 +3237,7 @@ end : Description := "CanonicalIdentificationFromCoimageToImageObject as the inv
 ## Final methods for Coimage
 
 ##
-AddFinalDerivation( IsomorphismFromCoimageToCokernelOfKernel,
+AddFinalDerivationBundle( # IsomorphismFromCoimageToCokernelOfKernel,
                     [ [ CokernelObject, 1 ],
                       [ KernelEmbedding, 1 ],
                       [ IdentityMorphism, 1 ] ],
@@ -3240,7 +3250,8 @@ AddFinalDerivation( IsomorphismFromCoimageToCokernelOfKernel,
                       UniversalMorphismIntoCoimageWithGivenCoimageObject,
                       IsomorphismFromCoimageToCokernelOfKernel,
                       IsomorphismFromCokernelOfKernelToCoimage ],
-                    
+[
+  IsomorphismFromCoimageToCokernelOfKernel,
   function( cat, mor )
     local cokernel_of_kernel;
     
@@ -3248,7 +3259,8 @@ AddFinalDerivation( IsomorphismFromCoimageToCokernelOfKernel,
     
     return IdentityMorphism( cat, cokernel_of_kernel );
     
-  end,
+  end
+],
 [
   IsomorphismFromCokernelOfKernelToCoimage,
   function( cat, mor )
@@ -3264,7 +3276,7 @@ AddFinalDerivation( IsomorphismFromCoimageToCokernelOfKernel,
 ## Final methods for initial object
 
 ##
-AddFinalDerivation( IsomorphismFromInitialObjectToZeroObject,
+AddFinalDerivationBundle( # IsomorphismFromInitialObjectToZeroObject,
                     [ [ ZeroObject, 1 ],
                       [ IdentityMorphism, 1 ] ],
                     [ IsomorphismFromInitialObjectToZeroObject,
@@ -3276,12 +3288,14 @@ AddFinalDerivation( IsomorphismFromInitialObjectToZeroObject,
                       ## deduce an InitialObject
 #                       UniversalMorphismFromInitialObjectWithGivenInitialObject
                     ],
-                    
+[
+  IsomorphismFromInitialObjectToZeroObject,
   function( cat )
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromZeroObjectToInitialObject,
   function( cat )
@@ -3294,7 +3308,7 @@ AddFinalDerivation( IsomorphismFromInitialObjectToZeroObject,
 ## Final methods for terminal object
 
 ##
-AddFinalDerivation( IsomorphismFromTerminalObjectToZeroObject,
+AddFinalDerivationBundle( # IsomorphismFromTerminalObjectToZeroObject,
                     [ [ ZeroObject, 1 ],
                       [ IdentityMorphism, 1 ] ],
                     [ IsomorphismFromTerminalObjectToZeroObject,
@@ -3306,12 +3320,14 @@ AddFinalDerivation( IsomorphismFromTerminalObjectToZeroObject,
                       ## deduce a TerminalObject
 #                       UniversalMorphismIntoTerminalObjectWithGivenTerminalObject
                     ],
-                    
+[
+  IsomorphismFromTerminalObjectToZeroObject,
   function( cat )
     
     return IdentityMorphism( cat, ZeroObject( cat ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromZeroObjectToTerminalObject,
   function( cat )
@@ -3324,7 +3340,7 @@ AddFinalDerivation( IsomorphismFromTerminalObjectToZeroObject,
 ## Final methods for product
 
 ##
-AddFinalDerivation( IsomorphismFromDirectSumToDirectProduct,
+AddFinalDerivationBundle( # IsomorphismFromDirectSumToDirectProduct,
                     [ [ DirectSum, 1 ],
                       [ IdentityMorphism, 1 ] ],
                     [ IsomorphismFromDirectSumToDirectProduct,
@@ -3335,12 +3351,14 @@ AddFinalDerivation( IsomorphismFromDirectSumToDirectProduct,
 #                       ProjectionInFactorOfDirectProductWithGivenDirectProduct,
                       UniversalMorphismIntoDirectProduct ],
 #                       UniversalMorphismIntoDirectProductWithGivenDirectProduct ],
-                      
+[
+  IsomorphismFromDirectSumToDirectProduct,
   function( cat, diagram )
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromDirectProductToDirectSum,
   function( cat, diagram )
@@ -3353,7 +3371,7 @@ AddFinalDerivation( IsomorphismFromDirectSumToDirectProduct,
 ## Final methods for coproduct
 
 ##
-AddFinalDerivation( IsomorphismFromCoproductToDirectSum,
+AddFinalDerivationBundle( # IsomorphismFromCoproductToDirectSum,
                     [ [ DirectSum, 1 ],
                       [ IdentityMorphism, 1 ] ],
                     [ IsomorphismFromCoproductToDirectSum,
@@ -3364,12 +3382,14 @@ AddFinalDerivation( IsomorphismFromCoproductToDirectSum,
 #                       InjectionOfCofactorOfCoproductWithGivenCoproduct,
                       UniversalMorphismFromCoproduct ],
 #                       UniversalMorphismFromCoproductWithGivenCoproduct ],
-                      
+[
+  IsomorphismFromCoproductToDirectSum,
   function( cat, diagram )
     
     return IdentityMorphism( cat, DirectSum( cat, diagram ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromDirectSumToCoproduct,
   function( cat, diagram )
@@ -3382,7 +3402,7 @@ AddFinalDerivation( IsomorphismFromCoproductToDirectSum,
 ## Final methods for homology object
 
 ##
-AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject,
+AddFinalDerivationBundle( # IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject,
                     [ [ ImageObject, 1 ],
                       [ PreCompose, 1 ],
                       [ KernelEmbedding, 1 ],
@@ -3393,7 +3413,8 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
                       IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject,
                       HomologyObject,
                       HomologyObjectFunctorialWithGivenHomologyObjects ],
-                      
+[
+  IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject,
   function( cat, alpha, beta )
     local homology_object;
     
@@ -3401,7 +3422,8 @@ AddFinalDerivation( IsomorphismFromHomologyObjectToItsConstructionAsAnImageObjec
     
     return IdentityMorphism( cat, homology_object );
     
-  end,
+  end
+],
 [
   IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject,
   function( cat, alpha, beta )
@@ -3458,7 +3480,7 @@ AddFinalDerivation( IsEqualForMorphisms,
 ## Final methods for BasisOfExternalHom & CoefficientsOfMorphism
 
 ##
-AddFinalDerivation( BasisOfExternalHom,
+AddFinalDerivationBundle( # BasisOfExternalHom,
                     [
                       [ HomomorphismStructureOnObjects, 1 ],
                       [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 2 ],
@@ -3471,6 +3493,8 @@ AddFinalDerivation( BasisOfExternalHom,
                       BasisOfExternalHom,
                       CoefficientsOfMorphismWithGivenBasisOfExternalHom
                     ],
+[
+  BasisOfExternalHom,
   function( cat, a, b )
     local range_cat, hom_a_b, D, B;
     
@@ -3484,7 +3508,8 @@ AddFinalDerivation( BasisOfExternalHom,
     
     return List( B, m -> InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, a, b, m ) );
   
-  end,
+  end
+],
 [
   CoefficientsOfMorphismWithGivenBasisOfExternalHom,
   function( cat, alpha, L )

--- a/CAP/gap/Finalize.gd
+++ b/CAP/gap/Finalize.gd
@@ -10,6 +10,8 @@ DeclareGlobalVariable( "CAP_INTERNAL_FINAL_DERIVATION_LIST" );
 
 DeclareGlobalFunction( "AddFinalDerivation" );
 
+DeclareGlobalFunction( "AddFinalDerivationBundle" );
+
 
 DeclareAttribute( "IsFinalized",
                   IsCapCategory,

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -11,25 +11,31 @@ BindGlobal( "CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK",
   function( derivation )
     local methods_to_check, method_name, filter_list, number_of_proposed_arguments, current_function_argument_number, method;
     
+    if IsEmpty( derivation.additional_functions ) then
+        
+        Error( "trying to add a final derivation without any functions to install" );
+        
+    fi;
+    
     if PositionSublist( String( derivation.category_filter ), "CanCompute" ) <> fail then
         
-        Print( "WARNING: The CategoryFilter of a final derivation for ", NameFunction( derivation.target_op ), " uses `CanCompute`. Please register all preconditions explicitly.\n" );
+        Print( "WARNING: The CategoryFilter of a final derivation for ", NameFunction( derivation.additional_functions[1][1] ), " uses `CanCompute`. Please register all preconditions explicitly.\n" );
         
     fi;
     
-    if StartsWith( NameFunction( derivation.target_op ), "IsomorphismFrom" ) and IsEmpty( derivation.additional_functions ) then
+    if StartsWith( NameFunction( derivation.additional_functions[1][1] ), "IsomorphismFrom" ) and Length( derivation.additional_functions ) = 1 then
         
-        Print( "WARNING: You are installing a final derivation for ", derivation.target_op, " which does not include its inverse. You should probably use a bundled final derivation to also install its inverse.\n" );
+        Print( "WARNING: You are installing a final derivation for ", NameFunction( derivation.additional_functions[1][1] ), " which does not include its inverse. You should probably use a bundled final derivation to also install its inverse.\n" );
         
     fi;
     
-    methods_to_check := Concatenation( [ [ derivation.target_op, derivation.func ] ], derivation.additional_functions );
+    methods_to_check := derivation.additional_functions;
     
     for method in methods_to_check do
         
         if not method[1] in derivation.cannot_compute then
             
-            Print( "WARNING: A final derivation for ", NameFunction( derivation.target_op ), " installs ", NameFunction( method[1] ), " but does not list it in its exclude list.\n" );
+            Print( "WARNING: A final derivation for ", NameFunction( derivation.additional_functions[1][1] ), " installs ", NameFunction( method[1] ), " but does not list it in its exclude list.\n" );
             
         fi;
         
@@ -63,16 +69,25 @@ BindGlobal( "CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK",
     
 end );
 
-
 InstallGlobalFunction( AddFinalDerivation,
                
   function( target_op, can_compute, cannot_compute, func, additional_functions... )
-    local final_derivation, loop_multiplier, category_getters, function_called_before_installation, operations_in_graph, operations_to_install, collected_list, union_of_collected_lists, used_op_names_with_multiples_and_category_getters, i, current_additional_func, x;
     
-    if IsList( func ) then
-        Error( "passing a list of functions to `AddFinalDerivation` is not supported anymore" );
-    fi;
+    CallFuncList( AddFinalDerivationBundle, Concatenation( [ can_compute, cannot_compute, [ target_op, func ] ], additional_functions ) );
+    
+end );
 
+InstallGlobalFunction( AddFinalDerivationBundle,
+               
+  function( can_compute, cannot_compute, additional_functions... )
+    local final_derivation, loop_multiplier, category_getters, operations_in_graph, operations_to_install, collected_list, union_of_collected_lists, used_op_names_with_multiples_and_category_getters, i, current_additional_func, x;
+    
+    if IsEmpty( additional_functions ) then
+        
+        Error( "trying to add a final derivation without any functions to install" );
+        
+    fi;
+    
     final_derivation := rec( );
     
     final_derivation.weight := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "Weight", 1 );
@@ -80,28 +95,32 @@ InstallGlobalFunction( AddFinalDerivation,
     final_derivation.category_filter := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "CategoryFilter", IsCapCategory );
     loop_multiplier := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "WeightLoopMultiple", 2 );
     category_getters := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "CategoryGetters", rec( ) );
-    function_called_before_installation := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FunctionCalledBeforeInstallation", false );
+    final_derivation.function_called_before_installation := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "FunctionCalledBeforeInstallation", false );
     
     for i in [ 1 .. Length( additional_functions ) ] do
-        if IsList( additional_functions[i][2] ) then
-            Error( "passing lists of functions to `AddFinalDerivation` is not supported anymore" );
+        
+        if not (IsList( additional_functions[i] ) and Length( additional_functions[i] ) = 2) then
+            
+            Error( "additional functions must be given as pairs [ <operation>, <function> ]" );
+            
         fi;
+        
+        if IsList( additional_functions[i][2] ) then
+            
+            Error( "passing lists of functions to `AddFinalDerivation` is not supported anymore" );
+            
+        fi;
+        
     od;
-    final_derivation.additional_functions := additional_functions;
     
     operations_in_graph := Operations( CAP_INTERNAL_DERIVATION_GRAPH );
     
     ## Find symbols in functions
     operations_to_install := [ ];
     
-    collected_list := CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION( func, operations_in_graph, loop_multiplier, CAP_INTERNAL_METHOD_RECORD_REPLACEMENTS, category_getters );
-    final_derivation.used_ops_with_multiples := collected_list;
+    union_of_collected_lists := [ ];
     
-    Add( operations_to_install, NameFunction( target_op ) );
-    
-    union_of_collected_lists := collected_list;
-    
-    for current_additional_func in final_derivation.additional_functions do
+    for current_additional_func in additional_functions do
         
         collected_list := CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION( current_additional_func[2], operations_in_graph, loop_multiplier, CAP_INTERNAL_METHOD_RECORD_REPLACEMENTS, category_getters );
         
@@ -131,7 +150,7 @@ InstallGlobalFunction( AddFinalDerivation,
         # CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK ensures that all installed operations appear in cannot_compute
         if (Length( x ) = 2 or (Length( x ) = 3 and x[3] = fail)) and x[1] in cannot_compute then
             
-            Error( "A final derivation for ", NameFunction( target_op ), " has precondition ", x[1], " which is also in its exclude list.\n" );
+            Error( "A final derivation for ", NameFunction( additional_functions[1][1] ), " has precondition ", x[1], " which is also in its exclude list.\n" );
             
         fi;
         
@@ -163,18 +182,16 @@ InstallGlobalFunction( AddFinalDerivation,
         SortBy( union_of_collected_lists, x -> x[1] );
         
         Print(
-            "WARNING: You have installed a final derivation for ", NameFunction( target_op ), " with preconditions ", used_op_names_with_multiples_and_category_getters,
+            "WARNING: You have installed a final derivation for ", NameFunction( additional_functions[1][1] ), " with preconditions ", used_op_names_with_multiples_and_category_getters,
             " but the automated detection has detected the following list of preconditions: ", union_of_collected_lists, ".\n",
             "If this is a bug in the automated detection, please report it. If the preconditions cannot be detected automatically, use the option `ConditionsListComplete := true`.\n"
         );
         
     fi;
     
-    final_derivation.target_op := target_op;
+    final_derivation.additional_functions := additional_functions;
     final_derivation.can_compute := used_op_names_with_multiples_and_category_getters;
     final_derivation.cannot_compute := cannot_compute;
-    final_derivation.func := func;
-    final_derivation.function_called_before_installation := function_called_before_installation;
     
     CAP_INTERNAL_FINAL_DERIVATION_SANITY_CHECK( final_derivation );
     
@@ -213,7 +230,7 @@ InstallMethod( Finalize,
     
     if not category!.is_computable then
         
-        derivation_list := Filtered( derivation_list, der -> not NameFunction( der!.target_op ) = "IsCongruentForMorphisms" );
+        derivation_list := Filtered( derivation_list, der -> not ForAny( der.additional_functions, x -> NameFunction( x[1] ) = "IsCongruentForMorphisms" ) );
         
     fi;
     
@@ -320,51 +337,6 @@ InstallMethod( Finalize,
             
             current_final_derivation := Remove( derivation_list, i );
             
-            weight := current_final_derivation.weight;
-            
-            for x in current_final_derivation.used_ops_with_multiples do
-                
-                if x[3] = fail then
-                    
-                    operation_weights := category_operation_weights;
-                    
-                else
-                    
-                    operation_weights := x[3](category)!.derivations_weight_list!.operation_weights;
-                    
-                fi;
-                
-                operation_name := x[1];
-                
-                if not IsBound( operation_weights.(operation_name) ) then
-                    
-                    weight := infinity;
-                    break;
-                    
-                fi;
-                
-                operation_weight := operation_weights.(operation_name);
-                
-                if operation_weight = infinity then
-                    
-                    weight := infinity;
-                    break;
-                    
-                fi;
-                
-                weight := weight + operation_weight * x[2];
-                
-            od;
-            
-            Assert( 0, weight <> infinity );
-            
-            Info( DerivationInfo, 1, Concatenation( "install(",
-                                          String( weight ),
-                                          ") ",
-                                          NameFunction( current_final_derivation.target_op ),
-                                          ": ",
-                                          current_final_derivation.description, " (final derivation)\n" ) );
-            
             ## call function before adding the method
             
             if current_final_derivation.function_called_before_installation <> false then
@@ -373,13 +345,6 @@ InstallMethod( Finalize,
                 
             fi;
             
-            ## Add method
-            add_name := ValueGlobal( Concatenation( [ "Add", NameFunction( current_final_derivation.target_op ) ] ) );
-            
-            # use the add method with signature IsCapCategory, IsList, IsInt to avoid
-            # the convenience for AddZeroObject etc.
-            add_name( category, [ Pair( current_final_derivation.func, [ ] ) ], weight : IsFinalDerivation := true );
-
             for current_additional_func in current_final_derivation.additional_functions do
                 
                 weight := current_final_derivation.weight;

--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2022.10-01",
+Version := "2022.10-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/CartesianCategories/gap/CartesianClosedCategoriesDerivedMethods.gi
+++ b/CartesianCategories/gap/CartesianClosedCategoriesDerivedMethods.gi
@@ -12,7 +12,7 @@
 ####################################
 
 ## Final methods for CartesianDual
-AddFinalDerivation( IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject,
+AddFinalDerivationBundle( # IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject,
                     [ [ IdentityMorphism, 1 ],
                       [ ExponentialOnObjects, 1 ],
                       [ TerminalObject, 1 ] ],
@@ -25,12 +25,14 @@ AddFinalDerivation( IsomorphismFromCartesianDualObjectToExponentialIntoTerminalO
                       DirectProductCartesianDualityCompatibilityMorphismWithGivenObjects,
                       CartesianEvaluationForCartesianDualWithGivenDirectProduct,
                       MorphismFromDirectProductToExponentialWithGivenObjects ],
-                 
+[
+  IsomorphismFromCartesianDualObjectToExponentialIntoTerminalObject,
   function( cat, object )
     
     return IdentityMorphism( cat, ExponentialOnObjects( cat, object, TerminalObject( cat ) ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromExponentialIntoTerminalObjectToCartesianDualObject,
   function( cat, object )

--- a/CartesianCategories/gap/CocartesianCoclosedCategoriesDerivedMethods.gi
+++ b/CartesianCategories/gap/CocartesianCoclosedCategoriesDerivedMethods.gi
@@ -12,7 +12,7 @@
 ####################################
 
 ## Final methods for CocartesianDual
-AddFinalDerivation( IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject,
+AddFinalDerivationBundle( # IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject,
                     [ [ IdentityMorphism, 1 ],
                       [ CoexponentialOnObjects, 1 ],
                       [ InitialObject, 1 ] ],
@@ -26,11 +26,14 @@ AddFinalDerivation( IsomorphismFromCocartesianDualObjectToCoexponentialFromIniti
                       CocartesianEvaluationForCocartesianDualWithGivenCoproduct,
                       MorphismFromCoexponentialToCoproductWithGivenObjects
                       ],
+[
+  IsomorphismFromCocartesianDualObjectToCoexponentialFromInitialObject,
   function( cat, object )
     
     return IdentityMorphism( cat, CoexponentialOnObjects( cat, InitialObject( cat ), object ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromCoexponentialFromInitialObjectToCocartesianDualObject,
   function( cat, object )

--- a/CartesianCategories/gap/HomomorphismStructureDerivedMethods.gi
+++ b/CartesianCategories/gap/HomomorphismStructureDerivedMethods.gi
@@ -12,7 +12,7 @@
 ####################################
 
 ##
-AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
+AddFinalDerivationBundle( # DistinguishedObjectOfHomomorphismStructure,
                     [ [ TerminalObject, 1 ],
                       [ ExponentialOnObjects, 1 ],
                       [ ExponentialOnMorphismsWithGivenExponentials, 1 ],
@@ -28,12 +28,14 @@ AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
                       InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects,
                       InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism
                     ],
-        
+[
+  DistinguishedObjectOfHomomorphismStructure,
   function ( cat )
     
     return TerminalObject( cat );
     
-  end,
+  end
+],
 [
   HomomorphismStructureOnObjects,
   function ( cat, a, b )

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.10-12",
+Version := "2022.10-13",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -279,7 +279,7 @@ end : Description := "WeakBiPushout as the range of DirectSumMorphismToWeakBiPus
 ## Final derivations
 
 ##
-AddFinalDerivation( WeakKernelObject,
+AddFinalDerivationBundle( # WeakKernelObject,
                     [ [ KernelObject, 1 ],
                       [ KernelEmbedding, 1 ],
                       [ KernelLift, 1 ] ],
@@ -287,12 +287,14 @@ AddFinalDerivation( WeakKernelObject,
                     [ WeakKernelObject,
                       WeakKernelEmbedding,
                       WeakKernelLift ],
-                    
+[
+  WeakKernelObject,
   function( cat, morphism )
     
     return KernelObject( cat, morphism );
     
-  end,
+  end
+],
 [
   WeakKernelEmbedding,
   function( cat, morphism )
@@ -311,7 +313,7 @@ AddFinalDerivation( WeakKernelObject,
 ] : Description := "weak kernel using kernel" );
 
 ##
-AddFinalDerivation( WeakCokernelObject,
+AddFinalDerivationBundle( # WeakCokernelObject,
                     [ [ CokernelObject, 1 ],
                       [ CokernelProjection, 1 ],
                       [ CokernelColift, 1 ] ],
@@ -319,12 +321,14 @@ AddFinalDerivation( WeakCokernelObject,
                     [ WeakCokernelObject,
                       WeakCokernelProjection,
                       WeakCokernelColift ],
-                    
+[
+  WeakCokernelObject,
   function( cat, morphism )
     
     return CokernelObject( cat, morphism );
     
-  end,
+  end
+],
 [
   WeakCokernelProjection,
   function( cat, morphism )
@@ -346,7 +350,7 @@ AddFinalDerivation( WeakCokernelObject,
 ## Decision: we use a derivation from weak kernels and direct sums
 
 ##
-AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
+AddFinalDerivationBundle( # WeakBiFiberProductMorphismToDirectSum,
                     [ [ DirectSumDiagonalDifference, 1 ],
                       [ WeakKernelEmbedding, 1 ],
                       [ ProjectionInFactorOfDirectSum, 1 ],
@@ -361,7 +365,8 @@ AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
                       UniversalMorphismIntoWeakBiFiberProduct,
                       WeakBiFiberProductMorphismToDirectSum,
                     ],
-                      
+[
+  WeakBiFiberProductMorphismToDirectSum,
   function( cat, alpha, beta )
     local diagonal_difference;
     
@@ -369,7 +374,8 @@ AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
     
     return WeakKernelEmbedding( cat, diagonal_difference );
     
-  end,
+  end
+],
 [
   ProjectionInFirstFactorOfWeakBiFiberProduct,
   function( cat, alpha, beta )
@@ -408,7 +414,7 @@ AddFinalDerivation( WeakBiFiberProductMorphismToDirectSum,
 
 ## weak bi-pushout
 ##
-AddFinalDerivation( DirectSumMorphismToWeakBiPushout,
+AddFinalDerivationBundle( # DirectSumMorphismToWeakBiPushout,
                     [ [ DirectSumCodiagonalDifference, 1 ],
                       [ WeakCokernelProjection, 1 ],
                       [ InjectionOfCofactorOfDirectSum, 1 ],
@@ -423,7 +429,8 @@ AddFinalDerivation( DirectSumMorphismToWeakBiPushout,
                       UniversalMorphismFromWeakBiPushout,
                       DirectSumMorphismToWeakBiPushout,
                     ],
-                      
+[
+  DirectSumMorphismToWeakBiPushout,
   function( cat, alpha, beta )
     local co_diagonal_difference;
     
@@ -431,7 +438,8 @@ AddFinalDerivation( DirectSumMorphismToWeakBiPushout,
     
     return WeakCokernelProjection( cat, co_diagonal_difference );
     
-end,
+end
+],
 [
   InjectionOfFirstCofactorOfWeakBiPushout,
   function( cat, alpha, beta )

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.10-04",
+Version := "2022.10-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
+++ b/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
@@ -50,7 +50,7 @@ BindGlobal( "CATEGORY_FILTER_CHECKER",
 end );
 
 ##
-AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
+AddFinalDerivationBundle( # DistinguishedObjectOfHomomorphismStructure,
                     [
                       [ BasisOfExternalHom, 3 ], # part of CoefficientsOfMorphism
                       [ CoefficientsOfMorphismWithGivenBasisOfExternalHom, 2 ],
@@ -65,7 +65,8 @@ AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
                       InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure,
                       InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism
                     ],
-  
+[
+  DistinguishedObjectOfHomomorphismStructure,
   function( cat )
     local k;
     
@@ -73,7 +74,8 @@ AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
     
     return VectorSpaceObject( 1, k );
     
-  end,
+  end
+],
 [
   HomomorphismStructureOnObjects,
   function( cat, a, b )

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.10-01",
+Version := "2022.10-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesDerivedMethods.gi
@@ -9,7 +9,7 @@
 ####################################
 
 ## Final methods for Dual
-AddFinalDerivation( IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
+AddFinalDerivationBundle( # IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
                     [ [ IdentityMorphism, 1 ],
                       [ InternalHomOnObjects, 1 ],
                       [ TensorUnit, 1 ] ],
@@ -22,12 +22,14 @@ AddFinalDerivation( IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
                       TensorProductDualityCompatibilityMorphismWithGivenObjects,
                       EvaluationForDualWithGivenTensorProduct,
                       MorphismFromTensorProductToInternalHomWithGivenObjects ],
-                 
+[
+  IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
   function( cat, object )
     
     return IdentityMorphism( cat, InternalHomOnObjects( cat, object, TensorUnit( cat ) ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromInternalHomIntoTensorUnitToDualObject,
   function( cat, object )

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesDerivedMethods.gi
@@ -9,7 +9,7 @@
 ####################################
 
 ## Final methods for CoDual
-AddFinalDerivation( IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
+AddFinalDerivationBundle( # IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
                     [ [ IdentityMorphism, 1 ],
                       [ InternalCoHomOnObjects, 1 ],
                       [ TensorUnit, 1 ] ],
@@ -23,11 +23,14 @@ AddFinalDerivation( IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
                       CoclosedEvaluationForCoDualWithGivenTensorProduct,
                       MorphismFromInternalCoHomToTensorProductWithGivenObjects
                       ],
+[
+  IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
   function( cat, object )
     
     return IdentityMorphism( cat, InternalCoHomOnObjects( cat, TensorUnit( cat ), object ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject,
   function( cat, object )

--- a/MonoidalCategories/gap/HomomorphismStructureDerivedMethods.gi
+++ b/MonoidalCategories/gap/HomomorphismStructureDerivedMethods.gi
@@ -9,7 +9,7 @@
 ####################################
 
 ##
-AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
+AddFinalDerivationBundle( # DistinguishedObjectOfHomomorphismStructure,
                     [ [ TensorUnit, 1 ],
                       [ InternalHomOnObjects, 1 ],
                       [ InternalHomOnMorphismsWithGivenInternalHoms, 1 ],
@@ -25,12 +25,14 @@ AddFinalDerivation( DistinguishedObjectOfHomomorphismStructure,
                       InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects,
                       InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism
                     ],
-        
+[
+  DistinguishedObjectOfHomomorphismStructure,
   function ( cat )
     
     return TensorUnit( cat );
     
-  end,
+  end
+],
 [
   HomomorphismStructureOnObjects,
   function ( cat, a, b )

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesDerivedMethods.gi
@@ -519,7 +519,7 @@ end : CategoryFilter := IsRigidSymmetricClosedMonoidalCategory,
 ## Final methods for InternalHom
 
 ##
-AddFinalDerivation( IsomorphismFromTensorProductWithDualObjectToInternalHom,
+AddFinalDerivationBundle( # IsomorphismFromTensorProductWithDualObjectToInternalHom,
                     [ [ IdentityMorphism, 1 ],
                       [ DualOnObjects, 1 ],
                       [ RightUnitor, 1 ],
@@ -542,12 +542,14 @@ AddFinalDerivation( IsomorphismFromTensorProductWithDualObjectToInternalHom,
                       IsomorphismFromInternalHomIntoTensorUnitToDualObject,
                       IsomorphismFromDualObjectToInternalHomIntoTensorUnit,
                     ],
-                    
+[
+  IsomorphismFromTensorProductWithDualObjectToInternalHom,
   function( cat, a, b )
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, DualOnObjects( cat, a ), b ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromInternalHomToTensorProductWithDualObject,
   function( cat, a, b )

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods.gi
@@ -425,7 +425,7 @@ end : CategoryFilter := IsRigidSymmetricCoclosedMonoidalCategory,
 ## Final methods for InternalCoHom
 
 ##
-AddFinalDerivation( IsomorphismFromTensorProductWithCoDualObjectToInternalCoHom,
+AddFinalDerivationBundle( # IsomorphismFromTensorProductWithCoDualObjectToInternalCoHom,
                     [ [ IdentityMorphism, 1 ],
                       [ CoDualOnObjects, 1 ],
                       [ LeftUnitor, 1 ],
@@ -448,12 +448,14 @@ AddFinalDerivation( IsomorphismFromTensorProductWithCoDualObjectToInternalCoHom,
                       IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject,
                       IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit,
                     ],
-                    
+[
+  IsomorphismFromTensorProductWithCoDualObjectToInternalCoHom,
   function( cat, a, b )
     
     return IdentityMorphism( cat, TensorProductOnObjects( cat, a, CoDualOnObjects( cat, b ) ) );
     
-  end,
+  end
+],
 [
   IsomorphismFromInternalCoHomToTensorProductWithCoDualObject,
   function( cat, a, b )


### PR DESCRIPTION
which does not have a target_op but only a list of "additional" functions.

AddFinalDerivation is a special case of this by treating [ target_op , func ]
just as another "additional" function. This allows to simplify `Finalize`.