### PR TITLE
Create types in Derivations.gi only once

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.11-22",
+Version := "2022.11-23",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -11,7 +11,13 @@ BindGlobal( "TheFamilyOfDerivationGraphs",
             NewFamily( "TheFamilyOfDerivationGraphs" ) );
 BindGlobal( "TheFamilyOfOperationWeightLists",
             NewFamily( "TheFamilyOfOperationWeightLists" ) );
+BindGlobal( "TheFamilyOfStringMinHeaps",
+            NewFamily( "TheFamilyOfStringMinHeaps" ) );
 
+BindGlobal( "TheTypeOfDerivedMethods", NewType( TheFamilyOfDerivations, IsDerivedMethod ) );
+BindGlobal( "TheTypeOfDerivationsGraphs", NewType( TheFamilyOfDerivationGraphs, IsDerivedMethodGraph ) );
+BindGlobal( "TheTypeOfOperationWeightLists", NewType( TheFamilyOfOperationWeightLists, IsOperationWeightList ) );
+BindGlobal( "TheTypeOfStringMinHeaps", NewType( TheFamilyOfStringMinHeaps, IsStringMinHeap ) );
 
 InstallGlobalFunction( "ActivateDerivationInfo",
   function( )
@@ -41,7 +47,7 @@ function( name, target_op, used_op_names_with_multiples_and_category_getters, we
     fi;
     
     return ObjectifyWithAttributes(
-        rec( ), NewType( TheFamilyOfDerivations, IsDerivedMethod ),
+        rec( ), TheTypeOfDerivedMethods,
         DerivationName, name,
         DerivationWeight, weight,
         DerivationFunction, func,
@@ -134,9 +140,7 @@ function( operations )
   local G, op_name;
   G := rec( derivations_by_target := rec(),
               derivations_by_used_ops := rec() );
-  G := ObjectifyWithAttributes( G,
-      NewType( TheFamilyOfDerivationGraphs,
-               IsDerivedMethodGraph ) );
+  G := ObjectifyWithAttributes( G, TheTypeOfDerivationsGraphs );
   
   SetOperations( G, operations );
   
@@ -415,7 +419,7 @@ function( C, G )
     od;
     
     owl := ObjectifyWithAttributes(
-        rec( operation_weights := operation_weights, operation_derivations := operation_derivations ), NewType( TheFamilyOfOperationWeightLists, IsOperationWeightList ),
+        rec( operation_weights := operation_weights, operation_derivations := operation_derivations ), TheTypeOfOperationWeightLists,
         DerivationGraph, G,
         CategoryOfOperationWeightList, C
     );
@@ -696,13 +700,9 @@ function( owl, op_name )
 end );
 
 
-BindGlobal( "TheFamilyOfStringMinHeaps",
-            NewFamily( "TheFamilyOfStringMinHeaps" ) );
-
 InstallGlobalFunction( StringMinHeap,
 function()
-  return Objectify( NewType( TheFamilyOfStringMinHeaps,
-                             IsStringMinHeap ),
+  return Objectify( TheTypeOfStringMinHeaps,
                     rec( key := function(n) return n[2]; end,
                          str := function(n) return n[1]; end,
                          array := [],

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -29,7 +29,7 @@ InstallGlobalFunction( CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY,
     completed_record := ShallowCopy( input_record );
     
     list_of_operations_to_install :=
-      Concatenation( List( RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ), p -> CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.(p) ) );
+      Set( Concatenation( List( RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD ), p -> CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.(p) ) ) );
     
     skip := [ ];
     


### PR DESCRIPTION
This speeds up package loading in Julia by a factor of 2 :o In GAP it does not really make a difference because `NewType` has a cache.

The second commit is a minor optimization.