### PR TITLE
add `CoefficientsOfMorphism` to the categorical-methods record

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.11-05",
+Version := "2022.11-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -202,20 +202,20 @@ DeclareOperation( "AddCoastrictionToImageWithGivenImageObject",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
-#! to the category for the basic operation `CoefficientsOfMorphismWithGivenBasisOfExternalHom`.
-#! $F: ( arg2, arg3 ) \mapsto \mathtt{CoefficientsOfMorphismWithGivenBasisOfExternalHom}(arg2, arg3)$.
+#! to the category for the basic operation `CoefficientsOfMorphism`.
+#! $F: ( arg2 ) \mapsto \mathtt{CoefficientsOfMorphism}(arg2)$.
 #! @Returns nothing
 #! @Arguments C, F
-DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphism",
                   [ IsCapCategory, IsFunction ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphism",
                   [ IsCapCategory, IsFunction, IsInt ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphism",
                   [ IsCapCategory, IsList, IsInt ] );
 
-DeclareOperation( "AddCoefficientsOfMorphismWithGivenBasisOfExternalHom",
+DeclareOperation( "AddCoefficientsOfMorphism",
                   [ IsCapCategory, IsList ] );
 
 #! @Description

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -358,33 +358,23 @@ InstallMethod( Simplify,
     
 end );
 
+##
+InstallOtherMethod( CoefficientsOfMorphismWithGivenBasisOfExternalHom,
+          [ IsCapCategory, IsCapCategoryMorphism, IsList ],
+
+  function( cat, morphism, basis )
+    
+    Display( "WARNING: CoefficientsOfMorphismWithGivenBasisOfExternalHom is deprecated and will not be supported after 2023.10.30. Please use CoefficientsOfMorphism instead!\n" );
+    
+    return CoefficientsOfMorphism( cat, morphism );
+    
+end );
 
 ##
-CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD(
-  rec(
-    CoefficientsOfMorphism := [
-        [ "BasisOfExternalHom", 1 ],
-        [ "CoefficientsOfMorphismWithGivenBasisOfExternalHom", 1 ],
-    ],
-  )
- );
+InstallMethod( CoefficientsOfMorphismWithGivenBasisOfExternalHom,
+          [ IsCapCategoryMorphism, IsList ],
 
-InstallMethod( CoefficientsOfMorphism,
-              [ IsCapCategoryMorphism ],
-  function( alpha )
-    
-    return CoefficientsOfMorphism( CapCategory( alpha ), alpha );
-    
-end );
-
-InstallOtherMethod( CoefficientsOfMorphism,
-              [ IsCapCategory, IsCapCategoryMorphism ],
-  function( cat, alpha )
-    
-    return CoefficientsOfMorphismWithGivenBasisOfExternalHom( cat, alpha, BasisOfExternalHom( cat, Source( alpha ), Range( alpha ) ) );
-    
-end );
-
+  { morphism, basis } -> CoefficientsOfMorphismWithGivenBasisOfExternalHom( CapCategory( morphism ), morphism, basis ) );
 
 ######################################
 ##

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -3507,11 +3507,11 @@ AddFinalDerivationBundle( # BasisOfExternalHom,
                       [ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure, 1 ],
                       [ DistinguishedObjectOfHomomorphismStructure, 1 ],
                       [ BasisOfExternalHom, 1, RangeCategoryOfHomomorphismStructure ],
-                      [ CoefficientsOfMorphismWithGivenBasisOfExternalHom, 1, RangeCategoryOfHomomorphismStructure ],
+                      [ CoefficientsOfMorphism, 1, RangeCategoryOfHomomorphismStructure ],
                     ],
                     [
                       BasisOfExternalHom,
-                      CoefficientsOfMorphismWithGivenBasisOfExternalHom
+                      CoefficientsOfMorphism
                     ],
 [
   BasisOfExternalHom,
@@ -3531,8 +3531,8 @@ AddFinalDerivationBundle( # BasisOfExternalHom,
   end
 ],
 [
-  CoefficientsOfMorphismWithGivenBasisOfExternalHom,
-  function( cat, alpha, L )
+  CoefficientsOfMorphism,
+  function( cat, alpha )
     local range_cat, beta;
     
     range_cat := RangeCategoryOfHomomorphismStructure( cat );
@@ -3583,5 +3583,5 @@ AddFinalDerivationBundle( # BasisOfExternalHom,
       return true;
       
   end,
-  Description := "Adding BasisOfExternalHom using homomorphism structure"
+  Description := "Adding BasisOfExternalHom and CoefficientsOfMorphism using homomorphism structure"
 );

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -3446,10 +3446,10 @@ BasisOfExternalHom := rec(
   dual_arguments_reversed := true
 ),
 
-CoefficientsOfMorphismWithGivenBasisOfExternalHom := rec(
-  filter_list := [ "category", "morphism", "list_of_morphisms" ],
+CoefficientsOfMorphism := rec(
+  filter_list := [ "category", "morphism" ],
   return_type := IsList,
-  dual_operation := "CoefficientsOfMorphismWithGivenBasisOfExternalHom",
+  dual_operation := "CoefficientsOfMorphism",
   dual_postprocessor_func := IdFunc
 ),
 

--- a/CAP/gap/WrapperCategory.gi
+++ b/CAP/gap/WrapperCategory.gi
@@ -410,14 +410,12 @@ InstallMethod( WrapperCategory,
         
     fi;
     
-    if "CoefficientsOfMorphismWithGivenBasisOfExternalHom" in list_of_operations_to_install then
+    if "CoefficientsOfMorphism" in list_of_operations_to_install then
         
-        AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( D,
-          function( cat, alpha, L )
+        AddCoefficientsOfMorphism( D,
+          function( cat, alpha )
             
-            return CoefficientsOfMorphismWithGivenBasisOfExternalHom( ModelingCategory( cat ),
-                           ModelingMorphism( cat, alpha ),
-                           List( L, l -> ModelingMorphism( cat, l ) ) );
+            return CoefficientsOfMorphism( ModelingCategory( cat ), ModelingMorphism( cat, alpha ) );
             
         end );
         

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2022.11-02",
+Version := "2022.11-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -87,7 +87,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12.1",
-  NeededOtherPackages := [ [ "CAP", ">= 2022.11-04" ],
+  NeededOtherPackages := [ [ "CAP", ">= 2022.11-06" ],
                            [ "MatricesForHomalg", ">= 2021.07-01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "MonoidalCategories", ">= 2022.06-01" ],

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -327,7 +327,7 @@
 #! * <Ref BookName="CAP" Func="BasisOfExternalHom" Label="for Is" />
 #! * <Ref BookName="CAP" Func="CoastrictionToImage" Label="for Is" />
 #! * <Ref BookName="CAP" Func="CoastrictionToImageWithGivenImageObject" Label="for Is" />
-#! * <Ref BookName="CAP" Func="CoefficientsOfMorphismWithGivenBasisOfExternalHom" Label="for Is" />
+#! * <Ref BookName="CAP" Func="CoefficientsOfMorphism" Label="for Is" />
 #! * <Ref BookName="CAP" Func="CoimageObject" Label="for Is" />
 #! * <Ref BookName="CAP" Func="CoimageProjection" Label="for Is" />
 #! * <Ref BookName="CAP" Func="CoimageProjectionWithGivenCoimageObject" Label="for Is" />

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -750,8 +750,8 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
       end );
       
       ##
-      AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( category,
-        function( cat, morphism, L )
+      AddCoefficientsOfMorphism( category,
+        function( cat, morphism )
           
           return EntriesOfHomalgMatrix( UnderlyingMatrix( morphism ) );
           

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -122,10 +122,10 @@ end
     , 100 );
     
     ##
-    AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
+    AddCoefficientsOfMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1 )
+function ( cat_1, arg2_1 )
     return EntriesOfHomalgMatrix( UnderlyingMatrix( arg2_1 ) );
 end
 ########

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.11-02",
+Version := "2022.11-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -89,7 +89,7 @@ Dependencies := rec(
   NeededOtherPackages := [ [ "ToolsForHomalg", ">=2015.09.18" ],
                            [ "MatricesForHomalg", ">= 2021.12-01" ],
                            [ "GaussForHomalg", ">= 2021.04-02" ],
-                           [ "CAP", ">= 2022.11-04" ],
+                           [ "CAP", ">= 2022.11-06" ],
                            [ "MonoidalCategories", ">= 2022.06-01" ],
                            ],
   SuggestedOtherPackages := [

--- a/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
+++ b/LinearAlgebraForCAP/gap/DerivedMethodsForMatrixCategories.gi
@@ -52,8 +52,8 @@ end );
 ##
 AddFinalDerivationBundle( # DistinguishedObjectOfHomomorphismStructure,
                     [
-                      [ BasisOfExternalHom, 3 ], # part of CoefficientsOfMorphism
-                      [ CoefficientsOfMorphismWithGivenBasisOfExternalHom, 2 ],
+                      [ BasisOfExternalHom, 1 ],
+                      [ CoefficientsOfMorphism, 2 ],
                       [ MultiplyWithElementOfCommutativeRingForMorphisms, 2 ],
                       [ ZeroMorphism, 1 ],
                       [ PreCompose, 2 ],

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -648,10 +648,10 @@ end
     , 2308 : IsPrecompiledDerivation := true );
     
     ##
-    AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
+    AddCoefficientsOfMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1 )
+function ( cat_1, arg2_1 )
     return EntriesOfHomalgMatrix( UnderlyingMatrix( arg2_1 ) );
 end
 ########

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -138,10 +138,10 @@ end
     , 100 );
     
     ##
-    AddCoefficientsOfMorphismWithGivenBasisOfExternalHom( cat,
+    AddCoefficientsOfMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1 )
+function ( cat_1, arg2_1 )
     return EntriesOfHomalgMatrix( UnderlyingMatrix( Opposite( arg2_1 ) ) );
 end
 ########


### PR DESCRIPTION
instead of `CoefficientsOfMorphismWithGivenBasisOfExternalHom`, and support `CoefficientsOfMorphismWithGivenBasisOfExternalHom` as a GAP method until `30.10.2023`.

why? the basis of external-hom is simply dropped in all installations of `CoefficientsOfMorphismWithGivenBasisOfExternalHom` previous to this commit causing unjustified inefficiency.