### PR TITLE
Add warning about using the filter `IsString` for data types

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.03-02",
+Version := "2023.03-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -373,7 +373,7 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
             
         end;
         
-    elif IsSpecializationOfFilter( IsList, filter ) and not IsSpecializationOfFilter( IsString, filter ) then
+    elif IsSpecializationOfFilter( IsList, filter ) then
         
         # In principle, we have to create an assertion function for each integer to get the human readable identifier correct.
         # The "correct" approach would be to generate those on demand but that would imply that we have to create assertion functions at runtime.

--- a/CAP/tst/CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER.tst
+++ b/CAP/tst/CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER.tst
@@ -7,7 +7,7 @@ true
 #
 gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( rec( filter := IsFunction, signature := [ [ rec( filter := IsInt ) ], fail ] ), [ "test value" ] )( x -> x );
 gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( rec( filter := IsList, element_type := rec( filter := IsList, element_type := rec( filter := IsInt ) ) ), [ "test value" ] )( [ [ 1, 2, 3, 4 ] ] );
-gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( rec( filter := IsNTuple, element_types := [ rec( filter := IsInt ), rec( filter := IsString ) ] ), [ "test value" ] )( Pair( 1, "2" ) );
+gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( rec( filter := IsNTuple, element_types := [ rec( filter := IsInt ), rec( filter := IsStringRep ) ] ), [ "test value" ] )( Pair( 1, "2" ) );
 gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( CapJitDataTypeOfCategory( CapCat ), [ "test value" ] )( CapCat );
 gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( CapJitDataTypeOfObjectOfCategory( CapCat ), [ "test value" ] )( TerminalObject( CapCat ) );
 gap> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( CapJitDataTypeOfMorphismOfCategory( CapCat ), [ "test value" ] )( IdentityMorphism( TerminalObject( CapCat ) ) );

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.03-02",
+Version := "2023.03-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/InferDataTypes.gd
+++ b/CompilerForCAP/gap/InferDataTypes.gd
@@ -16,6 +16,8 @@
 #!   * `IsNTuple` with additional component `element_types`: The types of the elements of the tuple.
 #!   * filters implying `IsCapCategory`, `IsCapCategoryObject`, `IsCapCategoryMorphism`, or `IsCapCategoryTwoCell` with additional component `category`:
 #!     The category instance (to which the object, morphism or two cell belongs).
+#!   WARNING: `IsString` implies `IsList`, so when creating a data type with filter implying `IsString` one must set `element_type` to
+#!   a data type with filter `IsChar`, or use `IsStringRep` instead of `IsString`.
 #! @Returns a record
 #! @Arguments tree
 DeclareGlobalFunction( "CapJitInferredDataTypes" );


### PR DESCRIPTION
`IsString` implies `IsList`, so when creating a data type with filter implying `IsString` one must set `element_type` to a data type with filter `IsChar`, or use `IsStringRep` instead of `IsString`.

@mohamed-barakat This might be relevant for you in the future, for example if the category of decorated quivers would incorporate the color strings in its data structures.