### PR TITLE
Introduce CapJitTypedExpression

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.12-04",
+Version := "2023.12-05",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -221,6 +221,18 @@ DeclareGlobalFunction( "CapJitDataTypeOfTwoCellOfCategory" );
 #! @EndGroup
 
 #! @Description
+#!   (experimental) Simply returns <A>value</A>, but allows to specify the data type of <A>value</A> for CompilerForCAP.
+#!   <A>data_type_getter</A> must be a literal function or a global variable pointing to a function.
+#!   The function must accept no arguments or a single argument, and return a valid data type.
+#!   If the function accepts a single argument, it must be inside a CAP operation or method known to CompilerForCAP (for example, see <Ref Func="InstallMethodForCompilerForCAP" />),
+#!   and the current category (i.e. the first argument of the CAP operation or method known to CompilerForCAP) will be passed to the function.
+#!   IMPORTANT: If <A>data_type_getter</A> is a literal function, it must not contain references to variables in its context.
+#!   Otherwise the code might access random memory locations.
+#!   See <Ref BookName="CompilerForCAP" Func="CapJitInferredDataTypes" /> for more details on data types.
+#! @Arguments value, data_type_getter
+DeclareGlobalFunction( "CapJitTypedExpression" );
+
+#! @Description
 #!   Computes a fixpoint of <A>func</A> with regard to equality given by <A>predicate</A>, starting with <A>initial_value</A>.
 #!   If no such fixpoint exists, the execution does not terminate.
 #! @Arguments predicate, func, initial_value

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1334,6 +1334,9 @@ InstallGlobalFunction( CapJitDataTypeOfTwoCellOfCategory, function ( cat )
 end );
 
 ##
+InstallGlobalFunction( CapJitTypedExpression, ReturnFirst );
+
+##
 InstallGlobalFunction( CapFixpoint, function ( predicate, func, initial_value )
   local x, y;
     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2023.12-08",
+Version := "2023.12-09",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -590,7 +590,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
                 domains := rec( );
                 
                 pre_func := function ( tree, func_stack )
-                  local value_of_binding_iterated, value_of_binding_and_CAP_JIT_INCOMPLETE_LOGIC_iterated, is_shorter_than, list_call, domain, simplify, enclosing_domain, index, resolved_domain, resolved_index, element;
+                  local value_of_binding_iterated, value_of_binding_and_CAP_JIT_INCOMPLETE_LOGIC_iterated, is_shorter_than, list_call, domain, simplify, enclosing_domain, index, resolved_domain, resolved_index, element, element_type;
                     
                     value_of_binding_iterated := function ( tree )
                       local func;
@@ -777,6 +777,38 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
                                             index, # index
                                         ] ),
                                     );
+                                    
+                                    if IsBound( domain.data_type ) and IsBound( index.data_type ) then
+                                        
+                                        element_type := CAP_JIT_INTERNAL_GET_OUTPUT_TYPE_OF_GLOBAL_FUNCTION_BY_INPUT_TYPES( "[]", [ domain.data_type, index.data_type ] );
+                                        
+                                        if element_type = fail then
+                                            
+                                            #Error( "could not determine element_type" );
+                                            
+                                        elif IsFunction( element_type ) then
+                                            
+                                            #Error( "cannot infer parametric output type by arguments types only" );
+                                            
+                                        # COVERAGE_IGNORE_NEXT_LINE
+                                        else
+                                            
+                                            element.data_type := element_type;
+                                            
+                                            element.funcref.data_type := rec(
+                                                filter := IsFunction,
+                                                signature := Pair(
+                                                    [
+                                                        domain.data_type,
+                                                        index.data_type
+                                                    ],
+                                                    element_type
+                                                )
+                                            );
+                                            
+                                        fi;
+                                        
+                                    fi;
                                     
                                 fi;
                                 

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -53,6 +53,7 @@ CapJitAddLogicFunction( function ( tree )
             
             return rec(
                 type := "EXPR_LIST",
+                data_type := CapJitDataTypeOfListOf( IsInt ),
                 list := AsSyntaxTreeList( List(
                     [ tree.first.value .. tree.last.value ],
                     int -> rec(
@@ -224,7 +225,12 @@ CapJitAddLogicFunction( function ( tree )
             
             args := tree.args.1.args;
             
-            if args.length = 1 then
+            if args.length = 0 then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Error( "`Concatenation` with zero arguments is not supported by CompilerForCAP" );
+                
+            elif args.length = 1 then
                 
                 # Length( Concatenation( list ) ) -> Sum( List( list, Length ) )
                 
@@ -253,6 +259,8 @@ CapJitAddLogicFunction( function ( tree )
                 );
                 
             else
+                
+                Assert( 0, args.length > 1 );
                 
                 # Length( Concatenation( list1, list2, ... ) ) -> Sum( [ Length( list1 ), Length( list2 ), ... ] )
                 
@@ -302,7 +310,7 @@ CapJitAddLogicFunction( function ( tree )
     Info( InfoCapJit, 1, "Apply logic for concatenation of literal lists." );
     
     pre_func := function ( tree, additional_arguments )
-      local args;
+      local args, new_tree;
         
         # Concatenation with a single argument has different semantics
         # -> convert to version with multiple arguments
@@ -310,7 +318,22 @@ CapJitAddLogicFunction( function ( tree )
             
             args := tree.args;
             
-            if args.1.list.length = 1 then
+            if args.1.list.length = 0 then
+                
+                new_tree := rec(
+                    type := "EXPR_LIST",
+                    list := AsSyntaxTreeList( [ ] ),
+                );
+                
+                if IsBound( tree.data_type ) then
+                    
+                    new_tree.data_type := tree.data_type;
+                    
+                fi;
+                
+                tree := new_tree;
+                
+            elif args.1.list.length = 1 then
                 
                 tree := args.1.list.1;
                 
@@ -326,18 +349,22 @@ CapJitAddLogicFunction( function ( tree )
             
         fi;
         
-        if CapJitIsCallToGlobalFunction( tree, "Concatenation" ) then
+        if CapJitIsCallToGlobalFunction( tree, "Concatenation" ) and tree.args.length > 1 and ForAll( tree.args, a -> a.type = "EXPR_LIST" ) then
             
             args := tree.args;
             
-            if args.length > 1 and ForAll( args, a -> a.type = "EXPR_LIST" ) then
+            new_tree := rec(
+                type := "EXPR_LIST",
+                list := ConcatenationForSyntaxTreeLists( AsListMut( List( args, a -> a.list ) ) ),
+            );
+            
+            if IsBound( tree.data_type ) then
                 
-                return rec(
-                    type := "EXPR_LIST",
-                    list := ConcatenationForSyntaxTreeLists( AsListMut( List( args, a -> a.list ) ) ),
-                );
+                new_tree.data_type := tree.data_type;
                 
             fi;
+            
+            tree := new_tree;
             
         fi;
         
@@ -391,7 +418,7 @@ CapJitAddLogicFunction( function ( tree )
     Info( InfoCapJit, 1, "Apply logic for List applied to a literal list." );
     
     pre_func := function ( tree, additional_arguments )
-      local args;
+      local args, new_tree;
         
         if CapJitIsCallToGlobalFunction( tree, "List" ) then
             
@@ -399,7 +426,7 @@ CapJitAddLogicFunction( function ( tree )
             
             if args.length = 2 and args.1.type = "EXPR_LIST" then
                 
-                return rec(
+                new_tree := rec(
                     type := "EXPR_LIST",
                     list := List(
                         args.1.list,
@@ -410,6 +437,14 @@ CapJitAddLogicFunction( function ( tree )
                         )
                     ),
                 );
+                
+                if IsBound( tree.data_type ) then
+                    
+                    new_tree.data_type := tree.data_type;
+                    
+                fi;
+                
+                tree := new_tree;
                 
             fi;
             

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -148,6 +148,13 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_ENHANCE_LOGIC_TEMPLATE, function ( templ
         
         if tree.type = "EXPR_REF_FVAR" and tree.func_id = outer_func_id then
             
+            if IsBound( tree.data_type ) then
+                
+                # COVERAGE_IGNORE_NEXT_LINE
+                Error( "using CapJitTypeExpression with logic template variables is currently not supported, use variable_filters instead" );
+                
+            fi;
+            
             id := SafeUniquePosition( template.variable_names, tree.name );
             
             AddSet( syntax_tree_variables_ids, id );
@@ -717,7 +724,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                         
                         if debug then
                             # COVERAGE_IGNORE_BLOCK_START
-                            Display( "type could not be inferred or did not match" );
+                            Display( "data type could not be inferred or did not match (variable_filters)" );
                             # COVERAGE_IGNORE_BLOCK_END
                         fi;
                         
@@ -757,8 +764,25 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 # COVERAGE_IGNORE_BLOCK_END
             fi;
             
+            if key = "data_type" then
+                
+                if not IsBound( tree.data_type ) or tree.data_type <> template_tree.data_type then
+                    
+                    if debug then
+                        # COVERAGE_IGNORE_NEXT_LINE
+                        Display( "data type could not be inferred or did not match (typed template tree)" );
+                    fi;
+                    
+                    return false;
+                    
+                fi;
+                
+                continue;
+                
+            fi;
+            
             # ignore these keys
-            if key = "data_type" or key = "CAP_JIT_NOT_RESOLVABLE" then
+            if key = "CAP_JIT_NOT_RESOLVABLE" then
                 
                 continue;
                 

--- a/CompilerForCAP/tst/CAP_JIT_INTERNAL_TELESCOPED_ITERATION.tst
+++ b/CompilerForCAP/tst/CAP_JIT_INTERNAL_TELESCOPED_ITERATION.tst
@@ -116,7 +116,7 @@ end
 # Iterated with empty literal list and initial_value
 gap> func := { cat, source } ->
 >     Iterated(
->         [ ],
+>         CapJitTypedExpression( [ ], cat -> CapJitDataTypeOfListOf( CapJitDataTypeOfMorphismOfCategory( cat ) ) ),
 >         { alpha, beta } -> PreCompose( cat, alpha, beta ),
 >         IdentityMorphism( cat, source )
 >     );;
@@ -133,7 +133,7 @@ end
 # Iterated with empty literal list, initial_value, and terminal_value
 gap> func := { cat, source, range } ->
 >     Iterated(
->         [ ],
+>         CapJitTypedExpression( [ ], cat -> CapJitDataTypeOfListOf( CapJitDataTypeOfMorphismOfCategory( cat ) ) ),
 >         { alpha, beta } -> PreCompose( cat, alpha, beta ),
 >         IdentityMorphism( cat, source ),
 >         IdentityMorphism( cat, range )

--- a/CompilerForCAP/tst/CapJitTypedExpression.tst
+++ b/CompilerForCAP/tst/CapJitTypedExpression.tst
@@ -1,0 +1,46 @@
+gap> START_TEST( "CapJitTypedExpression" );
+
+#
+gap> LoadPackage( "CompilerForCAP", false );
+true
+
+# CapJitTypedExpression with data_type_getter with a single argument
+gap> func := { cat } -> CapJitTypedExpression( [ ], cat -> CapJitDataTypeOfListOf( IsInt ) );;
+gap> ENHANCED_SYNTAX_TREE( func : given_arguments := [ CreateCapCategory( ) ] ).bindings.BINDING_RETURN_VALUE.data_type;
+rec( element_type := rec( filter := <Category "IsInt"> ), 
+  filter := <Category "IsList"> )
+
+# CapJitTypedExpression with data_type_getter without arguments
+gap> func := { } -> CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) );;
+gap> ENHANCED_SYNTAX_TREE( func ).bindings.BINDING_RETURN_VALUE.data_type;
+rec( element_type := rec( filter := <Category "IsInt"> ), 
+  filter := <Category "IsList"> )
+
+# CapJitTypedExpression with data_type_getter returning a filer
+gap> func := { } -> CapJitTypedExpression( [ ], { } -> IsInt );;
+gap> ENHANCED_SYNTAX_TREE( func ).bindings.BINDING_RETURN_VALUE.data_type;
+rec( filter := <Category "IsInt"> )
+
+# CapJitTypedExpression with data_type_getter being a global variable
+gap> data_type_getter := cat -> CapJitDataTypeOfListOf( IsInt );;
+gap> func := { cat } -> CapJitTypedExpression( [ ], data_type_getter );;
+gap> ENHANCED_SYNTAX_TREE( func : given_arguments := [ CreateCapCategory( ) ] ).bindings.BINDING_RETURN_VALUE.data_type;
+rec( element_type := rec( filter := <Category "IsInt"> ), 
+  filter := <Category "IsList"> )
+
+# ensure that empty lists of different types are not deduplicated
+gap> func := { } -> Pair( CapJitTypedExpression( [ ], { } -> IsInt ), CapJitTypedExpression( [ ], { } -> IsFloat ) );;
+gap> Display( CapJitCompiledFunction( func, [ [ ], fail ] ) );
+function (  )
+    return NTuple( 2, [  ], [  ] );
+end
+gap> func := { } -> Pair( CapJitTypedExpression( [ ], { } -> IsInt ), CapJitTypedExpression( [ ], { } -> IsInt ) );;
+gap> Display( CapJitCompiledFunction( func, [ [ ], fail ] ) );
+function (  )
+    local deduped_1_1;
+    deduped_1_1 := [  ];
+    return NTuple( 2, deduped_1_1, deduped_1_1 );
+end
+
+#
+gap> STOP_TEST( "CapJitTypedExpression" );

--- a/CompilerForCAP/tst/Logic.tst
+++ b/CompilerForCAP/tst/Logic.tst
@@ -14,9 +14,9 @@ gap> tree := CapJitAppliedLogic( tree );;
 gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 function (  )
     return [ function ( x_2 )
-                return x_2^2;
+                return x_2 ^ 2;
             end( 1 ), function ( x_2 )
-                return x_2^2;
+                return x_2 ^ 2;
             end( 2 ) ];
 end
 
@@ -30,9 +30,9 @@ gap> tree := CapJitAppliedLogic( tree );;
 gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
 function ( L1_1, L2_1 )
     return Concatenation( List( L1_1, function ( x_2 )
-              return x_2^2;
+              return x_2 ^ 2;
           end ), List( L2_1, function ( x_2 )
-              return x_2^2;
+              return x_2 ^ 2;
           end ) );
 end
 
@@ -199,6 +199,42 @@ function ( x_1 )
         return AdditiveInverse( 2 );
     fi;
     return;
+end
+
+# Concatenation of an empty list of lists
+gap> func := { } -> Concatenation( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( CapJitDataTypeOfListOf( IsInt ) ) ) );;
+
+#
+gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
+gap> tree := CapJitInferredDataTypes( tree );;
+gap> tree := CapJitAppliedLogic( tree );;
+gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+function (  )
+    return [  ];
+end
+
+# Concatenation of two empty lists
+gap> func := { } -> Concatenation( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ), CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ) );;
+
+#
+gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
+gap> tree := CapJitInferredDataTypes( tree );;
+gap> tree := CapJitAppliedLogic( tree );;
+gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+function (  )
+    return [  ];
+end
+
+# List of a literal empty list
+gap> func := { } -> List( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ), x -> [ x ] );;
+
+#
+gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( CapJitDataTypeOfListOf( IsInt ) ) ) );;
+gap> tree := CapJitInferredDataTypes( tree );;
+gap> tree := CapJitAppliedLogic( tree );;
+gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+function (  )
+    return [  ];
 end
 
 #

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-03",
+Version := "2023.12-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -866,7 +866,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
     AddZeroObject( category,
       function( cat )
         
-        return AdditiveClosureObject( cat, [ ] );
+        return AdditiveClosureObject( cat, CapJitTypedExpression( [ ], cat -> CapJitDataTypeOfListOf( CapJitDataTypeOfObjectOfCategory( UnderlyingCategory( cat ) ) ) ) );
         
     end );
     


### PR DESCRIPTION
Fixes #1213.

@mohamed-barakat `CapJitTypedExpression` allows to attach a data type to any expression, in particular empty lists and functions which both cannot infer their data type without context information. See the application in AdditiveClosure for an example for how to use this. Of course we can also add convenience methods like `CapJitFunctionWithDomainDataType` or similar later on.

I want to make sure that this works in principle, so feel free to play around with this. Currently, lots of warnings about empty lists are displayed which can be ignored for now.