### PR TITLE
Only derive (co)image via kernel and cokernel if category is abelian

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2022.12-15",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1841,7 +1841,8 @@ AddDerivationToCAP( IsomorphismFromImageObjectToKernelOfCokernel,
     
     return UniversalMorphismFromImage( cat, morphism, [ morphism_to_kernel, kernel_emb ] );
     
-end : Description := "IsomorphismFromImageObjectToKernelOfCokernel using the universal property of the image" );
+end : CategoryFilter := IsAbelianCategory,
+      Description := "IsomorphismFromImageObjectToKernelOfCokernel using the universal property of the image" );
 
 ##
 AddDerivationToCAP( IsomorphismFromCokernelOfKernelToCoimage,
@@ -1864,7 +1865,8 @@ AddDerivationToCAP( IsomorphismFromCokernelOfKernelToCoimage,
     
     return UniversalMorphismIntoCoimage( cat, morphism, [ cokernel_proj, morphism_from_cokernel ] );
     
-end : Description := "IsomorphismFromCokernelOfKernelToCoimage using the universal property of the coimage" );
+end : CategoryFilter := IsAbelianCategory,
+      Description := "IsomorphismFromCokernelOfKernelToCoimage using the universal property of the coimage" );
 
 ##
 AddDerivationToCAP( IsomorphismFromCoimageToCokernelOfKernel,
@@ -3911,7 +3913,8 @@ AddFinalDerivationBundle( # IsomorphismFromImageObjectToKernelOfCokernel,
     return IdentityMorphism( cat, kernel_of_cokernel );
     
   end,
-] : Description := "IsomorphismFromImageObjectToKernelOfCokernel as the identity of the kernel of the cokernel" );
+] : CategoryFilter := IsAbelianCategory,
+    Description := "IsomorphismFromImageObjectToKernelOfCokernel as the identity of the kernel of the cokernel" );
 
 ##
 AddDerivationToCAP( MorphismFromCoimageToImageWithGivenObjects,
@@ -3993,7 +3996,8 @@ AddFinalDerivationBundle( # IsomorphismFromCoimageToCokernelOfKernel,
     return IdentityMorphism( cat, cokernel_of_kernel );
     
   end,
-] : Description := "IsomorphismFromCoimageToCokernelOfKernel as the identity of the cokernel of the kernel" );
+] : CategoryFilter := IsAbelianCategory,
+    Description := "IsomorphismFromCoimageToCokernelOfKernel as the identity of the cokernel of the kernel" );
 
 ## Final methods for initial object
 


### PR DESCRIPTION
This condition originally was part of the final derivation for `ImageEmbedding` (before `IsomorphismFromImageObjectToKernelOfCokernel` etc. existed) but was lost in d2734eeb70542ffcd3206107a972c198967a5d11.