### PR TITLE
Deprecate compiler_hints.{category,object,morphism}_filter

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.01-02",
+Version := "2023.01-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryConstructor.gi
+++ b/CAP/gap/CategoryConstructor.gi
@@ -87,25 +87,6 @@ InstallMethod( CategoryConstructor,
     
     CC!.compiler_hints := rec( );
     
-    ## set filters and attributes
-    if IsBound( options.category_filter ) then
-        
-        CC!.compiler_hints.category_filter := options.category_filter;
-        
-    fi;
-    
-    if IsBound( options.category_object_filter ) then
-        
-        CC!.compiler_hints.object_filter := options.category_object_filter;
-        
-    fi;
-    
-    if IsBound( options.category_morphism_filter ) then
-        
-        CC!.compiler_hints.morphism_filter := options.category_morphism_filter;
-        
-    fi;
-    
     if IsBound( options.commutative_ring_of_linear_category ) then
         
         SetCommutativeRingOfLinearCategory( CC, options.commutative_ring_of_linear_category );

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -366,9 +366,6 @@ InstallMethod( Opposite,
         category_attribute_names := [
             "OppositeCategory",
         ],
-        category_filter := WasCreatedAsOppositeCategory,
-        object_filter := IsCapCategoryOppositeObject,
-        morphism_filter := IsCapCategoryOppositeMorphism,
     );
     
     SetOppositeCategory( opposite_category, category );

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.01-01",
+Version := "2023.01-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/doc/Usage.autodoc
+++ b/CompilerForCAP/doc/Usage.autodoc
@@ -100,7 +100,7 @@ You can give hints to the compiler to improve the result of the compilation. Com
                                                          of a morphism by `source_attribute_getter_name` (resp. `range_attribute_getter_name`) applied to
                                                          the attribute `morphism_attribute_name` of the morphism. Can be used if objects and morphisms can be
                                                          easily created from the morphism datum anyway. Note: Some simple expressions like integers are NOT replaced.
-* `{category,object,morphism}_filter`: filters used for the data types of the category and its objects and morphisms.
+* `{category,object,morphism}_filter`: (Deprecated: Use `CreateCapCategoryWithDataTypes` instead) filters used for the data types of the category and its objects and morphisms.
 
 Note: The compiler can only discover the hints if the category is the first argument of the function.
 

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.01-01",
+Version := "2023.01-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -87,7 +87,7 @@ InstallMethod( ADDITIVE_CLOSURE,
         
     fi;
     
-    category := CreateCapCategory( Concatenation( "Additive closure( ", Name( underlying_category )," )"  ) );
+    category := CreateCapCategory( Concatenation( "Additive closure( ", Name( underlying_category )," )" ), IsAdditiveClosureCategory, IsAdditiveClosureObject, IsAdditiveClosureMorphism, IsCapCategoryTwoCell );
     
     category!.category_as_first_argument := true;
     
@@ -97,9 +97,6 @@ InstallMethod( ADDITIVE_CLOSURE,
         category_attribute_names := [
             "UnderlyingCategory",
         ],
-        category_filter := IsAdditiveClosureCategory,
-        object_filter := IsAdditiveClosureObject,
-        morphism_filter := IsAdditiveClosureMorphism,
     );
     
     if ValueOption( "matrix_element_as_morphism" ) <> fail or ValueOption( "list_list_as_matrix" ) <> fail then
@@ -112,15 +109,9 @@ InstallMethod( ADDITIVE_CLOSURE,
         
     fi;
     
-    SetFilterObj( category, IsAdditiveClosureCategory );
-    
     SetIsAdditiveCategory( category, true );
     
     SetUnderlyingCategory( category, underlying_category );
-    
-    AddObjectRepresentation( category, IsAdditiveClosureObject );
-    
-    AddMorphismRepresentation( category, IsAdditiveClosureMorphism and HasMorphismMatrix );
     
     if HasIsLinearCategoryOverCommutativeRing( underlying_category ) and
         HasCommutativeRingOfLinearCategory( underlying_category ) then

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gi
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gi
@@ -39,7 +39,7 @@ InstallMethod( AdelmanCategory,
         
     fi;
     
-    adelman_category := CreateCapCategory( Concatenation( "Adelman category( ", Name( underlying_category ), " )" ) );
+    adelman_category := CreateCapCategory( Concatenation( "Adelman category( ", Name( underlying_category ), " )" ), IsAdelmanCategory, IsAdelmanCategoryObject, IsAdelmanCategoryMorphism, IsCapCategoryTwoCell );
     
     adelman_category!.category_as_first_argument := true;
     
@@ -47,12 +47,7 @@ InstallMethod( AdelmanCategory,
         category_attribute_names := [
             "UnderlyingCategory",
         ],
-        category_filter := IsAdelmanCategory,
-        object_filter := IsAdelmanCategoryObject,
-        morphism_filter := IsAdelmanCategoryMorphism,
     );
-    
-    SetFilterObj( adelman_category, IsAdelmanCategory );
     
     ## this is the purpose of the Adelman category
     SetIsAbelianCategory( adelman_category, true );
@@ -73,10 +68,6 @@ InstallMethod( AdelmanCategory,
     fi;
     
     DisableAddForCategoricalOperations( adelman_category );
-    
-    AddObjectRepresentation( adelman_category, IsAdelmanCategoryObject );
-    
-    AddMorphismRepresentation( adelman_category, IsAdelmanCategoryMorphism and HasUnderlyingMorphism );
     
     INSTALL_FUNCTIONS_FOR_ADELMAN_CATEGORY( adelman_category );
     

--- a/FreydCategoriesForCAP/gap/FreydCategory.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gi
@@ -31,7 +31,7 @@ InstallGlobalFunction( FREYD_CATEGORY,
     
     name := Concatenation( "Freyd( ", Name( underlying_category ), " )" );
     
-    freyd_category := CreateCapCategory( name );
+    freyd_category := CreateCapCategory( name, IsFreydCategory, IsFreydCategoryObject, IsFreydCategoryMorphism, IsCapCategoryTwoCell );
     
     freyd_category!.category_as_first_argument := true;
     
@@ -45,12 +45,7 @@ InstallGlobalFunction( FREYD_CATEGORY,
         category_attribute_names := [
             "UnderlyingCategory",
         ],
-        category_filter := IsFreydCategory,
-        object_filter := IsFreydCategoryObject,
-        morphism_filter := IsFreydCategoryMorphism,
     );
-    
-    SetFilterObj( freyd_category, IsFreydCategory );
     
     SetIsAdditiveCategory( freyd_category, true );
     
@@ -111,10 +106,6 @@ InstallGlobalFunction( FREYD_CATEGORY,
     
     # is a Freyd category always not a strict monoidal category?
     # SetIsStrictMonoidalCategory( freyd_category, false );
-    
-    AddObjectRepresentation( freyd_category, IsFreydCategoryObject and HasRelationMorphism );
-    
-    AddMorphismRepresentation( freyd_category, IsFreydCategoryMorphism and HasUnderlyingMorphism );
     
     INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY( freyd_category );
     

--- a/FreydCategoriesForCAP/gap/GroupsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/GroupsAsCats.gi
@@ -19,7 +19,7 @@ InstallMethod( GroupAsCategory,
   function( group )
     local category, is_finite;
     
-    category := CreateCapCategory( Concatenation( "Group as category( ", String( group )," )" ) : overhead := false );
+    category := CreateCapCategory( Concatenation( "Group as category( ", String( group )," )" ), IsGroupAsCategory, IsGroupAsCategoryObject, IsGroupAsCategoryMorphism, IsCapCategoryTwoCell : overhead := false );
     
     category!.category_as_first_argument := true;
     
@@ -27,18 +27,9 @@ InstallMethod( GroupAsCategory,
         category_attribute_names := [
             "UnderlyingGroup",
         ],
-        category_filter := IsGroupAsCategory,
-        object_filter := IsGroupAsCategoryObject,
-        morphism_filter := IsGroupAsCategoryMorphism,
     );
     
-    SetFilterObj( category, IsGroupAsCategory );
-    
     SetUnderlyingGroup( category, group );
-    
-    AddObjectRepresentation( category, IsGroupAsCategoryObject );
-    
-    AddMorphismRepresentation( category, IsGroupAsCategoryMorphism and HasUnderlyingGroupElement );
     
     is_finite := HasIsFinite( group ) and IsFinite( group );
     

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -13,7 +13,7 @@
 ##
 InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
     function( ring, underlying_category, arg... )
-    local category, is_finite, sorting_function, with_nf, cocycle;
+    local name, category, is_finite, sorting_function, with_nf, cocycle;
     
     if not ( HasIsCommutative( ring ) and IsCommutative( ring ) ) then
         
@@ -47,13 +47,15 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
     
     if IsBound( cocycle ) then
         
-        category := CreateCapCategory( Concatenation( "TwistedLinearClosure( ", Name( underlying_category )," )" ) : overhead := false );
+        name := Concatenation( "TwistedLinearClosure( ", Name( underlying_category )," )" );
         
     else
         
-        category := CreateCapCategory( Concatenation( "LinearClosure( ", Name( underlying_category )," )" ) : overhead := false );
+        name := Concatenation( "LinearClosure( ", Name( underlying_category )," )" );
         
     fi;
+    
+    category := CreateCapCategory( name, IsLinearClosure, IsLinearClosureObject, IsLinearClosureMorphism, IsCapCategoryTwoCell : overhead := false );
     
     category!.category_as_first_argument := true;
     
@@ -61,9 +63,6 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
         category_attribute_names := [
             "UnderlyingCategory",
         ],
-        category_filter := IsLinearClosure,
-        object_filter := IsLinearClosureObject,
-        morphism_filter := IsLinearClosureMorphism,
     );
     
     category!.with_nf := with_nf;
@@ -86,15 +85,9 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR,
     
     SetCommutativeRingOfLinearCategory( category, ring );
     
-    SetFilterObj( category, IsLinearClosure );
-    
     SetUnderlyingRing( category, ring );
     
     SetUnderlyingCategory( category, underlying_category );
-    
-    AddObjectRepresentation( category, IsLinearClosureObject and HasUnderlyingOriginalObject );
-    
-    AddMorphismRepresentation( category, IsLinearClosureMorphism and HasCoefficientsList and HasSupportMorphisms );
     
     INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE( category );
     

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -23,7 +23,7 @@ InstallMethod( RING_AS_CATEGORY,
   function( ring )
     local category;
     
-    category := CreateCapCategory( Concatenation( "Ring as category( ", String( ring )," )" ) );
+    category := CreateCapCategory( Concatenation( "Ring as category( ", String( ring )," )" ), IsRingAsCategory, IsRingAsCategoryObject, IsRingAsCategoryMorphism, IsCapCategoryTwoCell );
     
     category!.category_as_first_argument := true;
     
@@ -32,20 +32,11 @@ InstallMethod( RING_AS_CATEGORY,
             "UnderlyingRing",
             "RingAsCategoryUniqueObject",
         ],
-        category_filter := IsRingAsCategory,
-        object_filter := IsRingAsCategoryObject,
-        morphism_filter := IsRingAsCategoryMorphism,
     );
-    
-    SetFilterObj( category, IsRingAsCategory );
     
     SetUnderlyingRing( category, ring );
     
     SetIsAbCategory( category, true );
-    
-    AddObjectRepresentation( category, IsRingAsCategoryObject );
-    
-    AddMorphismRepresentation( category, IsRingAsCategoryMorphism and HasUnderlyingRingElement );
     
     INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY( category );
     


### PR DESCRIPTION
Use CreateCapCategory with five arguments or CreateCapCategoryWithDataTypes instead.