### PR TITLE
Remove restrictions of derivations of (Co)Equalizer

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.10-12",
+Version := "2022.11-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2718,8 +2718,7 @@ function( cat, A, diagram )
     
     return Source( EmbeddingOfEqualizer( cat, A, diagram ) );
     
-end : CategoryFilter := cat -> not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ),
-      Description := "Equalizer as the source of EmbeddingOfEqualizer" );
+end : Description := "Equalizer as the source of EmbeddingOfEqualizer" );
 
 ##
 AddDerivationToCAP( Coequalizer,
@@ -2729,8 +2728,7 @@ AddDerivationToCAP( Coequalizer,
     
     return Range( ProjectionOntoCoequalizer( cat, A, diagram ) );
     
-end : CategoryFilter := cat -> not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ),
-      Description := "Coequalizer as the range of ProjectionOntoCoequalizer" );
+end : Description := "Coequalizer as the range of ProjectionOntoCoequalizer" );
 
 ##
 AddDerivationToCAP( HomologyObject,


### PR DESCRIPTION
Since c644a8f7c6e2eca97063a1bd915de20d7c5849a2 computing EmbeddingOfEqualizer of an empty diagram is fine.
