### PR TITLE
d&a PostInverse/PreInverseForMorphisms together with two derivation methods

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.11-08",
+Version := "2022.11-09",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/Liftable.g
+++ b/CAP/examples/Liftable.g
@@ -23,4 +23,8 @@ IsColiftable( gamma, beta );
 #! false
 IsColiftableAlongEpimorphism( beta, gamma );
 #! true
+PreCompose( PreInverseForMorphisms( gamma ), gamma ) = IdentityMorphism( V );
+#! true
+PreCompose( alpha, PostInverseForMorphisms( alpha ) ) = IdentityMorphism( V );
+#! true
 #! @EndExample

--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -3356,6 +3356,25 @@ DeclareOperation( "AddPostComposeList",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
+#! to the category for the basic operation `PostInverseForMorphisms`.
+#! $F: ( alpha ) \mapsto \mathtt{PostInverseForMorphisms}(alpha)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddPostInverseForMorphisms",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddPostInverseForMorphisms",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddPostInverseForMorphisms",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddPostInverseForMorphisms",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
 #! to the category for the basic operation `PreCompose`.
 #! $F: ( alpha, beta ) \mapsto \mathtt{PreCompose}(alpha, beta)$.
 #! @Returns nothing
@@ -3389,6 +3408,25 @@ DeclareOperation( "AddPreComposeList",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddPreComposeList",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation `PreInverseForMorphisms`.
+#! $F: ( alpha ) \mapsto \mathtt{PreInverseForMorphisms}(alpha)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddPreInverseForMorphisms",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddPreInverseForMorphisms",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddPreInverseForMorphisms",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddPreInverseForMorphisms",
                   [ IsCapCategory, IsList ] );
 
 #! @Description

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -886,6 +886,26 @@ DeclareOperation( "IsColiftable",
 DeclareOperation( "InverseForMorphisms",
                   [ IsCapCategoryMorphism ] );
 
+#! @Description
+#! The argument is a split-epimorphism $\alpha: a \rightarrow b$.
+#! The output is a pre-inverse $\iota: b \rightarrow a$ of $\alpha$,
+#! i.e., $\iota$ satisfies $\alpha \circ \iota \sim_{b,b} \mathrm{id}_b$.
+#! The morphism $\iota$ is also known as a section or a right-inverse of $\alpha$.
+#! @Returns a morphism in $\mathrm{Hom}(b,a)$
+#! @Arguments alpha
+DeclareOperation( "PreInverseForMorphisms",
+                  [ IsCapCategoryMorphism ] );
+
+#! @Description
+#! The argument is a split-monomorphism $\alpha: a \rightarrow b$.
+#! The output is a post-inverse $\pi: b \rightarrow a$ of $\alpha$,
+#! i.e., $\pi$ satisfies $\pi \circ \alpha \sim_{a,a} \mathrm{id}_a$.
+#! The morphism $\pi$ is also known as a contraction or a left-inverse of $\alpha$.
+#! @Returns a morphism in $\mathrm{Hom}(b,a)$
+#! @Arguments alpha
+DeclareOperation( "PostInverseForMorphisms",
+                  [ IsCapCategoryMorphism ] );
+
 ###################################
 ##
 #! @Section Tool functions for caches

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1310,6 +1310,28 @@ AddDerivationToCAP( InverseForMorphisms,
 end : Description := "InverseForMorphisms using ColiftAlongEpimorphism of an identity morphism" );
 
 ##
+AddDerivationToCAP( PreInverseForMorphisms,
+                    [ [ IdentityMorphism, 1 ],
+                      [ Lift, 1 ] ],
+  
+  function( cat, mor )
+    
+    return Lift( cat, IdentityMorphism( cat, Range( mor ) ), mor );
+    
+end : Description := "PreInverseForMorphisms using IdentityMorphism and Lift" );
+
+##
+AddDerivationToCAP( PostInverseForMorphisms,
+                    [ [ IdentityMorphism, 1 ],
+                      [ Colift, 1 ] ],
+  
+  function( cat, mor )
+    
+    return Colift( cat, mor, IdentityMorphism( cat, Source( mor ) ) );
+    
+end : Description := "PostInverseForMorphisms using IdentityMorphism and Colift" );
+
+##
 AddDerivationToCAP( AdditionForMorphisms,
                     [ [ SumOfMorphisms, 1 ] ],
                     

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -307,6 +307,22 @@ InverseForMorphisms := rec(
   compatible_with_congruence_of_morphisms := true,
 ),
 
+PreInverseForMorphisms := rec(
+  filter_list := [ "category", "morphism" ],
+  io_type := [ [ "alpha" ], [ "alpha_range", "alpha_source" ] ],
+  return_type := "morphism",
+  dual_operation := "PostInverseForMorphisms",
+  is_merely_set_theoretic := true
+),
+
+PostInverseForMorphisms := rec(
+  filter_list := [ "category", "morphism" ],
+  io_type := [ [ "alpha" ], [ "alpha_range", "alpha_source" ] ],
+  return_type := "morphism",
+  dual_operation := "PreInverseForMorphisms",
+  is_merely_set_theoretic := true
+),
+
 KernelObject := rec(
   filter_list := [ "category", "morphism" ],
   return_type := "object",

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -98,8 +98,10 @@
 #! * <Ref BookName="CAP" Func="ObjectDatum" Label="for Is" />
 #! * <Ref BookName="CAP" Func="PostCompose" Label="for Is" />
 #! * <Ref BookName="CAP" Func="PostComposeList" Label="for Is" />
+#! * <Ref BookName="CAP" Func="PostInverseForMorphisms" Label="for Is" />
 #! * <Ref BookName="CAP" Func="PreCompose" Label="for Is" />
 #! * <Ref BookName="CAP" Func="PreComposeList" Label="for Is" />
+#! * <Ref BookName="CAP" Func="PreInverseForMorphisms" Label="for Is" />
 #! * <Ref BookName="CAP" Func="ProjectionInFactorOfDirectProduct" Label="for Is" />
 #! * <Ref BookName="CAP" Func="ProjectionInFactorOfDirectProductWithGivenDirectProduct" Label="for Is" />
 #! * <Ref BookName="CAP" Func="ProjectionInFactorOfDirectSum" Label="for Is" />

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -15,7 +15,7 @@ S := GradedRing( Q["x,y"] );
 Sgrmod := GradedLeftPresentations( S );
 #! The category of graded left f.p. modules over Q[x,y] (with weights [ 1, 1 ])
 InfoOfInstalledOperationsOfCategory( Sgrmod );
-#! 40 primitive operations were used to derive 199 operations for this category
+#! 40 primitive operations were used to derive 201 operations for this category
 #! which algorithmically
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2022.11-06",
+Version := "2022.11-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -89,7 +89,7 @@ Dependencies := rec(
   NeededOtherPackages := [ [ "ToolsForHomalg", ">=2015.09.18" ],
                            [ "MatricesForHomalg", ">= 2021.12-01" ],
                            [ "GaussForHomalg", ">= 2021.04-02" ],
-                           [ "CAP", ">= 2022.11-06" ],
+                           [ "CAP", ">= 2022.11-09" ],
                            [ "MonoidalCategories", ">= 2022.06-01" ],
                            ],
   SuggestedOtherPackages := [

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -4390,6 +4390,19 @@ end
     , 102 : IsPrecompiledDerivation := true );
     
     ##
+    AddPostInverseForMorphisms( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1;
+    deduped_1_1 := Source( alpha_1 );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), deduped_1_1, UnderlyingMatrix, LeftDivide( UnderlyingMatrix( alpha_1 ), HomalgIdentityMatrix( Dimension( deduped_1_1 ), UnderlyingRing( cat_1 ) ) ) );
+end
+########
+        
+    , 201 : IsPrecompiledDerivation := true );
+    
+    ##
     AddPreCompose( cat,
         
 ########
@@ -4414,6 +4427,19 @@ end
 ########
         
     , 101 : IsPrecompiledDerivation := true );
+    
+    ##
+    AddPreInverseForMorphisms( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1;
+    deduped_1_1 := Range( alpha_1 );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_1_1, Source( alpha_1 ), UnderlyingMatrix, RightDivide( HomalgIdentityMatrix( Dimension( deduped_1_1 ), UnderlyingRing( cat_1 ) ), UnderlyingMatrix( alpha_1 ) ) );
+end
+########
+        
+    , 201 : IsPrecompiledDerivation := true );
     
     ##
     AddProjectionInFactorOfDirectProduct( cat,

--- a/MonoidalCategories/examples/TerminalCategory.g
+++ b/MonoidalCategories/examples/TerminalCategory.g
@@ -6,7 +6,7 @@ LoadPackage( "MonoidalCategories" );
 T := TerminalCategory( );
 #! TerminalCategory( )
 InfoOfInstalledOperationsOfCategory( T );
-#! 68 primitive operations were used to derive 318 operations for this category
+#! 68 primitive operations were used to derive 320 operations for this category
 #! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing

--- a/MonoidalCategories/examples/TerminalCategoryWithMultipleObjects.g
+++ b/MonoidalCategories/examples/TerminalCategoryWithMultipleObjects.g
@@ -6,7 +6,7 @@ LoadPackage( "MonoidalCategories" );
 T := TerminalCategoryWithMultipleObjects( );
 #! TerminalCategoryWithMultipleObjects( )
 InfoOfInstalledOperationsOfCategory( T );
-#! 68 primitive operations were used to derive 318 operations for this category
+#! 68 primitive operations were used to derive 320 operations for this category
 #! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing


### PR DESCRIPTION
These are, up to their names, copy & paste of the same methods in `CategoryConstructor` package:

https://github.com/homalg-project/CategoryConstructor/blob/5b33ddfbefc58f4923fe8ff74fd4337e349e5209/gap/ToolsMethodRecord.gi#L47-L61