### PR TITLE
Allow to resolve calls of operations without category as first argument

### DIFF
--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -604,6 +604,51 @@ InstallMethod( HomStructure,
 );
 
 ##
+
+# usually the type signatures should be part of the gd file, but `CapJitAddTypeSignature` is not available there
+
+CapJitAddTypeSignature( "HomomorphismStructureOnObjectsExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "HomomorphismStructureOnMorphismsExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "HomomorphismStructureOnMorphismsWithGivenObjectsExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryMorphism, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "DistinguishedObjectOfHomomorphismStructureExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjectsExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[2].category );
+    
+end );
+
+CapJitAddTypeSignature( "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphismExtendedByFullEmbedding", [ IsCapCategory, IsCapCategory, IsCapCategoryObject, IsCapCategoryObject, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
 InstallMethod( ExtendRangeOfHomomorphismStructureByFullEmbedding,
                [ IsCapCategory, IsCapCategory, IsFunction, IsFunction, IsFunction, IsFunction ],
   function ( C, E, object_function, morphism_function, object_function_inverse, morphism_function_inverse )

--- a/CAP/gap/UniversalObjects.gi
+++ b/CAP/gap/UniversalObjects.gi
@@ -134,6 +134,13 @@ InstallMethod( DirectSumOp,
     
 end );
 
+# usually the type signatures should be part of the gd file, but `CapJitAddTypeSignature` is not available there
+CapJitAddTypeSignature( "DirectSumFunctorial", [ IsCapCategory, IsList ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
 ####################################
 ## Add methods
 ####################################

--- a/CAP/gap/WrapperCategory.gd
+++ b/CAP/gap/WrapperCategory.gd
@@ -216,6 +216,12 @@ DeclareAttribute( "WrappingFunctor",
 DeclareOperation( "ModelingObject",
                   [ IsCapCategory, IsCapCategoryObject ] );
 
+CapJitAddTypeSignature( "ModelingObject", [ IsCapCategory, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( ModelingCategory( input_types[1].category ) );
+    
+end );
+
 #! @Description
 #!  Returns the object modeled by the object <A>obj</A> in the modeling category of <A>cat</A>.
 #!  <A>cat</A> must be a CAP category which has been created as a wrapper CAP category (but not necessarily uses the default data structure).
@@ -224,6 +230,12 @@ DeclareOperation( "ModelingObject",
 DeclareOperation( "ModeledObject",
                   [ IsCapCategory, IsCapCategoryObject ] );
 
+CapJitAddTypeSignature( "ModeledObject", [ IsCapCategory, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 #! @Description
 #!  Returns the morphism modeling the morphism <A>mor</A> in <A>cat</A>.
 #!  <A>cat</A> must be a CAP category which has been created as a wrapper CAP category (but not necessarily uses the default data structure).
@@ -231,12 +243,24 @@ DeclareOperation( "ModeledObject",
 #! @Returns a CAP category morphism
 DeclareOperation( "ModelingMorphism", [ IsCapCategory, IsCapCategoryMorphism ] );
 
+CapJitAddTypeSignature( "ModelingMorphism", [ IsCapCategory, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( ModelingCategory( input_types[1].category ) );
+    
+end );
+
 #! @Description
 #!  Returns the morphism modeled by the morphism <A>mor</A> in the modeling category of <A>cat</A> with given source and range.
 #!  <A>cat</A> must be a CAP category which has been created as a wrapper CAP category (but not necessarily uses the default data structure).
 #! @Arguments cat, source, obj, range
 #! @Returns a CAP category morphism
 DeclareOperation( "ModeledMorphism", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ] );
+
+CapJitAddTypeSignature( "ModeledMorphism", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 # helper operations
 # Those should never be used outside of WrapperCategory, but allow to register methods for CompilerForCAP.

--- a/CartesianCategories/gap/CartesianCategoriesProperties.gd
+++ b/CartesianCategories/gap/CartesianCategoriesProperties.gd
@@ -11,6 +11,7 @@ DeclareProperty( "IsCartesianCategory", IsCapCategory );
 
 AddCategoricalProperty( [ "IsCartesianCategory", "IsCocartesianCategory" ] );
 
+#! @Description
 #!  The property of the category <A>C</A> being strict cartesian.
 #! @Arguments C
 DeclareProperty( "IsStrictCartesianCategory", IsCapCategory );
@@ -25,9 +26,18 @@ CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCartesianCategory  := Concatenatio
 "UniversalMorphismIntoTerminalObjectWithGivenTerminalObject",
 ], CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.EveryCategory );
 
-##
+## For internal use only:
+## we need an operation name different from `Coproduct`, since CompilerForCAP
+## seems to be unable to compile the CAP operation `Coproduct`
+## if declared in a way different from that in the method record
 DeclareOperation( "BinaryDirectProduct",
         [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ] );
+
+CapJitAddTypeSignature( "BinaryDirectProduct", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
 
 ##
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD(

--- a/CartesianCategories/gap/CocartesianCategoriesProperties.gd
+++ b/CartesianCategories/gap/CocartesianCategoriesProperties.gd
@@ -33,6 +33,12 @@ CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCocartesianCategory  := Concatenat
 DeclareOperation( "BinaryCoproduct",
         [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ] );
 
+CapJitAddTypeSignature( "BinaryCoproduct", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 ##
 CAP_INTERNAL_ADD_REPLACEMENTS_FOR_METHOD_RECORD(
   rec(

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.01-04",
+Version := "2023.01-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -335,12 +335,6 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         CapJitInlinedBindings,
     ];
     
-    if type_signature = fail or not CAP_JIT_DATA_TYPE_INFERENCE_ENABLED then
-        
-        Remove( rule_phase_functions, SafeUniquePosition( rule_phase_functions, CapJitInferredDataTypes ) );
-        
-    fi;
-    
     orig_tree := rec( );
     while tree <> orig_tree do
         
@@ -369,18 +363,6 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
             fi;
             
             tree := f( tree );
-            
-            # Hack: the tree might lose its type because we avoid partial typings.
-            # However, in many cases it can be typed later in the compilation process (after inlining etc.).
-            # Thus, we add the type back manually here.
-            if type_signature <> fail and not IsBound( tree.data_type ) then
-                
-                tree.data_type := rec(
-                    filter := IsFunction,
-                    signature := type_signature,
-                );
-                
-            fi;
             
             if debug_idempotence then
                 

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -264,6 +264,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
         CapJitDroppedUnusedBindings,
         CapJitInlinedBindingsToVariableReferences,
         CapJitResolvedGlobalVariables,
+        CapJitInferredDataTypes,
     ];
     
     orig_tree := rec( );

--- a/CompilerForCAP/gap/InferDataTypes.gd
+++ b/CompilerForCAP/gap/InferDataTypes.gd
@@ -8,7 +8,7 @@
 #! @Section Compilation steps
 
 #! @Description
-#!   Tries to infer the data types of expressions in <A>tree</A> and attaches it as component `data_type`.
+#!   Tries to infer the data types of expressions in the enhanced syntax tree <A>tree</A> of a function with data types.
 #!   A data type is a record with component `filter` (a GAP filter) and, depending on the filter, additional components:
 #!   * `IsFunction` with additional component `signature`: The signature is a list with two entries. The first entry is a list of data types
 #!     of the inputs, the second entry is the data type of the output.

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -171,7 +171,20 @@ InstallGlobalFunction( "CAP_JIT_INTERNAL_LOAD_DEFERRED_TYPE_SIGNATURES", functio
 end );
 
 InstallGlobalFunction( "CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_INPUT_TYPES", function ( gvar, input_types )
-  local input_filters, info, type_signatures, output_type;
+  local input_filters, info, pos, category, type_signatures, output_type;
+    
+    # normalize to the "official" name
+    gvar := NameFunction( ValueGlobal( gvar ) );
+    
+    # in GAP 4.11 and GAP 4.13, "MatElm" points to "[,]", in GAP 4.12 it's the other way round
+    if gvar = "MatElm" then
+        
+        # this code is only executed with GAP 4.12, but coverage information is only uploaded for GAP master
+        Assert( 0, IsIdenticalObj( \[\,\], MatElm ) );
+        
+        gvar := "[,]";
+        
+    fi;
     
     input_filters := List( input_types, type -> type.filter );
     
@@ -195,7 +208,37 @@ InstallGlobalFunction( "CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_I
                 
             else
                 
+                #Error( "could not get output_type" );
                 return fail;
+                
+            fi;
+            
+        elif info.install_convenience_without_category and IsSpecializationOfFilterList( info.filter_list{[ 2 .. Length( info.filter_list ) ]}, input_filters ) then
+            
+            pos := PositionProperty( info.filter_list, filter_string -> filter_string in [ "object", "morphism", "twocell", "list_of_objects", "list_of_morphisms", "list_of_twocells" ] );
+            
+            if pos <> fail then
+                
+                if StartsWith( info.filter_list[pos], "list_of_" ) then
+                    
+                    category := input_types[pos - 1].element_type.category;
+                    
+                else
+                    
+                    category := input_types[pos - 1].category;
+                    
+                fi;
+                
+                if IsString( info.return_type ) then
+                    
+                    return CAP_INTERNAL_GET_DATA_TYPE_FROM_STRING( info.return_type, category );
+                    
+                else
+                    
+                    #Error( "could not get output_type" );
+                    return fail;
+                    
+                fi;
                 
             fi;
             
@@ -1148,6 +1191,18 @@ CapJitAddTypeSignature( "NTuple", "any", function ( input_types )
     Assert( 0, input_types[1].filter = IsInt );
     
     return rec( filter := IsNTuple, element_types := input_types{[ 2 .. Length( input_types ) ]} );
+    
+end );
+
+CapJitAddTypeSignature( "Pair", [ IsObject, IsObject ], function ( input_types )
+    
+    return rec( filter := IsNTuple, element_types := input_types );
+    
+end );
+
+CapJitAddTypeSignature( "Triple", [ IsObject, IsObject, IsObject ], function ( input_types )
+    
+    return rec( filter := IsNTuple, element_types := input_types );
     
 end );
 

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -764,8 +764,41 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_INFERRED_DATA_TYPES, function ( tree, in
 end );
 
 InstallGlobalFunction( CapJitInferredDataTypes, function ( tree )
+  local orig_data_type;
     
-    return CAP_JIT_INTERNAL_INFERRED_DATA_TYPES( tree, [ ] );
+    if tree.type <> "EXPR_DECLARATIVE_FUNC" then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        ErrorWithCurrentlyCompiledFunctionLocation( "CapJitInferredDataTypes can only be applied to enhanced syntax trees of functions" );
+        
+    fi;
+    
+    if not CAP_JIT_DATA_TYPE_INFERENCE_ENABLED then
+        
+        return tree;
+        
+    fi;
+    
+    if not IsBound( tree.data_type ) then
+        
+        return tree;
+        
+    fi;
+    
+    orig_data_type := tree.data_type;
+    
+    tree := CAP_JIT_INTERNAL_INFERRED_DATA_TYPES( tree, [ ] );
+    
+    # The tree might lose its type because we avoid partial typings.
+    # However, in many cases it can be typed later in the compilation process (after inlining etc.).
+    # Thus, we add the type back manually here.
+    if not IsBound( tree.data_type ) then
+        
+        tree.data_type := orig_data_type;
+        
+    fi;
+    
+    return tree;
     
 end );
 

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -3,12 +3,53 @@
 #
 # Implementations
 #
+
+BindGlobal( "CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS", function ( operation, number_of_arguments, filters, expected_number_of_methods, warning_message_getter )
+  local operation_name, similar_methods;
+    
+    if not IsOperation( operation ) then
+        
+        operation := ValueGlobal( Concatenation( NameFunction( operation ), "Op" ) );
+        
+    fi;
+    
+    Assert( 0, IsOperation( operation ) );
+    
+    operation_name := NameFunction( operation );
+    
+    if operation_name in [ "IsEqualForObjects", "IsEqualForMorphisms", "IsCongruentForMorphisms" ] then
+        
+        # these operations have special fallback installations for objects/morphisms from different categories
+        
+        expected_number_of_methods := expected_number_of_methods + 1;
+        
+    fi;
+    
+    similar_methods := Filtered( MethodsOperation( operation, number_of_arguments ), m -> ForAll( [ 1 .. Length( filters ) ], i ->
+        IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( m.argFilt[i] ), WITH_IMPS_FLAGS( FLAGS_FILTER( filters[i] ) ) ) or
+        IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( filters[i] ) ), WITH_IMPS_FLAGS( m.argFilt[i] ) )
+    ) );
+    
+    if Length( similar_methods ) < expected_number_of_methods then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        Error( "found fewer methods than expected" );
+        
+    elif Length( similar_methods ) > expected_number_of_methods then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        Display( warning_message_getter( operation_name ) );
+        
+    fi;
+    
+end );
+
 InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
   local result_func;
     
     # operations are compiled recursively, so we can use result_func instead of pre_func
     result_func := function ( tree, result, keys, additional_arguments )
-      local key, operation, operation_name, info, category, resolved_tree, known_methods, known_method, similar_methods;
+      local operation, operation_name, resolved_tree, info, category, filters, pos, known_methods, known_method, key;
         
         tree := ShallowCopy( tree );
         
@@ -24,32 +65,89 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
             
             operation_name := NameFunction( operation );
             
-            # check if this is a CAP operation which is not a convenience method or if we know methods for this operation
-            if (IsBound( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name) ) and tree.args.length = Length( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name).filter_list )) or IsBound( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name) ) then
+            # all CAP operations and known methods get a category as first argument
+            if tree.args.length = 0 then
                 
-                if CAP_JIT_PROOF_ASSISTANT_MODE_ENABLED and IsBound( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name) ) then
+                return tree;
+                
+            fi;
+            
+            resolved_tree := fail;
+            
+            if IsBound( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name) ) then
+                
+                info := CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name);
+                
+                category := fail;
+                
+                if tree.args.length = Length( info.filter_list ) then
                     
-                    info := CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name);
+                    if IsBound( tree.args.1.data_type ) and IsSpecializationOfFilter( IsCapCategory, tree.args.1.data_type.filter ) then
+                        
+                        category := tree.args.1.data_type.category;
+                        
+                    elif tree.args.1.type = "EXPR_REF_GVAR" then
+                        
+                        # When compiling without a type signature we do not even try to infer data types -> we still need this case.
+                        category := ValueGlobal( tree.args.1.gvar );
+                        
+                    fi;
                     
-                    if not IsBound( info.compatible_with_congruence_of_morphisms ) then
+                elif info.install_convenience_without_category and tree.args.length = Length( info.filter_list ) - 1 and ForAll( tree.args, x -> IsBound( x.data_type ) ) then
+                    
+                    filters := AsListMut( List( tree.args, x -> x.data_type.filter ) );
+                    
+                    if IsSpecializationOfFilterList( info.filter_list{[ 2 .. Length( info.filter_list ) ]}, filters ) then
                         
-                        # COVERAGE_IGNORE_NEXT_LINE
-                        Print( "WARNING: please check if the CAP operation ", operation_name, " is compatible with the congruence of morphisms and add this information to the method name record.\n" );
+                        pos := PositionProperty( info.filter_list, filter_string -> filter_string in [ "object", "morphism", "twocell", "list_of_objects", "list_of_morphisms", "list_of_twocells" ] );
                         
-                    elif info.compatible_with_congruence_of_morphisms <> true then
-                        
-                        Print( "WARNING: the CAP operation ", operation_name, " is not compatible with the congruence of morphisms. Keep this in mind when writing logic templates.\n" );
+                        if pos <> fail then
+                            
+                            CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( operation, Length( info.filter_list ) - 1, filters, 1, { operation_name } -> Concatenation(
+                                # COVERAGE_IGNORE_BLOCK_START
+                                "WARNING: A method for the CAP operation ", operation_name, " without category as first argument was installed which could be confused with the convenience method ",
+                                "deriving the category from the arguments. CompilerForCAP will always resolve the convenience method.\n"
+                                # COVERAGE_IGNORE_BLOCK_END
+                            ) );
+                            
+                            if StartsWith( info.filter_list[pos], "list_of" ) then
+                                
+                                category := tree.args.(pos - 1).data_type.element_type.category;
+                                
+                            else
+                                
+                                category := tree.args.(pos - 1).data_type.category;
+                                
+                            fi;
+                            
+                            tree.args := ConcatenationForSyntaxTreeLists( AsSyntaxTreeList( [ rec( type := "EXPR_REF_GVAR", gvar := CapJitGetOrCreateGlobalVariable( category ) ) ] ), tree.args );
+                            
+                        fi;
                         
                     fi;
                     
                 fi;
                 
-                # we can resolve operations if and only if the category is known, i.e., stored in a global variable
-                if tree.args.1.type = "EXPR_REF_GVAR" then
-                    
-                    category := ValueGlobal( tree.args.1.gvar );
+                if category <> fail then
                     
                     Assert( 0, IsCapCategory( category ) );
+                    Assert( 0, CanCompute( category, operation_name ) );
+                    Assert( 0, tree.args.length = Length( info.filter_list ) );
+                    
+                    if CAP_JIT_PROOF_ASSISTANT_MODE_ENABLED then
+                        
+                        if not IsBound( info.compatible_with_congruence_of_morphisms ) then
+                            
+                            # COVERAGE_IGNORE_NEXT_LINE
+                            Print( "WARNING: please check if the CAP operation ", operation_name, " is compatible with the congruence of morphisms and add this information to the method name record.\n" );
+                            
+                        elif info.compatible_with_congruence_of_morphisms <> true then
+                            
+                            Print( "WARNING: the CAP operation ", operation_name, " is not compatible with the congruence of morphisms. Keep this in mind when writing logic templates.\n" );
+                            
+                        fi;
+                        
+                    fi;
                     
                     if IsBound( category!.stop_compilation ) and category!.stop_compilation = true then
                         
@@ -64,101 +162,97 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
                     fi;
                     
                     Info( InfoCapJit, 1, "####" );
-                    Info( InfoCapJit, 1, Concatenation( "Resolve ", operation_name, "." ) );
+                    Info( InfoCapJit, 1, Concatenation( "Resolve CAP operation ", operation_name, ", recurse compilation." ) );
                     
-                    # check if this is a CAP operation which is not a convenience method
-                    if IsBound( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name) ) and tree.args.length = Length( CAP_INTERNAL_METHOD_NAME_RECORD.(operation_name).filter_list ) then
-                        
-                        Assert( 0, CanCompute( category, operation_name ) );
-                        
-                        Info( InfoCapJit, 1, "This is a CAP operation, recurse compilation." );
-                        
-                        resolved_tree := CapJitCompiledCAPOperationAsEnhancedSyntaxTree( category, operation_name, false );
-                        
-                    # check if we know methods for this operation
-                    elif IsBound( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name) ) then
-                        
-                        Info( InfoCapJit, 1, "Methods are known for this operation." );
-                        
-                        known_methods := Filtered( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name),
-                            m -> Length( m.filters ) = tree.args.length and m.filters[1]( category )
-                        );
-                        
-                        if IsEmpty( known_methods ) then
-                            
-                            return tree;
-                            
-                        fi;
-                        
-                        if Length( known_methods ) > 1 then
-                            
-                            # COVERAGE_IGNORE_NEXT_LINE
-                            Error( "Found more than one known method for ", operation_name, " with correct length and category filter" );
-                            
-                        fi;
-                        
-                        known_method := known_methods[1];
-                        
-                        # look for GAP methods with the same number of arguments and first filter implying known_method.filters[1] or being implied by it
-                        similar_methods := Filtered( MethodsOperation( operation, tree.args.length ), m ->
-                            IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( m.argFilt[1] ), WITH_IMPS_FLAGS( FLAGS_FILTER( known_method.filters[1] ) ) ) or
-                            IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( known_method.filters[1] ) ), WITH_IMPS_FLAGS( m.argFilt[1] ) )
-                        );
-                        
-                        # we should always find the method installed using Install(Other)MethodForCompilerForCAP
-                        Assert( 0, not IsEmpty( similar_methods ) );
-                        
-                        if Length( similar_methods ) > 1 then
-                            
-                            # COVERAGE_IGNORE_BLOCK_START
-                            Print(
-                                "WARNING: A method for ", operation_name, " with ", Length( known_method.filters ), " arguments and first filter ", known_method.filters[1], " was installed using Install(Other)MethodForCompilerForCAP ",
-                                "but additional methods with the same number of arguments and the same first filter (or a filter implying or being implied by it) have been installed (using Install(Other)Method). ",
-                                "If such an additional method is used in the code, CompilerForCAP will resolve the wrong method.\n"
-                            );
-                            # COVERAGE_IGNORE_BLOCK_END
-                            
-                        fi;
-                        
-                        # precompile known methods and cache the result
-                        
-                        if not IsBound( category!.compiled_known_methods_trees ) then
-                            
-                            category!.compiled_known_methods_trees := rec( );
-                            
-                        fi;
-                        
-                        if not IsBound( category!.compiled_known_methods_trees.(operation_name) ) then
-                            
-                            category!.compiled_known_methods_trees.(operation_name) := [ ];
-                            
-                        fi;
-                        
-                        if not IsBound( category!.compiled_known_methods_trees.(operation_name)[tree.args.length] ) then
-                            
-                            category!.compiled_known_methods_trees.(operation_name)[tree.args.length] := CapJitCompiledFunctionAsEnhancedSyntaxTree( known_method.method, "without_post_processing", category );
-                            
-                        fi;
-                        
-                        resolved_tree := CapJitCopyWithNewFunctionIDs( category!.compiled_known_methods_trees.(operation_name)[tree.args.length] );
-                        
-                    else
-                        
-                        # COVERAGE_IGNORE_NEXT_LINE
-                        Error( "this should never happen" );
-                        
-                    fi;
+                    CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( operation, Length( info.filter_list ), [ CapJitDataTypeOfCategory( category ).filter ], Length( category!.added_functions.(operation_name) ), { operation_name } -> Concatenation(
+                        # COVERAGE_IGNORE_BLOCK_START
+                        "WARNING: A method for the CAP operation ", operation_name, " was installed manually (e.g. using Install(Other)Method), ",
+                        "but CompilerForCAP will always resolve the methods installed via CAP's Add-functions.\n"
+                        # COVERAGE_IGNORE_BLOCK_END
+                    ) );
                     
-                    if IsBound( tree.funcref.does_not_return_fail ) and tree.funcref.does_not_return_fail = true then
-                        
-                        resolved_tree := CapJitRemovedReturnFail( resolved_tree );
-                        
-                    fi;
-                    
-                    tree := ShallowCopy( tree );
-                    tree.funcref := resolved_tree;
+                    resolved_tree := CapJitCompiledCAPOperationAsEnhancedSyntaxTree( category, operation_name, false );
                     
                 fi;
+                
+            fi;
+            
+            if resolved_tree = fail and IsBound( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name) ) and tree.args.1.type = "EXPR_REF_GVAR" then
+                
+                category := ValueGlobal( tree.args.1.gvar );
+                
+                Assert( 0, IsCapCategory( category ) );
+                
+                if IsBound( category!.stop_compilation ) and category!.stop_compilation = true then
+                    
+                    return tree;
+                    
+                fi;
+                
+                Info( InfoCapJit, 1, "####" );
+                Info( InfoCapJit, 1, Concatenation( "Try to resolve ", operation_name, " by searching for known method." ) );
+                
+                known_methods := Filtered( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name),
+                    m -> Length( m.filters ) = tree.args.length and m.filters[1]( category )
+                );
+                
+                if IsEmpty( known_methods ) then
+                    
+                    return tree;
+                    
+                fi;
+                
+                if Length( known_methods ) > 1 then
+                    
+                    # COVERAGE_IGNORE_NEXT_LINE
+                    Error( "Found more than one known method for ", operation_name, " with correct length and category filter" );
+                    
+                fi;
+                
+                known_method := known_methods[1];
+                
+                CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( operation, tree.args.length, [ known_method.filters[1] ], 1, { operation_name } -> Concatenation(
+                    # COVERAGE_IGNORE_BLOCK_START
+                    "WARNING: A method for ", operation_name, " with ", String( Length( known_method.filters ) ), " arguments and first filter ", String( known_method.filters[1] ), " was installed using Install(Other)MethodForCompilerForCAP ",
+                    "but additional methods with the same number of arguments and the same first filter (or a filter implying or being implied by it) have been installed (using Install(Other)Method). ",
+                    "If such an additional method is used in the code, CompilerForCAP will resolve the wrong method.\n"
+                    # COVERAGE_IGNORE_BLOCK_END
+                ) );
+                
+                # precompile known methods and cache the result
+                
+                if not IsBound( category!.compiled_known_methods_trees ) then
+                    
+                    category!.compiled_known_methods_trees := rec( );
+                    
+                fi;
+                
+                if not IsBound( category!.compiled_known_methods_trees.(operation_name) ) then
+                    
+                    category!.compiled_known_methods_trees.(operation_name) := [ ];
+                    
+                fi;
+                
+                if not IsBound( category!.compiled_known_methods_trees.(operation_name)[tree.args.length] ) then
+                    
+                    category!.compiled_known_methods_trees.(operation_name)[tree.args.length] := CapJitCompiledFunctionAsEnhancedSyntaxTree( known_method.method, "without_post_processing", category );
+                    
+                fi;
+                
+                resolved_tree := CapJitCopyWithNewFunctionIDs( category!.compiled_known_methods_trees.(operation_name)[tree.args.length] );
+                
+            fi;
+            
+            if resolved_tree <> fail then
+                
+                if IsBound( tree.funcref.does_not_return_fail ) and tree.funcref.does_not_return_fail = true then
+                    
+                    resolved_tree := CapJitRemovedReturnFail( resolved_tree );
+                    
+                fi;
+                
+                tree := ShallowCopy( tree );
+                tree.funcref := resolved_tree;
                 
             fi;
             

--- a/CompilerForCAP/tst/CapJitResolvedOperations.tst
+++ b/CompilerForCAP/tst/CapJitResolvedOperations.tst
@@ -1,0 +1,32 @@
+gap> START_TEST( "CapJitResolvedOperations" );
+
+#
+gap> LoadPackage( "CompilerForCAP", false );
+true
+
+#
+gap> CapJitEnableProofAssistantMode( );
+
+# resolve CAP operations without category as first argument
+gap> func := { cat, mor1, mor2 } -> PreCompose( mor1, mor2 );;
+gap> cat := DummyCategory( rec( list_of_operations_to_install := [ "PreComposeList" ] ) );;
+gap> StopCompilationAtPrimitivelyInstalledOperationsOfCategory( cat );
+gap> Display( CapJitCompiledFunction( func, cat, [ "category", "morphism", "morphism" ], "morphism" ) );
+function ( cat_1, mor1_1, mor2_1 )
+    return PreComposeList( cat_1, [ mor1_1, mor2_1 ] );
+end
+
+# resolve CAP operations without category as first argument (list input)
+gap> func := { cat, mor1, mor2 } -> PreComposeList( [ mor1, mor2 ] );;
+gap> cat := DummyCategory( rec( list_of_operations_to_install := [ "PreCompose" ] ) );;
+gap> StopCompilationAtPrimitivelyInstalledOperationsOfCategory( cat );
+gap> Display( CapJitCompiledFunction( func, cat, [ "category", "morphism", "morphism" ], "morphism" ) );
+function ( cat_1, mor1_1, mor2_1 )
+    return PreCompose( cat_1, mor1_1, mor2_1 );
+end
+
+#
+gap> CapJitDisableProofAssistantMode( );
+
+#
+gap> STOP_TEST( "CapJitResolvedOperations" );

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -65,6 +65,12 @@ DeclareOperation( "ADDITIVE_CLOSURE",
 DeclareOperation( "AdditiveClosureObject",
                   [ IsList, IsAdditiveClosureCategory ] );
 
+CapJitAddTypeSignature( "AdditiveClosureObject", [ IsAdditiveClosureCategory, IsList ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 #! @Description
 #! The argument is an object $A$ in an Ab-category $C$. The output is the image of $A$ under the inclusion functor $\iota:C\to C^\oplus$.
 #! @Arguments A
@@ -80,6 +86,12 @@ DeclareAttribute( "AsAdditiveClosureObject",
 #! @Returns a morphism in $\mathrm{Hom}_{C^\oplus}(A,B)$
 DeclareOperation( "AdditiveClosureMorphism",
                   [ IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ] );
+
+CapJitAddTypeSignature( "AdditiveClosureMorphism", [ IsAdditiveClosureCategory, IsAdditiveClosureObject, IsList, IsAdditiveClosureObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 # deprecated
 DeclareOperation( "AdditiveClosureMorphismListList",

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -303,7 +303,6 @@ InstallMethod( NrRows,
                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return Length( ObjectList( Source( morphism ) ) );
     
@@ -314,7 +313,6 @@ InstallMethod( NrCols,
                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     return Length( ObjectList( Range( morphism ) ) );
     
@@ -520,7 +518,6 @@ InstallMethod( \[\,\],
                [ IsAdditiveClosureMorphism, IsInt, IsInt ],
                
   function( morphism, i, j )
-    #% CAP_JIT_RESOLVE_FUNCTION
     
     if not ( i in [ 1 .. NrRows( morphism ) ]
         and j in [ 1 .. NrCols( morphism ) ] ) then

--- a/FreydCategoriesForCAP/gap/AdelmanCategory.gd
+++ b/FreydCategoriesForCAP/gap/AdelmanCategory.gd
@@ -109,6 +109,12 @@ DeclareAttribute( "AdelmanCategory",
 DeclareOperation( "AdelmanCategoryObject",
                   [ IsCapCategoryMorphism, IsCapCategoryMorphism ] );
 
+CapJitAddTypeSignature( "AdelmanCategoryObject", [ IsAdelmanCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 #! @Description
 #! Let $A$ be an additive category.
 #! The arguments are
@@ -121,6 +127,12 @@ DeclareOperation( "AdelmanCategoryObject",
 #! @Arguments x, alpha, y
 DeclareOperation( "AdelmanCategoryMorphism",
                   [ IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ] );
+
+CapJitAddTypeSignature( "AdelmanCategoryMorphism", [ IsAdelmanCategory, IsAdelmanCategoryObject, IsCapCategoryMorphism, IsAdelmanCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 #! @Description
 #! The argument is an object $a$ of an additive category $A$.
@@ -300,6 +312,7 @@ DeclareAttribute( "WitnessPairForBeingCongruentToZero",
 #! @Arguments alpha
 DeclareAttribute( "MereExistenceOfWitnessPairForBeingCongruentToZero",
                   IsAdelmanCategoryMorphism );
+CapJitAddTypeSignature( "MereExistenceOfWitnessPairForBeingCongruentToZero", [ IsAdelmanCategory, IsAdelmanCategoryMorphism ], IsBool );
 
 DeclareOperation( "HomomorphismStructureOnObjectsForAdelmanCategoryGeneralizedEmbedding",
                   [ IsAdelmanCategoryObject, IsAdelmanCategoryObject ] );

--- a/FreydCategoriesForCAP/gap/CategoryOfColumns.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfColumns.gd
@@ -32,20 +32,41 @@ DeclareCategory( "IsCategoryOfColumns",
 ##
 ####################################
 
+##
 DeclareOperation( "CategoryOfColumns",
                   [ IsHomalgRing ] );
 
+##
 DeclareOperation( "CategoryOfColumnsObject",
                   [ IsInt, IsCategoryOfColumns ] );
 
 KeyDependentOperation( "CategoryOfColumnsObject",
                        IsCategoryOfColumns, IsInt, ReturnTrue );
 
+CapJitAddTypeSignature( "CategoryOfColumnsObject", [ IsCategoryOfColumns, IsInt ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareOperation( "AsCategoryOfColumnsMorphism",
                   [ IsHomalgMatrix, IsCategoryOfColumns ] );
 
+CapJitAddTypeSignature( "AsCategoryOfColumnsMorphism", [ IsCategoryOfColumns, IsHomalgMatrix ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
 DeclareOperation( "CategoryOfColumnsMorphism",
                   [ IsCategoryOfColumnsObject, IsHomalgMatrix, IsCategoryOfColumnsObject ] );
+
+CapJitAddTypeSignature( "CategoryOfColumnsMorphism", [ IsCategoryOfColumns, IsCategoryOfColumnsObject, IsHomalgMatrix, IsCategoryOfColumnsObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 DeclareOperation( "\/",
                   [ IsHomalgMatrix, IsCategoryOfColumns ] );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gd
@@ -32,20 +32,41 @@ DeclareCategory( "IsCategoryOfRows",
 ##
 ####################################
 
+##
 DeclareOperation( "CategoryOfRows",
                   [ IsHomalgRing ] );
 
+##
 DeclareOperation( "CategoryOfRowsObject",
                   [ IsInt, IsCategoryOfRows ] );
 
 KeyDependentOperation( "CategoryOfRowsObject",
                        IsCategoryOfRows, IsInt, ReturnTrue );
 
+CapJitAddTypeSignature( "CategoryOfRowsObject", [ IsCategoryOfRows, IsInt ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareOperation( "AsCategoryOfRowsMorphism",
                   [ IsHomalgMatrix, IsCategoryOfRows ] );
 
+CapJitAddTypeSignature( "AsCategoryOfRowsMorphism", [ IsCategoryOfRows, IsHomalgMatrix ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
 DeclareOperation( "CategoryOfRowsMorphism",
                   [ IsCategoryOfRowsObject, IsHomalgMatrix, IsCategoryOfRowsObject ] );
+
+CapJitAddTypeSignature( "CategoryOfRowsMorphism", [ IsCategoryOfRows, IsCategoryOfRowsObject, IsHomalgMatrix, IsCategoryOfRowsObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 DeclareOperation( "\/",
                   [ IsHomalgMatrix, IsCategoryOfRows ] );
@@ -186,8 +207,17 @@ CapJitAddTypeSignature( "CATEGORY_OF_ROWS_ReductionBySplitEpiSummandTuple", [ Is
 ##
 ####################################
 
+##
 DeclareGlobalFunction( "CATEGORY_OF_ROWS_SimplificationSourceAndRangeTuple" );
 
+CapJitAddTypeSignature( "CATEGORY_OF_ROWS_SimplificationSourceAndRangeTuple", [ IsCategoryOfRowsMorphism ], rec( filter := IsNTuple, element_types := [ rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ) ] ) );
+
+##
 DeclareGlobalFunction( "CATEGORY_OF_ROWS_SimplificationSourceTuple" );
 
+CapJitAddTypeSignature( "CATEGORY_OF_ROWS_SimplificationSourceTuple", [ IsCategoryOfRowsMorphism ], rec( filter := IsNTuple, element_types := [ rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ) ] ) );
+
+##
 DeclareGlobalFunction( "CATEGORY_OF_ROWS_SimplificationRangeTuple" );
+
+CapJitAddTypeSignature( "CATEGORY_OF_ROWS_SimplificationRangeTuple", [ IsCategoryOfRowsMorphism ], rec( filter := IsNTuple, element_types := [ rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ), rec( filter := IsHomalgMatrix ) ] ) );

--- a/FreydCategoriesForCAP/gap/FreydCategory.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategory.gd
@@ -30,24 +30,55 @@ DeclareGlobalFunction( "INSTALL_FUNCTIONS_FOR_FREYD_CATEGORY" );
 
 DeclareGlobalFunction( "FREYD_CATEGORY" );
 
+##
 DeclareAttribute( "FreydCategory",
                   IsCapCategory );
 
+##
 DeclareAttribute( "FreydCategoryObject",
                   IsCapCategoryMorphism );
 
+CapJitAddTypeSignature( "FreydCategoryObject", [ IsFreydCategory, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareOperation( "FreydCategoryMorphism",
                   [ IsFreydCategoryObject, IsCapCategoryMorphism, IsFreydCategoryObject ] );
 
+CapJitAddTypeSignature( "FreydCategoryMorphism", [ IsFreydCategory, IsFreydCategoryObject, IsCapCategoryMorphism, IsFreydCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareAttribute( "AsFreydCategoryObject",
                   IsCapCategoryObject );
 
+CapJitAddTypeSignature( "AsFreydCategoryObject", [ IsFreydCategory, IsCapCategoryObject ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareAttribute( "AsFreydCategoryMorphism",
                   IsCapCategoryMorphism );
 
+CapJitAddTypeSignature( "AsFreydCategoryMorphism", [ IsFreydCategory, IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
+##
 DeclareAttribute( "EmbeddingFunctorIntoFreydCategory",
                   IsCapCategory );
 
+##
 DeclareOperation( "\/",
                   [ IsCapCategoryMorphism, IsFreydCategory ] );
 
@@ -97,8 +128,15 @@ DeclareAttribute( "MorphismWitness",
 DeclareAttribute( "WitnessForBeingCongruentToZero",
                   IsFreydCategoryMorphism );
 
+CapJitAddTypeSignature( "WitnessForBeingCongruentToZero", [ IsFreydCategory, IsFreydCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );
+
 DeclareAttribute( "MereExistenceOfWitnessForBeingCongruentToZero",
                   IsFreydCategoryMorphism );
+CapJitAddTypeSignature( "MereExistenceOfWitnessForBeingCongruentToZero", [ IsFreydCategory, IsFreydCategoryMorphism ], IsBool );
 
 KeyDependentOperation( "FREYD_CATEGORIES_SimplifyObjectTuple", IsFreydCategoryObject, IsObject, ReturnTrue );
 

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
@@ -47,6 +47,12 @@ end );
 DeclareOperation( "RingAsCategoryMorphism",
                   [ IsRingAsCategory, IsRingElement ] );
 
+CapJitAddTypeSignature( "RingAsCategoryMorphism", [ IsRingAsCategory, IsRingElement ], function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
+
 ####################################
 ##
 #! @Section Attributes


### PR DESCRIPTION
if the data types of the arguments can be determined.

The recommended best practice remains to explicitly give the category as the first argument.