### PR TITLE
Allow to distinguish between (small) integers and big integers for Julia

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.04-04",
+Version := "2023.04-05",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -346,3 +346,11 @@ DeclareGlobalFunction( "FirstWithKeys" );
 #! @Arguments list, func
 #! @Returns a list
 DeclareGlobalFunction( "LastWithKeys" );
+
+#= comment for Julia
+# In Julia we have to distinguish between (small) integers and big integers. In GAP there is no difference.
+DeclareSynonym( "IsBigInt", IsInt );
+# CompilerForCAP has to distinguish between BigInt and IdFunc
+DeclareGlobalFunction( "BigInt" );
+InstallGlobalFunction( BigInt, IdFunc );
+# =#

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.04-01",
+Version := "2023.04-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -962,6 +962,7 @@ CapJitAddTypeSignature( "IS_IDENTICAL_OBJ", [ IsObject, IsObject ], IsBool );
 CapJitAddTypeSignature( "^", [ IsPerm, IsInt ], IsPerm );
 CapJitAddTypeSignature( "PermList", [ IsList ], IsPerm );
 CapJitAddTypeSignature( "PermutationMat", [ IsPerm, IsInt ], rec( filter := IsList, element_type := rec( filter := IsList, element_type := rec( filter := IsInt ) ) ) );
+CapJitAddTypeSignature( "BigInt", [ IsInt ], IsBigInt );
 
 CapJitAddTypeSignature( "ID_FUNC", [ IsObject ], function ( input_types )
     

--- a/CompilerForCAP/gap/ResolveGlobalVariables.gi
+++ b/CompilerForCAP/gap/ResolveGlobalVariables.gi
@@ -10,6 +10,9 @@ BindGlobal( "CAP_JIT_NON_RESOLVABLE_GLOBAL_VARIABLE_NAMES", [
     "CreateCapCategoryObjectWithAttributes",
     "CreateCapCategoryMorphismWithAttributes",
     "CAP_JIT_INCOMPLETE_LOGIC",
+    # we do not want to simplify (Is)BigInt to IsInt resp. IdFunc to keep the distinction for Julia
+    "IsBigInt",
+    "BigInt",
 ] );
 
 InstallGlobalFunction( "CapJitResolvedGlobalVariables", function ( tree )


### PR DESCRIPTION
Ideally, we would declare `IsBigInt` as a filter different from `IsInt` to properly distinguish the two in the type system of CompilerForCAP. However, this would make calling `InstallMethod` with filter `IsBigInt` impossible because we cannot force GAP's integers to lie in `IsBigInt`. Additionally, we would have to dynamically decide if literal integers should be interpreted as `IsInt` or as `IsBigInt` depending on the context in the type system of CompilerForCAP. So for now we just make `IsBigInt` a synonym of `IsInt`.