### PR TITLE
Remove trailing semicolon after \def

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.01-07",
+Version := "2023.01-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -583,8 +583,8 @@ DeclareOperation( "IsEqualAsFactorobjects",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\h{1};
+#! \def\w{2}
+#! \def\h{1}
 #! \node (a) at (0,\h) {$a$};
 #! \node (b) at (0,-\h) {$b$};
 #! \node (c) at (\w,0) {$c$};
@@ -609,8 +609,8 @@ DeclareOperation( "IsDominating",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\h{1};
+#! \def\w{2}
+#! \def\h{1}
 #! \node (c) at (0,0) {$c$};
 #! \node (a) at (\w,\h) {$a$};
 #! \node (b) at (\w,-\h) {$b$};
@@ -742,8 +742,8 @@ DeclareOperation( "IsWellDefinedForMorphisms",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\h{1};
+#! \def\w{2}
+#! \def\h{1}
 #! \node (a) at (0,\h) {$a$};
 #! \node (b) at (0,-\h) {$b$};
 #! \node (c) at (\w,0) {$c$};
@@ -759,8 +759,8 @@ DeclareOperation( "IsWellDefinedForMorphisms",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\h{1};
+#! \def\w{2}
+#! \def\h{1}
 #! \node (a) at (0,0) {$a$};
 #! \node (c) at (\w,\h) {$c$};
 #! \node (b) at (\w,-\h) {$b$};
@@ -904,8 +904,8 @@ DeclareOperation( "IsColiftable",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\h{1};
+#! \def\w{2}
+#! \def\h{1}
 #! \node (a) at (0,0) {$a$};
 #! \node (b) at (\w,0) {$b$};
 #! \draw[-latex] (a) to node[pos=0.45, above] {$\alpha$} (b);
@@ -1472,8 +1472,8 @@ DeclareAttribute( "Simplify",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
-#! \def\h{2};
+#! \def\w{4}
+#! \def\h{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (Ap) at (0,\h) {$A' \oplus A''$};
@@ -1495,8 +1495,8 @@ DeclareAttribute( "Simplify",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
-#! \def\h{2};
+#! \def\w{4}
+#! \def\h{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (Ap) at (0,\h) {$A'$};
@@ -1514,8 +1514,8 @@ DeclareAttribute( "Simplify",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{4};
-#! \def\h{2};
+#! \def\w{4}
+#! \def\h{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (Ap) at (0,\h) {$A'$};

--- a/CAP/gap/UniversalObjects.gd
+++ b/CAP/gap/UniversalObjects.gd
@@ -29,7 +29,7 @@
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (K) at (-\w,0) {$K$};
 #! \node (T) at (-\w,\w) {$T$};
 #! \node (A) at (0,0) {$A$};
@@ -187,7 +187,7 @@ DeclareOperation( "KernelObjectFunctorialWithGivenKernelObjects",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (K) at (2*\w,0) {$K$};
@@ -639,8 +639,8 @@ DeclareOperation( "InitialObjectFunctorialWithGivenInitialObjects",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\a{20};
+#! \def\w{2}
+#! \def\a{20}
 #! \node (S) at (0,0) {$S$};
 #! \node (S1) at (-\w,0) {$S_1$};
 #! \node (S2) at (\w,0) {$S_2$};
@@ -659,8 +659,8 @@ DeclareOperation( "InitialObjectFunctorialWithGivenInitialObjects",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
-#! \def\a{20};
+#! \def\w{2}
+#! \def\a{20}
 #! \node (S) at (0,0) {$S$};
 #! \node (S1) at (-\w,0) {$S_1$};
 #! \node (S2) at (\w,0) {$S_2$};
@@ -973,7 +973,7 @@ DeclareOperation( "DirectSumFunctorialWithGivenDirectSums",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (I) at (0,0) {$I$};
 #! \node (I1) at (-\w,0) {$I_1$};
 #! \node (I2) at (\w,0) {$I_2$};
@@ -1124,7 +1124,7 @@ DeclareOperation( "CoproductFunctorialWithGivenCoproducts",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (P) at (0,0) {$P$};
 #! \node (P1) at (-\w,0) {$P_1$};
 #! \node (P2) at (\w,0) {$P_2$};
@@ -1279,7 +1279,7 @@ DeclareOperation( "DirectProductFunctorialWithGivenDirectProducts",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (E) at (-\w,0) {$E$};
 #! \node (T) at (-\w,\w) {$T$};
 #! \node (A) at (0,0) {$A$};
@@ -1488,7 +1488,7 @@ DeclareOperation( "IsomorphismFromKernelOfJointPairwiseDifferencesOfMorphismsInt
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (B) at (0,0) {$B$};
 #! \node (A) at (\w,0) {$A$};
 #! \node (C) at (2*\w,0) {$C$};
@@ -1697,7 +1697,7 @@ DeclareOperation( "IsomorphismFromCokernelOfJointPairwiseDifferencesOfMorphismsF
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (T) at (-\w,2*\w) {$T$};
 #! \node (P) at (0,\w) {$P$};
 #! \node (P1) at (0,0) {$P_1$};
@@ -1929,7 +1929,7 @@ DeclareOperation( "FiberProductFunctorialWithGivenFiberProducts",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (B) at (0,0) {$B$};
 #! \node (I1) at (\w,0) {$I_1$};
 #! \node (I2) at (0,\w) {$I_2$};
@@ -2151,7 +2151,7 @@ DeclareOperation( "PushoutFunctorialWithGivenPushouts",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (-\w,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (I) at (0,-\w) {$I$};
@@ -2310,7 +2310,7 @@ DeclareOperation( "ImageObjectFunctorialWithGivenImageObjects",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (-\w,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (0,-\w) {$C$};

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.01-04",
+Version := "2023.01-05",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesForCAP.gd
@@ -39,7 +39,7 @@ DeclareGlobalFunction( "UNIVERSAL_MORPHISM_FROM_BIASED_WEAK_PUSHOUT_PREFUNCTION"
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (T) at (-\w,\w) {$T$};
 #! \node (K) at (-\w,0) {$K$};
 #! \node (A) at (0,0) {$A$};
@@ -222,7 +222,7 @@ DeclareOperation( "AddWeakKernelLiftWithGivenWeakKernelObject",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (K) at (2*\w,0) {$K$};
@@ -403,7 +403,7 @@ DeclareOperation( "AddWeakCokernelColiftWithGivenWeakCokernelObject",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (\w,\w) {$C$};
@@ -668,7 +668,7 @@ DeclareOperation( "AddWeakBiFiberProductMorphismToDirectSum",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (\w,\w) {$C$};
@@ -851,7 +851,7 @@ DeclareOperation( "AddUniversalMorphismIntoBiasedWeakFiberProductWithGivenBiased
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (0,\w) {$C$};
@@ -1115,7 +1115,7 @@ DeclareOperation( "AddDirectSumMorphismToWeakBiPushout",
 #! @BeginLatexOnly
 #! \begin{center}
 #! \begin{tikzpicture}
-#! \def\w{2};
+#! \def\w{2}
 #! \node (A) at (0,0) {$A$};
 #! \node (B) at (\w,0) {$B$};
 #! \node (C) at (0,\w) {$C$};


### PR DESCRIPTION
to avoid the following LaTeX message:
> Missing character: There is no ; in font nullfont!