### PR TITLE
Display warning if `category_as_first_argument` is not set explicitly

### DIFF
--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
-Version := "2023.01-01",
+Version := "2023.01-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ActionsForCAP/examples/IndirectionTest2.g
+++ b/ActionsForCAP/examples/IndirectionTest2.g
@@ -37,6 +37,8 @@ vec := MatrixCategory( Q );;
 wrapped_cat := CreateCapCategory( "Wrapped Category", IsCapCategory, IsWrappedObject, IsWrappedMorphism, IsCapCategoryTwoCell );
 #! Wrapped Category
 
+wrapped_cat!.category_as_first_argument := false;;
+
 #################################
 ##
 ## Constructors for objects and morphisms

--- a/ActionsForCAP/gap/ActionsCategory.gi
+++ b/ActionsForCAP/gap/ActionsCategory.gi
@@ -53,6 +53,8 @@ InstallMethod( LeftActionsCategory,
     
     left_actions_category := CreateCapCategory( name );
     
+    left_actions_category!.category_as_first_argument := false;
+    
     ## WARNING: This should be adjusted
     if HasIsAbelianCategory( underlying_monoidal_category )
        and IsAbelianCategory( underlying_monoidal_category )
@@ -307,6 +309,8 @@ InstallMethod( RightActionsCategory,
     fi;
     
     right_actions_category := CreateCapCategory( name );
+    
+    right_actions_category!.category_as_first_argument := false;
     
     ## WARNING: This should be adjusted
     if HasIsAbelianCategory( underlying_monoidal_category )

--- a/ActionsForCAP/gap/CoactionsCategory.gi
+++ b/ActionsForCAP/gap/CoactionsCategory.gi
@@ -52,6 +52,8 @@ InstallMethod( LeftCoactionsCategory,
     
     left_coactions_category := CreateCapCategory( name );
     
+    left_coactions_category!.category_as_first_argument := false;
+    
     ## WARNING: This should be adjusted
     if HasIsAbelianCategory( underlying_monoidal_category )
        and IsAbelianCategory( underlying_monoidal_category )
@@ -285,6 +287,8 @@ InstallMethod( RightCoactionsCategory,
     fi;
     
     right_coactions_category := CreateCapCategory( name );
+    
+    right_coactions_category!.category_as_first_argument := false;
     
     ## WARNING: This should be adjusted
     if HasIsAbelianCategory( underlying_monoidal_category )

--- a/ActionsForCAP/gap/SemisimpleCategory.gi
+++ b/ActionsForCAP/gap/SemisimpleCategory.gi
@@ -64,6 +64,8 @@ InstallMethod( SemisimpleCategory,
     
     semisimple_category := CreateCapCategory( name );
     
+    semisimple_category!.category_as_first_argument := false;
+    
     SetUnderlyingCategoryForSemisimpleCategory( semisimple_category, underlying_category );
     
     SetMembershipFunctionForSemisimpleCategory( semisimple_category, membership_function );

--- a/AttributeCategoryForCAP/PackageInfo.g
+++ b/AttributeCategoryForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "AttributeCategoryForCAP",
 Subtitle := "Automatic enhancement with attributes of a CAP category",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/AttributeCategoryForCAP/examples/example.g
+++ b/AttributeCategoryForCAP/examples/example.g
@@ -54,6 +54,8 @@ underlying_category := MatrixCategory( Q );;
 ## We create a "void" CapCategory here and set its properties (abelian, monoidal) in the beginning
 category_of_objects_with_endomorphism := CreateCapCategory( "Category of objects with endomorphisms" );;
 
+category_of_objects_with_endomorphism!.category_as_first_argument := false;;
+
 SetIsAbelianCategory( category_of_objects_with_endomorphism, true );;
 
 SetIsRigidSymmetricClosedMonoidalCategory( category_of_objects_with_endomorphism, true );;

--- a/AttributeCategoryForCAP/gap/AttributeCategory.gi
+++ b/AttributeCategoryForCAP/gap/AttributeCategory.gi
@@ -671,6 +671,8 @@ InstallGlobalFunction( EnhancementWithAttributes,
         
         structure_record.category_with_attributes := CreateCapCategory( structure_record.category_name );
         
+        structure_record.category_with_attributes!.category_as_first_argument := false;
+        
     fi;
     
     category_with_attributes := structure_record.category_with_attributes;

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.01-09",
+Version := "2023.01-10",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/DerivationTest.g
+++ b/CAP/examples/DerivationTest.g
@@ -32,6 +32,7 @@ AddDerivation( G, MakeDerivation( "quuux", C,
                                   2, [ f, [] ], IsCapCategory ) );
 
 cat := CreateCapCategory( "test category" );
+cat!.category_as_first_argument := false;
 owl := MakeOperationWeightList( cat, G );
 Print( "Adding A with weight 2\n" );
 AddPrimitiveOperation( owl, "A", 2 );

--- a/CAP/examples/FieldAsCategory.g
+++ b/CAP/examples/FieldAsCategory.g
@@ -40,6 +40,8 @@ InstallMethod( FieldAsCategory,
     
     category := CreateCapCategory( Concatenation( "Field as category( ", RingName( field )," )"  ) : overhead := false );
     
+    category!.category_as_first_argument := false;
+    
     SetFilterObj( category, IsFieldAsCategory );
     
     SetUnderlyingFieldForHomalg( category, field );

--- a/CAP/examples/IntegerCategory.g
+++ b/CAP/examples/IntegerCategory.g
@@ -34,6 +34,8 @@ DeclareAttribute( "AsInteger",
 
 integer_category := CreateCapCategory( "Integers" );
 
+integer_category!.category_as_first_argument := false;
+
 #############################
 ##
 ## Constructors

--- a/CAP/examples/NewAddVectorSpaces.g
+++ b/CAP/examples/NewAddVectorSpaces.g
@@ -54,6 +54,8 @@ DeclareOperation( "VectorSpaceMorphism",
 
 vecspaces := CreateCapCategory( "VectorSpaces" );
 
+vecspaces!.category_as_first_argument := false;
+
 SetIsAbelianCategory( vecspaces, true );
 
 VECTORSPACES_FIELD := HomalgFieldOfRationals( );

--- a/CAP/examples/Schemes.g
+++ b/CAP/examples/Schemes.g
@@ -369,6 +369,8 @@ InstallValue( MORPHISM_LOGIC_LIST,
 
 Schemes := CreateCapCategory( "Schemes" );
 
+Schemes!.category_as_first_argument := false;
+
 ## Implementation
 
 InstallGlobalFunction( SCHEMES_INSTALL_TODO_LIST_FOR_MORPHISM,

--- a/CAP/examples/StringsAsCategory.g
+++ b/CAP/examples/StringsAsCategory.g
@@ -69,6 +69,8 @@ InstallMethod( StringsAsCategory,
     
     category := CreateCapCategory( "Category of strings up to vowels" );
     
+    category!.category_as_first_argument := false;
+    
     SetFilterObj( category, IsStringsAsCategory );
     
     AddObjectRepresentation( category, IsStringsAsCategoryObject );

--- a/CAP/examples/VectorSpacesAddKernel01.g
+++ b/CAP/examples/VectorSpacesAddKernel01.g
@@ -12,9 +12,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-  
-  vecspaces := CreateCapCategory( "VectorSpacesK1" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesK1" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 ##

--- a/CAP/examples/VectorSpacesAddKernel02.g
+++ b/CAP/examples/VectorSpacesAddKernel02.g
@@ -12,9 +12,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-  
-  vecspaces := CreateCapCategory( "VectorSpacesK2" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesK2" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 ##

--- a/CAP/examples/VectorSpacesAddKernel03.g
+++ b/CAP/examples/VectorSpacesAddKernel03.g
@@ -10,9 +10,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-  
-  vecspaces := CreateCapCategory( "VectorSpacesK3" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesK3" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 ##

--- a/CAP/examples/VectorSpacesAllMethods.g
+++ b/CAP/examples/VectorSpacesAllMethods.g
@@ -5,9 +5,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-
-  vecspaces := CreateCapCategory( "VectorSpacesAllMethods" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesAllMethods" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 DeactivateCachingOfCategory( vecspaces );

--- a/CAP/examples/VectorSpacesFinalizeTest.g
+++ b/CAP/examples/VectorSpacesFinalizeTest.g
@@ -5,9 +5,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-  
-  vecspaces := CreateCapCategory( "VectorSpacesFinalizeTest" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesFinalizeTest" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 SetIsAbelianCategory( vecspaces, true );

--- a/CAP/examples/VectorSpacesForGAPDays.g
+++ b/CAP/examples/VectorSpacesForGAPDays.g
@@ -43,6 +43,8 @@ VECTORSPACES_FIELD := HomalgFieldOfRationals( );
 
 BindGlobal( "QVectorSpaces", CreateCapCategory( "QVectorSpaces" ) );
 
+QVectorSpaces!.category_as_first_argument := false;
+
 ###################################
 ##
 ## Constructors for objects and morphisms

--- a/CAP/examples/VectorSpacesGeneralizedMorphismsCategory.g
+++ b/CAP/examples/VectorSpacesGeneralizedMorphismsCategory.g
@@ -12,6 +12,7 @@ fi;
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 LoadPackage( "GeneralizedMorphismsForCAP", false );
@@ -91,6 +92,7 @@ Arrow( c1 + c2 );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 1 );
@@ -142,6 +144,7 @@ RangeAid( composition );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 1 );
@@ -196,6 +199,7 @@ SourceAid( composition2 );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 3 );
@@ -343,6 +347,7 @@ RangeAid( p );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 1 );

--- a/CAP/examples/VectorSpacesIsWellDefined.g
+++ b/CAP/examples/VectorSpacesIsWellDefined.g
@@ -11,6 +11,7 @@ fi;
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForIsWellDefinedTest" );
 #! VectorSpacesForIsWellDefinedTest 
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 LoadPackage( "GeneralizedMorphismsForCAP", false );

--- a/CAP/examples/VectorSpacesKernelTest.g
+++ b/CAP/examples/VectorSpacesKernelTest.g
@@ -11,6 +11,7 @@ fi;
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpaces01" );
 #! VectorSpaces01
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAddKernel01.g" );
 #! true
 V := QVectorSpace( 2 );
@@ -47,6 +48,7 @@ KernelEmbedding( alpha );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpaces02" );
 #! VectorSpaces02
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAddKernel02.g" );
 #! true
 V := QVectorSpace( 2 );
@@ -79,6 +81,7 @@ HasKernelEmbedding( alpha );
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpaces03" );
 #! VectorSpaces03
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAddKernel03.g" );
 #! true
 V := QVectorSpace( 2 );

--- a/CAP/examples/VectorSpacesMethodGlueing.g
+++ b/CAP/examples/VectorSpacesMethodGlueing.g
@@ -5,9 +5,11 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 if not IsCapCategory( vecspaces ) then
-
-  vecspaces := CreateCapCategory( "VectorSpacesCacheIssue" );
-  
+    
+    vecspaces := CreateCapCategory( "VectorSpacesCacheIssue" );
+    
+    vecspaces!.category_as_first_argument := false;
+    
 fi;
 
 ##

--- a/CAP/examples/VectorSpacesPullback.g
+++ b/CAP/examples/VectorSpacesPullback.g
@@ -11,6 +11,7 @@ fi;
 #! @Example
 vecspaces := CreateCapCategory( "VectorSpacesForFiberProductTest" );
 #! VectorSpacesForFiberProductTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 1 );

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -26,6 +26,8 @@ BindGlobal( "CAP_INTERNAL_CREATE_Cat",
     
     cat := CREATE_CAP_CATEGORY_OBJECT( obj_rec, "Cat", IsCapCategory, IsCapCategoryAsCatObject, IsCapFunctor, IsCapNaturalTransformation, fail, fail, fail );
     
+    cat!.category_as_first_argument := false;
+    
     INSTALL_CAP_CAT_FUNCTIONS( cat );
     
     return cat;

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -256,6 +256,17 @@ InstallGlobalFunction( CapInternalInstallAdd,
         
         ## Nr arguments sanity check
         
+        if not IsBound( category!.category_as_first_argument ) then
+            
+            Print(
+                "WARNING: The category with name \"", Name( category ), "\" has no component `category_as_first_argument`. Please explicitly set this component. ",
+                "Currently, the default value is `false` (which will now be set automatically), but this will change in the future.\n"
+            );
+            
+            category!.category_as_first_argument := false;
+            
+        fi;
+        
         needs_wrapping := record.install_convenience_without_category and not ( ( is_derivation or is_final_derivation ) or ( IsBound( category!.category_as_first_argument ) and category!.category_as_first_argument = true ) );
         
         # backwards compatibility for categories without category!.category_as_first_argument

--- a/CAP/gap/ProductCategory.gi
+++ b/CAP/gap/ProductCategory.gi
@@ -212,6 +212,8 @@ InstallMethodWithCrispCache( ProductOp,
     
     product_category := CreateCapCategory( namestring );
     
+    product_category!.category_as_first_argument := false;
+    
     SetComponents( product_category, category_list );
     
     SetLength( product_category, Length( category_list ) );

--- a/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
+++ b/ComplexesAndFilteredObjectsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ComplexesAndFilteredObjectsForCAP",
 Subtitle := "Implementation of complexes, cocomplexes and filtered objects for CAP",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ComplexesAndFilteredObjectsForCAP/gap/CocomplexCategory.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/CocomplexCategory.gi
@@ -62,6 +62,8 @@ InstallMethod( CocomplexCategory,
     
     cocomplex_category := CreateCapCategory( name );
     
+    cocomplex_category!.category_as_first_argument := false;
+    
     SetUnderlyingCategory( cocomplex_category, category );
     
     SetCocomplexCategory( category, cocomplex_category );
@@ -92,6 +94,8 @@ InstallMethod( ComplexCategory,
     name := Concatenation( "Complex category of ", name );
     
     complex_category := CreateCapCategory( name );
+    
+    complex_category!.category_as_first_argument := false;
     
     SetUnderlyingCategory( complex_category, category );
     

--- a/ComplexesAndFilteredObjectsForCAP/gap/FilteredObjects.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/FilteredObjects.gi
@@ -56,6 +56,8 @@ InstallMethod( CategoryOfAscendingFilteredObjects,
     
     filtered_objects_category := CreateCapCategory( name );
     
+    filtered_objects_category!.category_as_first_argument := false;
+    
     SetUnderlyingCategory( filtered_objects_category, category );
     
     SetCategoryOfAscendingFilteredObjects( category, filtered_objects_category );
@@ -80,6 +82,8 @@ InstallMethod( CategoryOfDescendingFilteredObjects,
     name := Concatenation( "Descending filtered object category of ", name );
     
     filtered_objects_category := CreateCapCategory( name );
+    
+    filtered_objects_category!.category_as_first_argument := false;
     
     SetUnderlyingCategory( filtered_objects_category, category );
     

--- a/ComplexesAndFilteredObjectsForCAP/gap/ZFunctors.gi
+++ b/ComplexesAndFilteredObjectsForCAP/gap/ZFunctors.gi
@@ -55,6 +55,8 @@ InstallMethod( ZFunctorCategory,
     
     z_functor_category := CreateCapCategory( name );
     
+    z_functor_category!.category_as_first_argument := false;
+    
     SetUnderlyingCategory( z_functor_category, category );
     
     SetZFunctorCategory( category, z_functor_category );

--- a/DeductiveSystemForCAP/PackageInfo.g
+++ b/DeductiveSystemForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "DeductiveSystemForCAP",
 Subtitle := "Deductive system for CAP",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/DeductiveSystemForCAP/examples/LogicExample.g
+++ b/DeductiveSystemForCAP/examples/LogicExample.g
@@ -7,6 +7,7 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 vecspaces := CreateCapCategory( "vecspaces" );
+vecspaces!.category_as_first_argument := false;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 
 ## create example input

--- a/DeductiveSystemForCAP/examples/VectorSpaces.g
+++ b/DeductiveSystemForCAP/examples/VectorSpaces.g
@@ -56,6 +56,8 @@ DeclareOperation( "VectorSpaceMorphism",
 
 vecspaces := CreateCapCategory( "VectorSpaces" );
 
+vecspaces!.category_as_first_argument := false;
+
 SetIsAbelianCategory( vecspaces, true );
 
 VECTORSPACES_FIELD := HomalgFieldOfRationals( );

--- a/DeductiveSystemForCAP/examples/deductive_generalized.g
+++ b/DeductiveSystemForCAP/examples/deductive_generalized.g
@@ -5,6 +5,7 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 vecspaces := CreateCapCategory( "VectorSpacesForGeneralizedMorphismsTest" );
 #! VectorSpacesForGeneralizedMorphismsTest
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 #! true
 A := QVectorSpace( 3 );

--- a/DeductiveSystemForCAP/gap/DeductiveSystem.gi
+++ b/DeductiveSystemForCAP/gap/DeductiveSystem.gi
@@ -617,6 +617,8 @@ InstallMethod( DeductiveSystem,
     
     deductive_system := CreateCapCategory( Concatenation( "Deduction system of ", Name( category ) ) );
     
+    deductive_system!.category_as_first_argument := false;
+    
     SetTheoremRecord( deductive_system, TheoremRecord( category ) );
     
     SetUnderlyingCategory( deductive_system, category );

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.01-06",
+Version := "2023.01-07",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedColumns.gi
@@ -23,6 +23,8 @@ InstallMethod( CategoryOfGradedColumns,
       # create category
       category := CreateCapCategory( Concatenation( "Category of graded columns over ", RingName( homalg_graded_ring ) ), IsCategoryOfGradedColumns, IsGradedColumn, IsGradedColumnMorphism, IsCapCategoryTwoCell );
       
+      category!.category_as_first_argument := false;
+      
       SetUnderlyingGradedRing( category, homalg_graded_ring );
       
       # here we can switch internal checks in constructor on or of - true means they are performed and false means they are not

--- a/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfGradedRowsAndColumns/CategoryOfGradedRows.gi
@@ -23,6 +23,8 @@ InstallMethod( CategoryOfGradedRows,
       # construct the category
       category := CreateCapCategory( Concatenation( "Category of graded rows over ", RingName( homalg_graded_ring ) ), IsCategoryOfGradedRows, IsGradedRow, IsGradedRowMorphism, IsCapCategoryTwoCell );
       
+      category!.category_as_first_argument := false;
+      
       SetUnderlyingGradedRing( category, homalg_graded_ring );
       
       # here we can switch internal checks in constructor on or of - true means they are performed and false means they are not

--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -50,6 +50,8 @@ InstallMethod( CokernelImageClosure,
     
     cokernel_image_closure := CreateCapCategory( Concatenation( "Cokernel image closure( ", Name( underlying_category ), " )" ) );
     
+    cokernel_image_closure!.category_as_first_argument := false;
+    
     SetFilterObj( cokernel_image_closure, IsCokernelImageClosure );
     
     SetIsAdditiveCategory( cokernel_image_closure, true );

--- a/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
@@ -54,7 +54,9 @@ InstallMethod( ProSetAsCategory,
     fi;
 
     category := CreateCapCategory( "ProSet" : overhead := false );
-
+    
+    category!.category_as_first_argument := false;
+    
     SetFilterObj( category, IsProSetAsCategory );
 
     SetIncidenceMatrix( category, incidence_matrix );

--- a/FreydCategoriesForCAP/gap/Relations.gi
+++ b/FreydCategoriesForCAP/gap/Relations.gi
@@ -21,6 +21,8 @@ InstallMethod( RelCategory,
     
     category := CreateCapCategory( Concatenation( "Rel( ", Name( underlying_category )," )" ) );
     
+    category!.category_as_first_argument := false;
+    
     SetFilterObj( category, IsRelCategory );
     
     SetUnderlyingCategory( category, underlying_category );

--- a/GeneralizedMorphismsForCAP/PackageInfo.g
+++ b/GeneralizedMorphismsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GeneralizedMorphismsForCAP",
 Subtitle := "Implementations of generalized morphisms for the CAP project",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
@@ -268,6 +268,8 @@ InstallMethod( GeneralizedMorphismCategoryByCospans,
     
     generalized_morphism_category := CreateCapCategory( name );
     
+    generalized_morphism_category!.category_as_first_argument := false;
+    
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryByCospansObject );
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByCospan and HasArrow and HasReversedArrow );

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
@@ -264,6 +264,8 @@ InstallMethod( GeneralizedMorphismCategoryBySpans,
     
     generalized_morphism_category := CreateCapCategory( name );
     
+    generalized_morphism_category!.category_as_first_argument := false;
+    
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryBySpansObject );
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismBySpan and HasArrow and HasReversedArrow );

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -286,6 +286,8 @@ InstallMethod( GeneralizedMorphismCategoryByThreeArrows,
     
     generalized_morphism_category := CreateCapCategory( name );
     
+    generalized_morphism_category!.category_as_first_argument := false;
+    
     AddObjectRepresentation( generalized_morphism_category, IsGeneralizedMorphismCategoryByThreeArrowsObject );
     
     AddMorphismRepresentation( generalized_morphism_category, IsGeneralizedMorphismByThreeArrows and HasSourceAid and HasRangeAid and HasArrow );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
@@ -357,6 +357,8 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospans,
     
     serre_category := CreateCapCategory( name );
     
+    serre_category!.category_as_first_argument := false;
+    
     SetFilterObj( serre_category, IsSerreQuotientCategory );
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByCospansObject );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
@@ -424,6 +424,8 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpans,
     
     serre_category := CreateCapCategory( name );
     
+    serre_category!.category_as_first_argument := false;
+    
     SetFilterObj( serre_category, IsSerreQuotientCategory );
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryBySpansObject );

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -378,6 +378,8 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrows,
     
     serre_category := CreateCapCategory( name );
     
+    serre_category!.category_as_first_argument := false;
+    
     SetFilterObj( serre_category, IsSerreQuotientCategory );
     
     AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsObject );

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2023.01-01",
+Version := "2023.01-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
+++ b/GradedModulePresentationsForCAP/gap/GradedModulePresentations.gi
@@ -13,6 +13,8 @@ InstallMethod( GradedLeftPresentations,
     
     category := CreateCapCategory( Concatenation( "The category of graded left f.p. modules over ", RingName( ring ) ) );
     
+    category!.category_as_first_argument := false;
+    
     category!.ring_for_representation_category := ring;
     
     category!.underlying_presentation_category := LeftPresentations( ring );
@@ -67,6 +69,8 @@ InstallMethod( GradedRightPresentations,
     local category;
     
     category := CreateCapCategory( Concatenation( "The category of graded right f.p. modules over ", RingName( ring ) ) );
+    
+    category!.category_as_first_argument := false;
     
     category!.ring_for_representation_category := ring;
     

--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
+++ b/GroupRepresentationsForCAP/gap/SemisimpleCategory.gi
@@ -2728,6 +2728,8 @@ InstallMethod( SemisimpleCategory,
     
     semisimple_category := CreateCapCategory( name );
     
+    semisimple_category!.category_as_first_argument := false;
+    
     SetIsAbelianCategory( semisimple_category, true );
     
     SetIsRigidSymmetricClosedMonoidalCategory( semisimple_category, true );

--- a/HomologicalAlgebraForCAP/PackageInfo.g
+++ b/HomologicalAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomologicalAlgebraForCAP",
 Subtitle := "Homological algebra algorithms for CAP",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/HomologicalAlgebraForCAP/examples/GapDays2015FallHandsOn.g
+++ b/HomologicalAlgebraForCAP/examples/GapDays2015FallHandsOn.g
@@ -41,6 +41,8 @@ DeclareOperation( "VectorSpaceMorphism",
 
 BindGlobal( "vecspaces", CreateCapCategory( "VectorSpaces" ) );
 
+vecspaces!.category_as_first_argument := false;
+
 SetIsAbelianCategory( vecspaces, true );
 
 BindGlobal( "VECTORSPACES_FIELD", HomalgFieldOfRationals( ) );

--- a/HomologicalAlgebraForCAP/examples/SnakeLemma.g
+++ b/HomologicalAlgebraForCAP/examples/SnakeLemma.g
@@ -7,6 +7,7 @@ if not IsBound( VectorSpacesConstructorsLoaded ) then
 fi;
 
 vecspaces := CreateCapCategory( "vecspaces" );
+vecspaces!.category_as_first_argument := false;
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 
 LoadPackage( "HomologicalAlgebraForCAP" );

--- a/HomologicalAlgebraForCAP/examples/SpectralSequences.g
+++ b/HomologicalAlgebraForCAP/examples/SpectralSequences.g
@@ -7,6 +7,8 @@ fi;
 
 vecspaces := CreateCapCategory( "VectorSpacesForSpectralSequenceTest" );
 
+vecspaces!.category_as_first_argument := false;
+
 ReadPackage( "CAP", "examples/VectorSpacesAllMethods.g" );
 
 LoadPackage( "HomologicalAlgebraForCAP" );

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2022.12-01",
+Version := "2023.01-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/examples/BasicTests.g
+++ b/MonoidalCategories/examples/BasicTests.g
@@ -7,6 +7,7 @@ LoadPackage( "MonoidalCategories" );
 #! true
 vecspaces := CreateCapCategory( "VectorSpaces" );
 #! VectorSpaces
+vecspaces!.category_as_first_argument := false;;
 ReadPackage( "MonoidalCategories",
         "examples/VectorSpacesMonoidalCategory.gi" );
 #! true

--- a/MonoidalCategories/examples/VectorSpacesMonoidalCategory.gi
+++ b/MonoidalCategories/examples/VectorSpacesMonoidalCategory.gi
@@ -57,6 +57,8 @@ DeclareOperation( "VectorSpaceMorphism",
 ##this has an effect on the constructors below!
 vecspaces := CreateCapCategory( "VectorSpacesMonoidalCategory" );
 
+vecspaces!.category_as_first_argument := false;
+
 ## set all properties of the category in the beginning 
 SetIsAbelianCategory( vecspaces, true );
 


### PR DESCRIPTION
This is a preparatory step for changing the default to `true` in the future.

@ all: Should this cause too much trouble for now, we can of course disable the warning again. But let's see how many packages are affected by this.