### PR TITLE
Use only the category for method selection of CAP operations

### DIFF
--- a/CAP/examples/TerminalCategoryWithMultipleObjects.g
+++ b/CAP/examples/TerminalCategoryWithMultipleObjects.g
@@ -10,7 +10,7 @@ T := TerminalCategoryWithMultipleObjects( );
 Display( T );
 #! A CAP category with name TerminalCategoryWithMultipleObjects( ):
 #! 
-#! 63 primitive operations were used to derive 304 operations for this category
+#! 63 primitive operations were used to derive 306 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts

--- a/CAP/examples/TerminalCategoryWithSingleObject.g
+++ b/CAP/examples/TerminalCategoryWithSingleObject.g
@@ -10,7 +10,7 @@ T := TerminalCategoryWithSingleObject( );
 Display( T );
 #! A CAP category with name TerminalCategoryWithSingleObject( ):
 #! 
-#! 63 primitive operations were used to derive 304 operations for this category
+#! 63 primitive operations were used to derive 306 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -167,25 +167,25 @@ InstallGlobalFunction( "CreateCapCategoryWithDataTypes",
     ## plausibility checks
     if not IsSpecializationOfFilter( IsCapCategory, category_filter ) then
         
-        Error( "the category filter must imply IsCapCategory" );
+        Print( "WARNING: filter ", category_filter, " does not imply `IsCapCategory`. This will probably cause errors.\n" );
         
     fi;
     
     if not IsSpecializationOfFilter( IsCapCategoryObject, object_filter ) then
         
-        Error( "the object filter must imply IsCapCategoryObject" );
+        Print( "WARNING: filter ", object_filter, " does not imply `IsCapCategoryObject`. This will probably cause errors.\n" );
         
     fi;
     
     if not IsSpecializationOfFilter( IsCapCategoryMorphism, morphism_filter ) then
         
-        Error( "the morphism filter must imply IsCapCategoryMorphism" );
+        Print( "WARNING: filter ", morphism_filter, " does not imply `IsCapCategoryMorphism`. This will probably cause errors.\n" );
         
     fi;
     
     if not IsSpecializationOfFilter( IsCapCategoryTwoCell, two_cell_filter ) then
         
-        Error( "the two cell filter must imply IsCapCategoryTwoCell" );
+        Print( "WARNING: filter ", two_cell_filter, " does not imply `IsCapCategoryTwoCell`. This will probably cause errors.\n" );
         
     fi;
     

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -234,14 +234,22 @@ end );
 InstallMethod( IsEqualForCache,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],
                
-  { mor1, mor2 } -> IsEqualForCacheForMorphisms( CapCategory( mor1 ), mor1, mor2 ) );
-
-##
-# generic fallback to IsIdenticalObj
-InstallOtherMethod( IsEqualForCacheForMorphisms,
-               [ IsCapCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ],
-               
-  { cat, mor1, mor2 } -> IsIdenticalObj( mor1, mor2 ) );
+  function( mor1, mor2 )
+    local cat;
+    
+    cat := CapCategory( mor1 );
+    
+    # convenience functions with cache which can be applied to different categories might compare morphisms from different categories
+    if not IsIdenticalObj( cat, CapCategory( mor2 ) ) then
+        
+        return false;
+        
+    fi;
+    
+    # every finalized category can compute `IsEqualForCacheForMorphisms`
+    return IsEqualForCacheForMorphisms( cat, mor1, mor2 );
+    
+end );
 
 ##
 InstallMethod( AddMorphismRepresentation,

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -401,48 +401,6 @@ InstallMethod( CoefficientsOfMorphismWithGivenBasisOfExternalHom,
 ##
 ######################################
 
-# This method should usually not be selected when the two morphisms belong to the same category
-InstallOtherMethod( IsEqualForMorphisms,
-                    [ IsCapCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ],
-
-  function( cat, morphism_1, morphism_2 )
-    
-    if not HasCapCategory( morphism_1 ) then
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" has no CAP category" ) );
-    fi;
-    if not HasCapCategory( morphism_2 ) then
-        Error( Concatenation( "the morphism \"", String( morphism_2 ), "\" has no CAP category" ) );
-    fi;
-    
-    if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
-    else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsEqualForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
-    fi;
-    
-end );
-
-# This method should usually not be selected when the two morphisms belong to the same category
-InstallOtherMethod( IsCongruentForMorphisms,
-                    [ IsCapCategory, IsCapCategoryMorphism, IsCapCategoryMorphism ],
-
-  function( cat, morphism_1, morphism_2 )
-    
-    if not HasCapCategory( morphism_1 ) then
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" has no CAP category" ) );
-    fi;
-    if not HasCapCategory( morphism_2 ) then
-        Error( Concatenation( "the morphism \"", String( morphism_2 ), "\" has no CAP category" ) );
-    fi;
-    
-    if not IsIdenticalObj( CapCategory( morphism_1 ), CapCategory( morphism_2 ) ) then
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" do not belong to the same CAP category" ) );
-    else
-        Error( Concatenation( "the morphism \"", String( morphism_1 ), "\" and the morphism \"", String( morphism_2 ), "\" belong to the same CAP category, but no specific method IsCongruentForMorphisms is installed. Maybe you forgot to finalize the category?" ) );
-    fi;
-    
-end );
-
 ##
 InstallMethod( \=,
                [ IsCapCategoryMorphism, IsCapCategoryMorphism ],

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -215,14 +215,22 @@ IsZeroForObjects );
 InstallMethod( IsEqualForCache,
                [ IsCapCategoryObject, IsCapCategoryObject ],
                
-  { obj1, obj2 } -> IsEqualForCacheForObjects( CapCategory( obj1 ), obj1, obj2 ) );
-
-##
-# generic fallback to IsIdenticalObj
-InstallOtherMethod( IsEqualForCacheForObjects,
-               [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ],
-               
-  { cat, obj1, obj2 } -> IsIdenticalObj( obj1, obj2 ) );
+  function( obj1, obj2 )
+    local cat;
+    
+    cat := CapCategory( obj1 );
+    
+    # convenience functions with cache which can be applied to different categories might compare objects from different categories
+    if not IsIdenticalObj( cat, CapCategory( obj2 ) ) then
+        
+        return false;
+        
+    fi;
+    
+    # every finalized category can compute `IsEqualForCacheForObjects`
+    return IsEqualForCacheForObjects( cat, obj1, obj2 );
+    
+end );
 
 ##
 InstallMethod( AddObjectRepresentation,

--- a/CAP/gap/CategoryObjects.gi
+++ b/CAP/gap/CategoryObjects.gi
@@ -35,27 +35,6 @@ InstallValue( PROPAGATION_LIST_FOR_EQUAL_OBJECTS,
 ##
 ###################################
 
-# This method should usually not be selected when the two morphisms belong to the same category
-InstallOtherMethod( IsEqualForObjects,
-                    [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ],
-
-  function( cat, object_1, object_2 )
-
-    if not HasCapCategory( object_1 ) then
-        Error( Concatenation( "the object \"", String( object_1 ), "\" has no CAP category" ) );
-    fi;
-    if not HasCapCategory( object_2 ) then
-        Error( Concatenation( "the object \"", String( object_2 ), "\" has no CAP category" ) );
-    fi;
-
-    if not IsIdenticalObj( CapCategory( object_1 ), CapCategory( object_2 ) ) then
-        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" do not belong to the same CAP category" ) );
-    else
-        Error( Concatenation( "the object \"", String( object_1 ), "\" and the object \"", String( object_2 ), "\" belong to the same CAP category, but no specific method IsEqualForObjects is installed. Maybe you forgot to finalize the category?" ) );
-    fi;
-    
-end );
-
 ##
 InstallMethod( \=,
                [ IsCapCategoryObject, IsCapCategoryObject ],

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -4132,6 +4132,21 @@ AddFinalDerivationBundle( # IsomorphismFromHomologyObjectToItsConstructionAsAnIm
       Description := "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject as the identity of the homology object constructed as an image object" );
 
 
+## Final method for IsEqualForCacheForObjects/Morphisms
+##
+AddFinalDerivation( IsEqualForCacheForObjects,
+                    [ ],
+                    [ IsEqualForCacheForObjects ],
+                    
+  { cat, mor1, mor2 } -> IsIdenticalObj( mor1, mor2 ) : Description := "using IsIdenticalObj" );
+
+##
+AddFinalDerivation( IsEqualForCacheForMorphisms,
+                    [ ],
+                    [ IsEqualForCacheForMorphisms ],
+                    
+  { cat, mor1, mor2 } -> IsIdenticalObj( mor1, mor2 ) : Description := "using IsIdenticalObj" );
+
 ## Final method for IsEqualForObjects
 ##
 AddFinalDerivation( IsEqualForObjects,
@@ -4140,7 +4155,7 @@ AddFinalDerivation( IsEqualForObjects,
                     
   ReturnFail );
 
-## Final methods for IsEqual/IsEqualForMorphisms
+## Final methods for IsEqual/IsCongruentForMorphisms
 ##
 AddFinalDerivation( IsCongruentForMorphisms,
                     [ ],

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -498,10 +498,16 @@ InstallGlobalFunction( CapInternalInstallAdd,
                     
                     if not IsFinalized( category ) then
                         
-                        Display( Concatenation(
-                            "WARNING: You are calling an operation in a unfinalized category with name \"", Name( category ),
-                            "\". This is fine for debugging purposes, but for production use you should finalize the category by calling `Finalize` (with the option `FinalizeCategory := true` if needed)."
-                        ) );
+                        Print(
+                            "WARNING: You are calling an operation in a unfinalized category with name \"", Name( category ), "\".",
+                            " This is fine for debugging purposes, but for production use you should finalize the category by calling `Finalize` (with the option `FinalizeCategory := true` if needed).\n"
+                        );
+                        
+                        if not CanCompute( category, "IsEqualForCacheForObjects" ) or not CanCompute( category, "IsEqualForCacheForMorphisms" ) then
+                            
+                            Print( "You might run into caching related errors because IsEqualForCacheForObjects and/or IsEqualForCacheForMorphisms are not yet installed for this category.\n" );
+                            
+                        fi;
                         
                     fi;
                     

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -186,7 +186,7 @@ InstallGlobalFunction( CapInternalInstallAdd,
                    [ IsCapCategory, IsList, IsInt ],
       
       function( category, method_list, weight )
-        local install_func, replaced_filter_list, needs_wrapping, i, is_derivation, is_final_derivation, is_precompiled_derivation, without_given_name, with_given_name,
+        local install_func, needs_wrapping, i, is_derivation, is_final_derivation, is_precompiled_derivation, without_given_name, with_given_name,
               without_given_weight, with_given_weight, number_of_proposed_arguments, current_function_number,
               current_function_argument_number, current_additional_filter_list_length, input_human_readable_identifier_getter, input_sanity_check_functions,
               output_human_readable_identifier_getter, output_sanity_check_function, name;
@@ -237,8 +237,6 @@ InstallGlobalFunction( CapInternalInstallAdd,
             Error( "at most one of the options `IsDerivation`, `IsFinalDerivation` and `IsPrecompiledDerivation` may be set" );
             
         fi;
-        
-        replaced_filter_list := CAP_INTERNAL_REPLACE_STRINGS_WITH_FILTERS( filter_list, category );
         
         ## Nr arguments sanity check
         
@@ -484,9 +482,17 @@ InstallGlobalFunction( CapInternalInstallAdd,
         install_func := function( func_to_install, additional_filters )
           local new_filter_list, index;
             
+            Assert( 0, filter_list[1] = "category" );
+            
+            new_filter_list := Concatenation( [ CategoryFilter( category ) ], ListWithIdenticalEntries( Length( filter_list ) - 1, IsObject ) );
+            
+            CAP_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( ValueGlobal( install_name ), new_filter_list, Length( category!.added_functions.( function_name ) ), { operation_name } -> Concatenation(
+                "WARNING: A method for the CAP operation ", operation_name, " was installed manually (e.g. using Install(Other)Method). This is not supported.\n"
+            ) );
+            
             Add( category!.added_functions.( function_name ), [ func_to_install, additional_filters ] );
             
-            new_filter_list := CAP_INTERNAL_MERGE_FILTER_LISTS( replaced_filter_list, additional_filters );
+            new_filter_list := CAP_INTERNAL_MERGE_FILTER_LISTS( new_filter_list, additional_filters );
             
             if category!.overhead then
                 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1304,7 +1304,7 @@ MultiplyWithElementOfCommutativeRingForMorphisms := rec(
   
   pre_function := function( cat, r, morphism )
     
-    if not r in CommutativeRingOfLinearCategory( CapCategory( morphism ) ) then
+    if not r in CommutativeRingOfLinearCategory( cat ) then
       
       return [ false, "the first argument is not an element of the ring of the category of the morphism" ];
       
@@ -2510,16 +2510,13 @@ IsWellDefinedForMorphisms := rec(
   dual_operation := "IsWellDefinedForMorphisms",
   
   redirect_function := function( cat, morphism )
-    local category, source, range;
+    local source, range;
     
     source := Source( morphism );
     
     range := Range( morphism );
     
-    category := CapCategory( morphism );
-    
-    if not ( IsWellDefined( source ) and IsWellDefined( range ) ) or
-       not ( IsIdenticalObj( CapCategory( source ), category ) and IsIdenticalObj( CapCategory( range ), category ) ) then
+    if not ( IsWellDefinedForObjects( cat, source ) and IsWellDefinedForObjects( cat, range ) ) then
       
       return [ true, false ];
       

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1689,3 +1689,41 @@ InstallGlobalFunction( LastWithKeys, function ( list, func )
     return fail;
     
 end );
+
+##
+# Checks if similar methods for `operation` exist.
+# If `operation` is not a operation, "Op" is appended to its name.
+# "similar" means: a method of `operation` with the same number of filters as `filters` and
+# each filter implying or being implied by the corresponding filter in `filters`.
+# Throws an error if the number of similar methods is strictly smaller than `expected_number_of_methods`
+# and displays a warning if the number of similar methods is strictly greater than `expected_number_of_methods`
+# The warning is composed using `warning_message_getter`.
+BindGlobal( "CAP_INTERNAL_WARN_ABOUT_SIMILAR_METHODS", function ( operation, filters, expected_number_of_methods, warning_message_getter )
+  local similar_methods;
+    
+    if not IsOperation( operation ) then
+        
+        operation := ValueGlobal( Concatenation( NameFunction( operation ), "Op" ) );
+        
+    fi;
+    
+    Assert( 0, IsOperation( operation ) );
+    
+    similar_methods := Filtered( MethodsOperation( operation, Length( filters ) ), m -> ForAll( [ 1 .. Length( filters ) ], i ->
+        IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( m.argFilt[i] ), WITH_IMPS_FLAGS( FLAGS_FILTER( filters[i] ) ) ) or
+        IS_SUBSET_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( filters[i] ) ), WITH_IMPS_FLAGS( m.argFilt[i] ) )
+    ) );
+    
+    if Length( similar_methods ) < expected_number_of_methods then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        Error( "found fewer methods than expected" );
+        
+    elif Length( similar_methods ) > expected_number_of_methods then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        Display( warning_message_getter( NameFunction( operation ) ) );
+        
+    fi;
+    
+end );

--- a/CAP/tst/bare.tst
+++ b/CAP/tst/bare.tst
@@ -1,0 +1,48 @@
+gap> START_TEST( "bare" );
+
+#
+gap> LoadPackage( "CAP", false );
+true
+gap> LoadPackage( "MatricesForHomalg", false );
+true
+
+#
+gap> ZZ := HomalgRingOfIntegers( );;
+gap> cat := CreateCapCategory( "Mat_ZZ", IsCapCategory, IsInt, IsHomalgMatrix, IsCapCategoryTwoCell );
+WARNING: filter <Category "IsInt"> does not imply `IsCapCategoryObject`. This \
+will probably cause errors.
+WARNING: filter <Category "IsHomalgMatrix"> does not imply `IsCapCategoryMorph\
+ism`. This will probably cause errors.
+Mat_ZZ
+gap> cat!.category_as_first_argument := true;;
+gap> DisableSanityChecks( cat );
+gap> #AddIsEqualForObjects( cat, { cat, dim1, dim2 } -> dim1 = dim2 ); TODO
+gap> AddIsWellDefinedForObjects( cat, { cat, dim } -> IsInt( dim ) and dim >= 0 );
+gap> AddIsWellDefinedForMorphisms( cat, { cat, matrix } -> IsHomalgMatrix( matrix ) and IsIdenticalObj( HomalgRing( matrix ), ZZ ) and HasSource( matrix ) and Source( matrix ) = NrRows( matrix ) and HasRange( matrix ) and Range( matrix ) = NrCols( matrix ) and ForAll( [ 1 .. NrRows( matrix ) ], i -> ForAll( [ 1 .. NrCols( matrix ) ], j -> IsInt( matrix[i,j] ) ) ) );
+gap> AddIsEqualForMorphisms( cat, { cat, matrix1, matrix2 } -> ForAll( [ 1 .. NrRows( matrix1 ) ], i -> ForAll( [ 1 .. NrCols( matrix1 ) ], j -> matrix1[i,j] = matrix2[i,j] ) ) );
+gap> AddIsCongruentForMorphisms( cat, { cat, matrix1, matrix2 } -> IsEqualForMorphisms( cat, matrix1, matrix2 ) );
+gap> AddPreCompose( cat, function ( cat, matrix1, matrix2 )
+> local result;
+>   result := matrix1 * matrix2;
+>   SetSource( result, Source( matrix1 ) );
+>   SetRange( result, Range( matrix2 ) );
+>   return result;
+> end );
+gap> AddIdentityMorphism( cat, function ( cat, dim )
+> local result;
+>   result := HomalgIdentityMatrix( dim, ZZ );
+>   SetSource( result, dim );
+>   SetRange( result, dim );
+>   return result;
+> end );
+gap> Finalize( cat );;
+gap> IsWellDefinedForObjects( cat, 2 );
+true
+gap> id := IdentityMorphism( cat, 2 );;
+gap> IsWellDefinedForMorphisms( cat, id );
+true
+gap> IsCongruentForMorphisms( cat, id, PreCompose( cat, id, id ) );
+true
+
+#
+gap> STOP_TEST( "bare" );

--- a/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
+++ b/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
@@ -16,7 +16,7 @@ distributive := DummyCategory( rec(
                   "IsSkeletalCategory" ] ) );;
 
 InfoOfInstalledOperationsOfCategory( distributive );
-#! 19 primitive operations were used to derive 110 operations for this category
+#! 19 primitive operations were used to derive 112 operations for this category
 #! which algorithmically
 #! * IsBicartesianClosedCategory
 #! and furthermore mathematically

--- a/CartesianCategories/examples/InitialCategory.g
+++ b/CartesianCategories/examples/InitialCategory.g
@@ -10,7 +10,7 @@ IsInitialCategory( I );
 Display( I );
 #! A CAP category with name InitialCategory( ):
 #! 
-#! 5 primitive operations were used to derive 13 operations for this category
+#! 5 primitive operations were used to derive 15 operations for this category
 #! which mathematically
 #! * IsInitialCategory
 OI := Opposite( I );
@@ -20,7 +20,7 @@ IsInitialCategory( OI );
 Display( OI );
 #! A CAP category with name Opposite( InitialCategory( ) ):
 #! 
-#! 17 primitive operations were used to derive 17 operations for this category
+#! 19 primitive operations were used to derive 19 operations for this category
 #! which mathematically
 #! * IsInitialCategory
 #! @EndExample

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -60,6 +60,8 @@
 #! * <Ref BookName="CAP" Func="IsEpimorphism" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualAsFactorobjects" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualAsSubobjects" Label="for Is" />
+#! * <Ref BookName="CAP" Func="IsEqualForCacheForMorphisms" Label="for Is" />
+#! * <Ref BookName="CAP" Func="IsEqualForCacheForObjects" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualForMorphisms" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualForMorphismsOnMor" Label="for Is" />
 #! * <Ref BookName="CAP" Func="IsEqualForObjects" Label="for Is" />

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -80,7 +80,7 @@ Display( CohP1 );
 #! The Serre quotient category of The category of graded left f.p. modules
 #! over Q[x,y] (with weights [ 1, 1 ]) by test function with name: is_artinian:
 #! 
-#! 21 primitive operations were used to derive 184 operations for this category
+#! 21 primitive operations were used to derive 186 operations for this category
 #! which algorithmically
 #! * IsAbelianCategory
 Sh := CanonicalProjection( CohP1 );

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -2370,6 +2370,28 @@ end
     , 205 : IsPrecompiledDerivation := true );
     
     ##
+    AddIsEqualForCacheForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IS_IDENTICAL_OBJ( arg2_1, arg3_1 );
+end
+########
+        
+    , 1 : IsPrecompiledDerivation := true );
+    
+    ##
+    AddIsEqualForCacheForObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return IS_IDENTICAL_OBJ( arg2_1, arg3_1 );
+end
+########
+        
+    , 1 : IsPrecompiledDerivation := true );
+    
+    ##
     AddIsEqualForMorphisms( cat,
         
 ########


### PR DESCRIPTION
The main commit is the 4th commit. For example, the method for `IdentityMorphism` is now installed with filters `[ CategoryFilter( cat ), IsObject ]` instead of `[ CategoryFilter( cat ), ObjectFilter( cat ) ]` (convenience methods are unaffected by this). This has several advantages:

1. It corresponds to how CompilerForCAP selects methods for CAP operations.
2. Method selection might be a bit faster (I have not checked).
3. It allows to model bare categories (categories with primitive data structures like integers for objects) without further modifications (see the last commit).
4. It automatically covers some cases of wrong input which previously were caught by special fallbacks, see the removed code in the 4th commit. For example, when calling `IsEqualForObjects` with two objects in different categories one now automatically gets "Error, The CapCategory of the 3-th argument of the function IsEqualForObjects of the category named ... is not identical to the category named ...."
5. It emphasizes that the category is the single source of truth.

It also has some disadvantages:
1. One cannot install convenience methods for CAP operations with the same number of arguments as the actual CAP operation anymore. However, I've never seen such convenience methods, they would be forbidden when using CompilerForCAP anyway, and I have added a warning catching this case.
2. The type checking now only happens in the input sanity checks. So when input sanity checks are disabled not even basic filters are tested. However, I would say that this should actually be expected by the user when disabling input sanity checks :D

@ all: Are you fine with this change?
