### PR TITLE
Warn if a derivation depends on other categories but does not test if those are available

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.02-10",
+Version := "2023.02-11",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -46,6 +46,12 @@ function( name, target_op, used_op_names_with_multiples_and_category_getters, we
         
     fi;
     
+    if ForAny( used_op_names_with_multiples_and_category_getters, x -> x[3] <> fail ) and category_filter = IsCapCategory then
+        
+        Print( "WARNING: A derivation for ", NameFunction( target_op ), " depends on other categories (e.g. RangeCategoryOfHomomorphismStructure) but does no test via the CategoryFilter if the other categories are available (e.g. by testing HasRangeCategoryOfHomomorphismStructure).\n" );
+        
+    fi;
+    
     if IsProperty( category_filter ) then
         
         category_filter := Tester( category_filter ) and category_filter;

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -2695,6 +2695,7 @@ AddDerivationToCAP( Lift,
     return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Source( alpha ), Source( beta ), Lift( range_cat, a, b ) );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive Lift using the homomorphism structure and Lift in the range of the homomorphism structure" );
 
 ##
@@ -2725,6 +2726,7 @@ AddDerivationToCAP( LiftOrFail,
     return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Source( alpha ), Source( beta ), l );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive LiftOrFail using the homomorphism structure and LiftOrFail in the range of the homomorphism structure" );
 
 ##
@@ -2746,6 +2748,7 @@ AddDerivationToCAP( IsLiftable,
     return IsLiftable( range_cat, a, b );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive IsLiftable using the homomorphism structure and Liftable in the range of the homomorphism structure" );
 
 ## B ←β- C -α→ A, α•ℓ = β ⇔ ν(ℓ)•H(α,B) = ν(β)
@@ -2769,6 +2772,7 @@ AddDerivationToCAP( Colift,
     return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Range( alpha ), Range( beta ), Lift( range_cat, b, a ) );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive Colift using the homomorphism structure and Lift in the range of the homomorphism structure" );
 
 ##
@@ -2799,6 +2803,7 @@ AddDerivationToCAP( ColiftOrFail,
     return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Range( alpha ), Range( beta ), l );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive ColiftOrFail using the homomorphism structure and LiftOrFail in the range of the homomorphism structure" );
 
 ##
@@ -2820,6 +2825,7 @@ AddDerivationToCAP( IsColiftable,
     return IsLiftable( range_cat, b, a );
     
 end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      CategoryFilter := cat -> HasRangeCategoryOfHomomorphismStructure( cat ),
       Description := "Derive IsColiftable using the homomorphism structure and IsLiftable in the range of the homomorphism structure" );
 
 ##

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -72,7 +72,7 @@ end );
 InstallGlobalFunction( AddFinalDerivationBundle,
                
   function( can_compute, cannot_compute, additional_functions... )
-    local weight, description, category_filter, loop_multiplier, category_getters, function_called_before_installation, operations_in_graph, operations_to_install, union_of_collected_lists, derivations, collected_list, used_op_names_with_multiples_and_category_getters, dummy_derivation, final_derivation, i, current_additional_func, x;
+    local weight, description, category_filter, loop_multiplier, category_getters, function_called_before_installation, operations_in_graph, operations_to_install, union_of_collected_lists, derivations, collected_list, used_op_names_with_multiples_and_category_getters, dummy_func, dummy_derivation, final_derivation, i, current_additional_func, x;
     
     if IsEmpty( additional_functions ) then
         
@@ -264,10 +264,15 @@ InstallGlobalFunction( AddFinalDerivationBundle,
         
     fi;
     
+    dummy_func := x -> x;
+    #= comment for Julia
+    SetNameFunction( dummy_func, "internal dummy function of a final derivation" );
+    # =#
+    
     # only used to check if we can install all the derivations in `derivations`
     dummy_derivation := MakeDerivation(
         "dummy derivation",
-        IsEqualForObjects,
+        dummy_func,
         used_op_names_with_multiples_and_category_getters,
         1,
         ReturnTrue,


### PR DESCRIPTION
@mohamed-barakat @kamalsaleh  This might display warnings in your packages which can be fixed by adding correct CategoryFilters similar to the CategoryFilters added in this PR.