### PR TITLE
Add some basic logic to generalized loop fusion

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.01-05",
+Version := "2023.01-06",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -737,7 +737,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATES, function ( tree
                     
                 fi;
                 
-                matching_info := CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE( tree, template.src_template_tree, template.variable_filters, IsBound( template.debug_path ) and template.debug_path = additional_arguments[2] );
+                matching_info := CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE( tree, template.src_template_tree, template.variable_filters, path_debugging_enabled and IsBound( template.debug_path ) and template.debug_path = additional_arguments[2] );
                 
                 if matching_info = fail then
                     

--- a/CompilerForCAP/tst/generalized_loop_fusion.tst
+++ b/CompilerForCAP/tst/generalized_loop_fusion.tst
@@ -81,5 +81,38 @@ function ( L_1, filter_func_1, func_1 )
         end );
 end
 
+# simplify [ 1 .. last ][x]
+gap> func := function ( last, func, index )
+>   
+>   return List( [ 1 .. last ], func )[index];
+>   
+> end;;
+gap> Display( CapJitCompiledFunction( func ) );
+function ( last_1, func_1, index_1 )
+    return func_1( CAP_JIT_INCOMPLETE_LOGIC( index_1 ) );
+end
+
+# simplify [ 0 .. last ][1 + x]
+gap> func := function ( last, func, index )
+>   
+>   return List( [ 0 .. last ], func )[1 + index];
+>   
+> end;;
+gap> Display( CapJitCompiledFunction( func ) );
+function ( last_1, func_1, index_1 )
+    return func_1( CAP_JIT_INCOMPLETE_LOGIC( index_1 ) );
+end
+
+# simplify nested CAP_JIT_INCOMPLETE_LOGIC
+gap> func := function ( last, func, index )
+>   
+>   return List( [ 1 .. last ], x -> List( [ 1 .. last ], func )[x] )[index];
+>   
+> end;;
+gap> Display( CapJitCompiledFunction( func ) );
+function ( last_1, func_1, index_1 )
+    return func_1( CAP_JIT_INCOMPLETE_LOGIC( index_1 ) );
+end
+
 #
 gap> STOP_TEST( "generalized_loop_fusion" );

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -211,28 +211,26 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_11_1 := UnderlyingRing( cat_1 );
-    deduped_10_1 := RankOfObject( source_1 );
-    deduped_9_1 := RankOfObject( range_1 );
-    deduped_8_1 := [ 1 .. deduped_9_1 ];
-    hoisted_7_1 := deduped_12_1;
-    hoisted_6_1 := deduped_11_1;
-    hoisted_5_1 := UnderlyingMatrix( alpha_1 );
-    hoisted_4_1 := Length( EntriesOfHomalgColumnVector( deduped_12_1 ) );
-    hoisted_3_1 := [ 1 .. deduped_10_1 ];
-    hoisted_2_1 := deduped_10_1;
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
+    deduped_9_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := RankOfObject( source_1 );
+    deduped_7_1 := RankOfObject( range_1 );
+    hoisted_6_1 := [ 1 .. deduped_8_1 ];
+    hoisted_5_1 := deduped_10_1;
+    hoisted_4_1 := deduped_9_1;
+    hoisted_3_1 := UnderlyingMatrix( alpha_1 );
+    hoisted_2_1 := Length( EntriesOfHomalgColumnVector( deduped_10_1 ) );
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( deduped_8_1, function ( logic_new_func_x_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_7_1 ], function ( logic_new_func_x_2 )
                 local hoisted_1_2;
-                hoisted_1_2 := hoisted_2_1 * (CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[logic_new_func_x_2] ) - 1);
-                return List( hoisted_3_1, function ( logic_new_func_x_3 )
+                hoisted_1_2 := hoisted_1_1 * (CAP_JIT_INCOMPLETE_LOGIC( logic_new_func_x_2 ) - 1);
+                return List( hoisted_6_1, function ( logic_new_func_x_3 )
                         local deduped_1_3;
-                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[logic_new_func_x_3] ) - 1, hoisted_4_1 ) ) + 1;
-                        return EntriesOfHomalgMatrix( CoercedMatrix( hoisted_6_1, CertainColumns( hoisted_5_1, [ deduped_1_3 .. (deduped_1_3 - 1 + hoisted_4_1) ] ) ) * hoisted_7_1 )[1];
+                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( logic_new_func_x_3 ) - 1, hoisted_2_1 ) ) + 1;
+                        return EntriesOfHomalgMatrix( CoercedMatrix( hoisted_4_1, CertainColumns( hoisted_3_1, [ deduped_1_3 .. (deduped_1_3 - 1 + hoisted_2_1) ] ) ) * hoisted_5_1 )[1];
                     end );
-            end ), deduped_9_1, deduped_10_1, deduped_11_1 ) );
+            end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -211,28 +211,26 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
-    deduped_12_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_11_1 := UnderlyingRing( cat_1 );
-    deduped_10_1 := RankOfObject( range_1 );
-    deduped_9_1 := RankOfObject( source_1 );
-    deduped_8_1 := [ 1 .. deduped_9_1 ];
-    hoisted_7_1 := deduped_12_1;
-    hoisted_6_1 := deduped_11_1;
-    hoisted_5_1 := UnderlyingMatrix( alpha_1 );
-    hoisted_4_1 := Length( EntriesOfHomalgColumnVector( deduped_12_1 ) );
-    hoisted_3_1 := [ 1 .. deduped_10_1 ];
-    hoisted_2_1 := deduped_10_1;
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
+    deduped_9_1 := UnderlyingRing( cat_1 );
+    deduped_8_1 := RankOfObject( range_1 );
+    deduped_7_1 := RankOfObject( source_1 );
+    hoisted_6_1 := [ 1 .. deduped_8_1 ];
+    hoisted_5_1 := deduped_10_1;
+    hoisted_4_1 := deduped_9_1;
+    hoisted_3_1 := UnderlyingMatrix( alpha_1 );
+    hoisted_2_1 := Length( EntriesOfHomalgColumnVector( deduped_10_1 ) );
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( deduped_8_1, function ( logic_new_func_x_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_7_1 ], function ( logic_new_func_x_2 )
                 local hoisted_1_2;
-                hoisted_1_2 := hoisted_2_1 * (CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[logic_new_func_x_2] ) - 1);
-                return List( hoisted_3_1, function ( logic_new_func_x_3 )
+                hoisted_1_2 := hoisted_1_1 * (CAP_JIT_INCOMPLETE_LOGIC( logic_new_func_x_2 ) - 1);
+                return List( hoisted_6_1, function ( logic_new_func_x_3 )
                         local deduped_1_3;
-                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[logic_new_func_x_3] ) - 1, hoisted_4_1 ) ) + 1;
-                        return EntriesOfHomalgMatrix( CoercedMatrix( hoisted_6_1, CertainColumns( hoisted_5_1, [ deduped_1_3 .. (deduped_1_3 - 1 + hoisted_4_1) ] ) ) * hoisted_7_1 )[1];
+                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( logic_new_func_x_3 ) - 1, hoisted_2_1 ) ) + 1;
+                        return EntriesOfHomalgMatrix( CoercedMatrix( hoisted_4_1, CertainColumns( hoisted_3_1, [ deduped_1_3 .. (deduped_1_3 - 1 + hoisted_2_1) ] ) ) * hoisted_5_1 )[1];
                     end );
-            end ), deduped_9_1, deduped_10_1, deduped_11_1 ) );
+            end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );
 end
 ########
         

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -5428,35 +5428,34 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1, arg4_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := UnderlyingRing( cat_1 );
-    deduped_10_1 := arg2_1[1];
-    deduped_9_1 := [ 1 .. Length( arg2_1 ) ];
-    deduped_8_1 := [ 1 .. Length( deduped_10_1 ) ];
-    hoisted_4_1 := deduped_11_1;
-    hoisted_3_1 := deduped_9_1;
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := arg2_1[1];
+    deduped_8_1 := [ 1 .. Length( arg2_1 ) ];
+    deduped_7_1 := [ 1 .. Length( deduped_9_1 ) ];
+    hoisted_4_1 := deduped_10_1;
+    hoisted_3_1 := deduped_8_1;
     hoisted_2_1 := arg3_1[1];
-    hoisted_1_1 := deduped_10_1;
-    hoisted_7_1 := SafeRightDivide( UnionOfColumns( deduped_11_1, 1, List( deduped_9_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := deduped_9_1;
+    hoisted_6_1 := SafeRightDivide( UnionOfColumns( deduped_10_1, 1, List( deduped_8_1, function ( logic_new_func_x_2 )
                 return ConvertMatrixToRow( UnderlyingMatrix( arg4_1[logic_new_func_x_2] ) );
-            end ) ), UnionOfRows( deduped_11_1, Sum( List( deduped_9_1, function ( logic_new_func_x_2 )
+            end ) ), UnionOfRows( deduped_10_1, Sum( List( deduped_8_1, function ( logic_new_func_x_2 )
                   return Dimension( Source( arg2_1[logic_new_func_x_2][1] ) ) * Dimension( Range( arg3_1[logic_new_func_x_2][1] ) );
-              end ) ), List( deduped_8_1, function ( logic_new_func_x_2 )
+              end ) ), List( deduped_7_1, function ( logic_new_func_x_2 )
                 return UnionOfColumns( hoisted_4_1, Dimension( Range( hoisted_1_1[logic_new_func_x_2] ) ) * Dimension( Source( hoisted_2_1[logic_new_func_x_2] ) ), List( hoisted_3_1, function ( logic_new_func_x_3 )
                           return KroneckerMat( TransposedMatrix( UnderlyingMatrix( arg2_1[logic_new_func_x_3][logic_new_func_x_2] ) ), UnderlyingMatrix( arg3_1[logic_new_func_x_3][logic_new_func_x_2] ) );
                       end ) );
             end ) ) );
-    hoisted_6_1 := deduped_8_1;
-    hoisted_5_1 := List( deduped_8_1, function ( logic_new_func_x_2 )
+    hoisted_5_1 := List( deduped_7_1, function ( logic_new_func_x_2 )
             return Dimension( Range( hoisted_1_1[logic_new_func_x_2] ) ) * Dimension( Source( hoisted_2_1[logic_new_func_x_2] ) );
         end );
-    return List( deduped_8_1, function ( j_2 )
+    return List( deduped_7_1, function ( j_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2;
-            deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_6_1[j_2] );
+            deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( j_2 );
             deduped_3_2 := Source( hoisted_2_1[j_2] );
             deduped_2_2 := Range( hoisted_1_1[j_2] );
             deduped_1_2 := Sum( hoisted_5_1{[ 1 .. j_2 - 1 ]} ) + 1;
-            return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_2_2, deduped_3_2, UnderlyingMatrix, ConvertRowToMatrix( CertainColumns( hoisted_7_1, [ deduped_1_2 .. deduped_1_2 - 1 + Dimension( Range( hoisted_1_1[deduped_4_2] ) ) * Dimension( Source( hoisted_2_1[deduped_4_2] ) ) ] ), Dimension( deduped_2_2 ), Dimension( deduped_3_2 ) ) );
+            return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_2_2, deduped_3_2, UnderlyingMatrix, ConvertRowToMatrix( CertainColumns( hoisted_6_1, [ deduped_1_2 .. deduped_1_2 - 1 + Dimension( Range( hoisted_1_1[deduped_4_2] ) ) * Dimension( Source( hoisted_2_1[deduped_4_2] ) ) ] ), Dimension( deduped_2_2 ), Dimension( deduped_3_2 ) ) );
         end );
 end
 ########


### PR DESCRIPTION
Fixes https://github.com/homalg-project/CAP_project/issues/1185.

I think I could allow arbitrary logic templates after generalized loop fusion by making sure logic templates do not match parts of the tree containing `CAP_JIT_INCOMPLETE_LOGIC`. For now, let use see what kind of statements actually appear besides `[ 1 .. last ][x]` and `[ 0 .. last ][1 + x]` in our applications.