### PR TITLE
Explicitly pass the opposite category as second argument to *Test

### DIFF
--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2023.05-02",
+Version := "2023.05-03",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/CartesianCategories/gap/BraidedCartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/BraidedCartesianCategoriesTest.gi
@@ -9,14 +9,12 @@
 
 InstallGlobalFunction( "BraidedCartesianCategoriesTest",
     
-    function( cat, a, b )
+    function( cat, opposite, a, b )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, braiding_a_b, braiding_a_b_op, braiding_inverse_a_b, braiding_inverse_a_b_op, 
               b_op, braiding_b_a, braiding_b_a_op, braiding_inverse_b_a, braiding_inverse_b_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/BraidedCocartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/BraidedCocartesianCategoriesTest.gi
@@ -9,14 +9,12 @@
 
 InstallGlobalFunction( "BraidedCocartesianCategoriesTest",
     
-    function( cat, a, b )
+    function( cat, opposite, a, b )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, braiding_a_b, braiding_a_b_op, braiding_inverse_a_b, braiding_inverse_a_b_op, 
               b_op, braiding_b_a, braiding_b_a_op, braiding_inverse_b_a, braiding_inverse_b_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/CartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/CartesianCategoriesTest.gi
@@ -9,9 +9,9 @@
 
 InstallGlobalFunction( "CartesianCategoriesTest",
     
-    function( cat, a, b, c, alpha, beta )
+    function( cat, opposite, a, b, c, alpha, beta )
     
-        local opposite, verbose,
+        local verbose,
               
               a_op,
               b_op,
@@ -32,8 +32,6 @@ InstallGlobalFunction( "CartesianCategoriesTest",
               
               associator_left_to_right_abc, associator_left_to_right_abc_op, associator_right_to_left_abc, associator_right_to_left_abc_op,
               associator_left_to_right_cba, associator_left_to_right_cba_op, associator_right_to_left_cba, associator_right_to_left_cba_op;
-        
-        opposite := Opposite( cat );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/CartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/CartesianCategoriesTest.gi
@@ -44,7 +44,7 @@ InstallGlobalFunction( "CartesianCategoriesTest",
         
         verbose := ValueOption( "verbose" ) = true;
         
-        if CanCompute( cat, "DirectProductOnMorphisms" ) then 
+        if CanCompute( cat, "DirectProductOnMorphisms" ) then
             
             if verbose then
                 

--- a/CartesianCategories/gap/CartesianClosedCategoriesTest.gi
+++ b/CartesianCategories/gap/CartesianClosedCategoriesTest.gi
@@ -9,9 +9,9 @@
 
 InstallGlobalFunction( "CartesianClosedCategoriesTest",
     
-    function( cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
+    function( cat, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -77,8 +77,6 @@ InstallGlobalFunction( "CartesianClosedCategoriesTest",
               
               isomorphism_from_a_to_hom, isomorphism_from_exp_to_a, isomorphism_from_a_to_coexp_op, isomorphism_from_coexp_to_a_op,
               isomorphism_from_b_to_hom, isomorphism_from_exp_to_b, isomorphism_from_b_to_coexp_op, isomorphism_from_coexp_to_b_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/CocartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/CocartesianCategoriesTest.gi
@@ -44,7 +44,7 @@ InstallGlobalFunction( "CocartesianCategoriesTest",
         
         verbose := ValueOption( "verbose" ) = true;
         
-        if CanCompute( cat, "CoproductOnMorphisms" ) then 
+        if CanCompute( cat, "CoproductOnMorphisms" ) then
             
             if verbose then
                 

--- a/CartesianCategories/gap/CocartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/CocartesianCategoriesTest.gi
@@ -9,9 +9,9 @@
 
 InstallGlobalFunction( "CocartesianCategoriesTest",
     
-    function( cat, a, b, c, alpha, beta )
+    function( cat, opposite, a, b, c, alpha, beta )
     
-        local opposite, verbose,
+        local verbose,
               
               a_op,
               b_op,
@@ -32,8 +32,6 @@ InstallGlobalFunction( "CocartesianCategoriesTest",
               
               associator_left_to_right_abc, associator_left_to_right_abc_op, associator_right_to_left_abc, associator_right_to_left_abc_op,
               associator_left_to_right_cba, associator_left_to_right_cba_op, associator_right_to_left_cba, associator_right_to_left_cba_op;
-        
-        opposite := Opposite( cat );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/CocartesianCoclosedCategoriesTest.gi
+++ b/CartesianCategories/gap/CocartesianCoclosedCategoriesTest.gi
@@ -9,9 +9,9 @@
 
 InstallGlobalFunction( "CocartesianCoclosedCategoriesTest",
     
-    function( cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
+    function( cat, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
     
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -77,8 +77,6 @@ InstallGlobalFunction( "CocartesianCoclosedCategoriesTest",
               
               isomorphism_from_a_to_cohom, isomorphism_from_coexp_to_a, isomorphism_from_a_to_exp_op, isomorphism_from_exp_to_a_op,
               isomorphism_from_b_to_cohom, isomorphism_from_coexp_to_b, isomorphism_from_b_to_exp_op, isomorphism_from_exp_to_b_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/CartesianCategories/gap/CodistributiveCocartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/CodistributiveCocartesianCategoriesTest.gi
@@ -9,14 +9,12 @@
 
 InstallGlobalFunction( "CodistributiveCocartesianCategoriesTest",
     
-    function( cat, a, L )
+    function( cat, opposite, a, L )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, left_expanding_a_L, left_expanding_a_L_op, left_factoring_a_L, left_factoring_a_L_op, 
               L_op, right_expanding_L_a, right_expanding_L_a_op, right_factoring_L_a, right_factoring_L_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         L_op := List( L, l -> Opposite( opposite, l ) );

--- a/CartesianCategories/gap/DistributiveCartesianCategoriesTest.gi
+++ b/CartesianCategories/gap/DistributiveCartesianCategoriesTest.gi
@@ -9,14 +9,12 @@
 
 InstallGlobalFunction( "DistributiveCartesianCategoriesTest",
     
-    function( cat, a, L )
+    function( cat, opposite, a, L )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, left_expanding_a_L, left_expanding_a_L_op, left_factoring_a_L, left_factoring_a_L_op, 
               L_op, right_expanding_L_a, right_expanding_L_a_op, right_factoring_L_a, right_factoring_L_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         L_op := List( L, l -> Opposite( opposite, l ) );

--- a/CartesianCategories/tst/TerminalCategoryCartesian.tst
+++ b/CartesianCategories/tst/TerminalCategoryCartesian.tst
@@ -8,8 +8,6 @@ gap> START_TEST( "TerminalCategoryCartesian" );
 #
 gap> LoadPackage( "CartesianCategories", false );
 true
-gap> LoadPackage( "MonoidalCategories", false );
-true
 
 #
 gap> T := TerminalCategoryWithMultipleObjects( );;
@@ -97,15 +95,15 @@ gap> c := "c" / T;;
 gap> d := "d" / T;;
 
 #
-gap> u := TensorUnit( T );;
+gap> u := TerminalObject( T );;
 
 #
-gap> a_product_b := TensorProduct( a, b );;
-gap> c_product_d := TensorProduct( c, d );;
+gap> a_product_b := DirectProduct( a, b );;
+gap> c_product_d := DirectProduct( c, d );;
 
 #
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
+gap> hom_ab := ExponentialOnObjects( a, b );;
+gap> hom_cd := ExponentialOnObjects( c, d );;
 
 #
 gap> alpha := MorphismConstructor( a, "f_ab", b );;
@@ -123,12 +121,12 @@ gap> CartesianClosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, ep
 gap> z := ZeroObject( T );;
 
 #
-gap> z_product_a := TensorProduct( z, a );;
-gap> a_product_z := TensorProduct( a, z );;
+gap> z_product_a := DirectProduct( z, a );;
+gap> a_product_z := DirectProduct( a, z );;
 
 #
-gap> hom_za := InternalHom( z, a );;
-gap> hom_az := InternalHom( a, z );;
+gap> hom_za := ExponentialOnObjects( z, a );;
+gap> hom_az := ExponentialOnObjects( a, z );;
 
 #
 gap> alpha := MorphismConstructor( z, "f_za", a );;

--- a/CartesianCategories/tst/TerminalCategoryCartesian.tst
+++ b/CartesianCategories/tst/TerminalCategoryCartesian.tst
@@ -11,6 +11,8 @@ true
 
 #
 gap> T := TerminalCategoryWithMultipleObjects( );;
+gap> opposite := Opposite( T, "Opposite with all operations" );;
+gap> opposite_primitive := Opposite( T, "Opposite with primitive operations" : only_primitive_operations := true );;
 
 #
 ##############################################
@@ -27,8 +29,8 @@ gap> alpha := MorphismConstructor( a, "f_ab", b );;
 gap> beta := MorphismConstructor( c, "f_cd", d );;
 
 #
-gap> CartesianCategoriesTest( T, a, b, c, alpha, beta );;
-gap> CartesianCategoriesTest( T, a, b, c, alpha, beta : only_primitive_operations := true );;
+gap> CartesianCategoriesTest( T, opposite, a, b, c, alpha, beta );;
+gap> CartesianCategoriesTest( T, opposite_primitive, a, b, c, alpha, beta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -38,12 +40,12 @@ gap> alpha := UniversalMorphismFromZeroObject( a );;
 gap> beta := UniversalMorphismIntoZeroObject( a );;
 
 #
-gap> CartesianCategoriesTest( T, z, a, a, alpha, beta );;
-gap> CartesianCategoriesTest( T, z, a, a, alpha, beta : only_primitive_operations := true );;
+gap> CartesianCategoriesTest( T, opposite, z, a, a, alpha, beta );;
+gap> CartesianCategoriesTest( T, opposite_primitive, z, a, a, alpha, beta );;
 
 #
-gap> CartesianCategoriesTest( T, a, z, z, beta, alpha );;
-gap> CartesianCategoriesTest( T, a, z, z, beta, alpha : only_primitive_operations := true );;
+gap> CartesianCategoriesTest( T, opposite, a, z, z, beta, alpha );;
+gap> CartesianCategoriesTest( T, opposite_primitive, a, z, z, beta, alpha );;
 
 #
 ##############################################
@@ -54,8 +56,8 @@ gap> a := "a" / T;;
 gap> L := [ "b" / T, "c" / T, "d" / T ];;
 
 #
-gap> DistributiveCartesianCategoriesTest( T, a, L );;
-gap> DistributiveCartesianCategoriesTest( T, a, L : only_primitive_operations := true );;
+gap> DistributiveCartesianCategoriesTest( T, opposite, a, L );;
+gap> DistributiveCartesianCategoriesTest( T, opposite_primitive, a, L );;
 
 #
 ##############################################
@@ -66,23 +68,23 @@ gap> a := "a" / T;;
 gap> b := "b" / T;;
 
 #
-gap> BraidedCartesianCategoriesTest( T, a, b );;
-gap> BraidedCartesianCategoriesTest( T, a, b : only_primitive_operations := true );;
+gap> BraidedCartesianCategoriesTest( T, opposite, a, b );;
+gap> BraidedCartesianCategoriesTest( T, opposite_primitive, a, b );;
 
 #
-gap> BraidedCartesianCategoriesTest( T, b, a );;
-gap> BraidedCartesianCategoriesTest( T, b, a : only_primitive_operations := true );;
+gap> BraidedCartesianCategoriesTest( T, opposite, b, a );;
+gap> BraidedCartesianCategoriesTest( T, opposite_primitive, b, a );;
 
 #
 gap> z := ZeroObject( T );;
 
 #
-gap> BraidedCartesianCategoriesTest( T, z, a );;
-gap> BraidedCartesianCategoriesTest( T, z, a : only_primitive_operations := true );;
+gap> BraidedCartesianCategoriesTest( T, opposite, z, a );;
+gap> BraidedCartesianCategoriesTest( T, opposite_primitive, z, a );;
 
 #
-gap> BraidedCartesianCategoriesTest( T, a, z );;
-gap> BraidedCartesianCategoriesTest( T, a, z : only_primitive_operations := true );;
+gap> BraidedCartesianCategoriesTest( T, opposite, a, z );;
+gap> BraidedCartesianCategoriesTest( T, opposite_primitive, a, z );;
 
 #
 ##############################################
@@ -114,8 +116,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomab", hom_ab );;
 gap> zeta := MorphismConstructor( u, "f_uhomcd", hom_cd );;
 
 #
-gap> CartesianClosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CartesianClosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CartesianClosedCategoriesTest( T, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CartesianClosedCategoriesTest( T, opposite_primitive, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -137,8 +139,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomza", hom_za );;
 gap> zeta := MorphismConstructor( u, "f_uhomaz", hom_az );;
 
 #
-gap> CartesianClosedCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CartesianClosedCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CartesianClosedCategoriesTest( T, opposite, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CartesianClosedCategoriesTest( T, opposite_primitive, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 ##############################################

--- a/CartesianCategories/tst/TerminalCategoryCocartesian.tst
+++ b/CartesianCategories/tst/TerminalCategoryCocartesian.tst
@@ -11,6 +11,8 @@ true
 
 #
 gap> T := TerminalCategoryWithMultipleObjects( );;
+gap> opposite := Opposite( T, "Opposite with all operations" );;
+gap> opposite_primitive := Opposite( T, "Opposite with primitive operations" : only_primitive_operations := true );;
 
 #
 ##############################################
@@ -27,8 +29,8 @@ gap> alpha := MorphismConstructor( a, "f_ab", b );;
 gap> beta := MorphismConstructor( c, "f_cd", d );;
 
 #
-gap> CocartesianCategoriesTest( T, a, b, c, alpha, beta );;
-gap> CocartesianCategoriesTest( T, a, b, c, alpha, beta : only_primitive_operations := true );;
+gap> CocartesianCategoriesTest( T, opposite, a, b, c, alpha, beta );;
+gap> CocartesianCategoriesTest( T, opposite_primitive, a, b, c, alpha, beta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -38,12 +40,12 @@ gap> alpha := UniversalMorphismFromZeroObject( a );;
 gap> beta := UniversalMorphismIntoZeroObject( a );;
 
 #
-gap> CocartesianCategoriesTest( T, z, a, a, alpha, beta );;
-gap> CocartesianCategoriesTest( T, z, a, a, alpha, beta : only_primitive_operations := true );;
+gap> CocartesianCategoriesTest( T, opposite, z, a, a, alpha, beta );;
+gap> CocartesianCategoriesTest( T, opposite_primitive, z, a, a, alpha, beta );;
 
 #
-gap> CocartesianCategoriesTest( T, a, z, z, beta, alpha );;
-gap> CocartesianCategoriesTest( T, a, z, z, beta, alpha : only_primitive_operations := true );;
+gap> CocartesianCategoriesTest( T, opposite, a, z, z, beta, alpha );;
+gap> CocartesianCategoriesTest( T, opposite_primitive, a, z, z, beta, alpha );;
 
 #
 ##############################################
@@ -54,8 +56,8 @@ gap> a := "a" / T;;
 gap> L := [ "b" / T, "c" / T, "d" / T ];;
 
 #
-gap> CodistributiveCocartesianCategoriesTest( T, a, L );;
-gap> CodistributiveCocartesianCategoriesTest( T, a, L : only_primitive_operations := true );;
+gap> CodistributiveCocartesianCategoriesTest( T, opposite, a, L );;
+gap> CodistributiveCocartesianCategoriesTest( T, opposite_primitive, a, L );;
 
 #
 ##############################################
@@ -66,23 +68,23 @@ gap> a := "a" / T;;
 gap> b := "b" / T;;
 
 #
-gap> BraidedCocartesianCategoriesTest( T, a, b );;
-gap> BraidedCocartesianCategoriesTest( T, a, b : only_primitive_operations := true );;
+gap> BraidedCocartesianCategoriesTest( T, opposite, a, b );;
+gap> BraidedCocartesianCategoriesTest( T, opposite_primitive, a, b );;
 
 #
-gap> BraidedCocartesianCategoriesTest( T, b, a );;
-gap> BraidedCocartesianCategoriesTest( T, b, a : only_primitive_operations := true );;
+gap> BraidedCocartesianCategoriesTest( T, opposite, b, a );;
+gap> BraidedCocartesianCategoriesTest( T, opposite_primitive, b, a );;
 
 #
 gap> z := ZeroObject( T );;
 
 #
-gap> BraidedCocartesianCategoriesTest( T, z, a );;
-gap> BraidedCocartesianCategoriesTest( T, z, a : only_primitive_operations := true );;
+gap> BraidedCocartesianCategoriesTest( T, opposite, z, a );;
+gap> BraidedCocartesianCategoriesTest( T, opposite_primitive, z, a );;
 
 #
-gap> BraidedCocartesianCategoriesTest( T, a, z );;
-gap> BraidedCocartesianCategoriesTest( T, a, z : only_primitive_operations := true );;
+gap> BraidedCocartesianCategoriesTest( T, opposite, a, z );;
+gap> BraidedCocartesianCategoriesTest( T, opposite_primitive, a, z );;
 
 #
 ##############################################
@@ -114,8 +116,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomab", hom_ab );;
 gap> zeta := MorphismConstructor( u, "f_uhomcd", hom_cd );;
 
 #
-gap> CocartesianCoclosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CocartesianCoclosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CocartesianCoclosedCategoriesTest( T, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CocartesianCoclosedCategoriesTest( T, opposite_primitive, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -137,8 +139,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomza", hom_za );;
 gap> zeta := MorphismConstructor( u, "f_uhomaz", hom_az );;
 
 #
-gap> CocartesianCoclosedCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CocartesianCoclosedCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CocartesianCoclosedCategoriesTest( T, opposite, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CocartesianCoclosedCategoriesTest( T, opposite_primitive, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 ##############################################

--- a/CartesianCategories/tst/TerminalCategoryCocartesian.tst
+++ b/CartesianCategories/tst/TerminalCategoryCocartesian.tst
@@ -8,8 +8,6 @@ gap> START_TEST( "TerminalCategoryCocartesian" );
 #
 gap> LoadPackage( "CartesianCategories", false );
 true
-gap> LoadPackage( "MonoidalCategories", false );
-true
 
 #
 gap> T := TerminalCategoryWithMultipleObjects( );;
@@ -97,15 +95,15 @@ gap> c := "c" / T;;
 gap> d := "d" / T;;
 
 #
-gap> u := TensorUnit( T );;
+gap> u := InitialObject( T );;
 
 #
-gap> a_product_b := TensorProduct( a, b );;
-gap> c_product_d := TensorProduct( c, d );;
+gap> a_product_b := Coproduct( a, b );;
+gap> c_product_d := Coproduct( c, d );;
 
 #
-gap> hom_ab := InternalHom( a, b );;
-gap> hom_cd := InternalHom( c, d );;
+gap> hom_ab := CoexponentialOnObjects( a, b );;
+gap> hom_cd := CoexponentialOnObjects( c, d );;
 
 #
 gap> alpha := MorphismConstructor( a, "f_ab", b );;
@@ -123,12 +121,12 @@ gap> CocartesianCoclosedCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta
 gap> z := ZeroObject( T );;
 
 #
-gap> z_product_a := TensorProduct( z, a );;
-gap> a_product_z := TensorProduct( a, z );;
+gap> z_product_a := Coproduct( z, a );;
+gap> a_product_z := Coproduct( a, z );;
 
 #
-gap> hom_za := InternalHom( z, a );;
-gap> hom_az := InternalHom( a, z );;
+gap> hom_za := CoexponentialOnObjects( z, a );;
+gap> hom_az := CoexponentialOnObjects( a, z );;
 
 #
 gap> alpha := MorphismConstructor( z, "f_za", a );;

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.05-02",
+Version := "2023.05-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
+++ b/FreydCategoriesForCAP/tst/TensorCorrespondenceRowsAndOppositeOfRows.tst
@@ -9,6 +9,7 @@ true
 
 gap> Q := HomalgFieldOfRationals();;
 gap> rows := CategoryOfRows( Q );;
+gap> opposite := Opposite( rows );;
 
 ##############################################
 # MonoidalCategoriesTensorProductAndUnitTest
@@ -17,17 +18,17 @@ gap> rows := CategoryOfRows( Q );;
 gap> a := 2 / rows;;
 gap> b := 3 / rows;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( rows, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( rows, opposite, a, b );;
 
 gap> a := 0 / rows;;
 gap> b := 2 / rows;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( rows, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( rows, opposite, a, b );;
 
 gap> a := 3 / rows;;
 gap> b := 0 / rows;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( rows, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( rows, opposite, a, b );;
 
 ##############################################
 # MonoidalCategoriesTest
@@ -41,21 +42,21 @@ gap> d := 4 / rows;;
 gap> alpha := CategoryOfRowsMorphism( a, HomalgMatrix( [ 2 .. 7 ], RankOfObject( a ), RankOfObject( b ), Q ), b );;
 gap> beta := CategoryOfRowsMorphism( c, HomalgMatrix( [ 8 .. 31 ], RankOfObject( c ), RankOfObject( d ), Q ), d );;
 
-gap> MonoidalCategoriesTest( rows, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( rows, opposite, a, b, c, alpha, beta );;
 
 gap> a := 0 / rows;;
 gap> b := 3 / rows;;
 
 gap> alpha := ZeroMorphism( a, b );;
 
-gap> MonoidalCategoriesTest( rows, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( rows, opposite, a, b, c, alpha, beta );;
 
 gap> a := 3 / rows;;
 gap> b := 0 / rows;;
 
 gap> alpha := ZeroMorphism( a, b );;
 
-gap> MonoidalCategoriesTest( rows, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( rows, opposite, a, b, c, alpha, beta );;
 
 ##############################################
 # AdditiveMonoidalCategoriesTest
@@ -64,17 +65,17 @@ gap> MonoidalCategoriesTest( rows, a, b, c, alpha, beta );;
 gap> a := 2 / rows;;
 gap> L := [ 3 / rows, 4 / rows, 5 / rows ];;
 
-gap> AdditiveMonoidalCategoriesTest( rows, a, L );;
+gap> AdditiveMonoidalCategoriesTest( rows, opposite, a, L );;
 
 gap> a := 0 / rows;;
 gap> L := [ 3 / rows, 4 / rows, 5 / rows ];;
 
-gap> AdditiveMonoidalCategoriesTest( rows, a, L );;
+gap> AdditiveMonoidalCategoriesTest( rows, opposite, a, L );;
 
 gap> a := 2 / rows;;
 gap> L := [ 3 / rows, 0 / rows, 5 / rows ];;
 
-gap> AdditiveMonoidalCategoriesTest( rows, a, L );;
+gap> AdditiveMonoidalCategoriesTest( rows, opposite, a, L );;
 
 ##############################################
 # BraidedMonoidalCategoriesTest
@@ -83,17 +84,17 @@ gap> AdditiveMonoidalCategoriesTest( rows, a, L );;
 gap> a := 2 / rows;;
 gap> b := 3 / rows;;
 
-gap> BraidedMonoidalCategoriesTest( rows, a, b );;
+gap> BraidedMonoidalCategoriesTest( rows, opposite, a, b );;
 
 gap> a := 0 / rows;;
 gap> b := 2 / rows;;
 
-gap> BraidedMonoidalCategoriesTest( rows, a, b );;
+gap> BraidedMonoidalCategoriesTest( rows, opposite, a, b );;
 
 gap> a := 2 / rows;;
 gap> b := 0 / rows;;
 
-gap> BraidedMonoidalCategoriesTest( rows, a, b );;
+gap> BraidedMonoidalCategoriesTest( rows, opposite, a, b );;
 
 ##############################################
 # ClosedMonoidalCategoriesTest
@@ -119,7 +120,7 @@ gap> delta := CategoryOfRowsMorphism( c_tensor_d, HomalgMatrix( [ 8 .. 31 ], Ran
 gap> epsilon := CategoryOfRowsMorphism( u, HomalgMatrix( [ 2 .. 7], RankOfObject( u ), RankOfObject( hom_ab ), Q ), hom_ab );;
 gap> zeta := CategoryOfRowsMorphism( u, HomalgMatrix( [ 8 .. 31 ], RankOfObject( u ), RankOfObject( hom_cd ), Q ), hom_cd );;
 
-gap> ClosedMonoidalCategoriesTest( rows, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 gap> a = 0 / rows;;
 gap> d = 0 / rows;;
@@ -137,7 +138,7 @@ gap> delta := ZeroMorphism( c_tensor_d, u );;
 gap> epsilon := ZeroMorphism( u, hom_ab );;
 gap> zeta := ZeroMorphism( u, hom_cd );;
 
-gap> ClosedMonoidalCategoriesTest( rows, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 ##############################################
 # CoclosedMonoidalCategoriesTest
@@ -163,7 +164,7 @@ gap> delta := CategoryOfRowsMorphism( u, HomalgMatrix( [ 8 .. 31 ], RankOfObject
 gap> epsilon := CategoryOfRowsMorphism( cohom_ab, HomalgMatrix( [ 2 .. 7 ], RankOfObject( cohom_ab ), RankOfObject( u ), Q ), u );;
 gap> zeta := CategoryOfRowsMorphism( cohom_cd, HomalgMatrix( [ 8 .. 31 ], RankOfObject( cohom_cd ), RankOfObject( u ), Q ), u );;
 
-gap> CoclosedMonoidalCategoriesTest( rows, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 gap> a = 0 / rows;;
 gap> d = 0 / rows;;
@@ -181,7 +182,7 @@ gap> delta := ZeroMorphism( u, c_tensor_d );;
 gap> epsilon := ZeroMorphism( cohom_ab, u );;
 gap> zeta := ZeroMorphism( cohom_cd, u );;
 
-gap> CoclosedMonoidalCategoriesTest( rows, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 ##############################################
 # RigidSymmetricClosedMonoidalCategoriesTest
@@ -194,14 +195,14 @@ gap> d := 4 / rows;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricClosedMonoidalCategoriesTest( rows, a, b, c, d, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha );;
 
 gap> a := 0 / rows;;
 gap> d := 0 / rows;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricClosedMonoidalCategoriesTest( rows, a, b, c, d, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( rows, opposite, a, b, c, d, alpha );;
 
 ##############################################
 # RigidSymmetricCoclosedMonoidalCategoriesTest
@@ -214,14 +215,14 @@ gap> d := 4 / rows;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( rows, a, b, a, b, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( rows, opposite, a, b, a, b, alpha );;
 
 gap> a := 0 / rows;;
 gap> d := 0 / rows;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( rows, a, b, a, b, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( rows, opposite, a, b, a, b, alpha );;
 
 ##############################################
 

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2023.05-02",
+Version := "2023.05-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
+++ b/LinearAlgebraForCAP/tst/TensorCorrespondenceMatrixCategoryAndOpposite.tst
@@ -9,6 +9,7 @@ true
 
 gap> Q := HomalgFieldOfRationals();;
 gap> mc := MatrixCategory( Q );;
+gap> opposite := Opposite( mc );;
 
 ##############################################
 # MonoidalCategoriesTensorProductAndUnitTest
@@ -17,17 +18,17 @@ gap> mc := MatrixCategory( Q );;
 gap> a := 2 / mc;;
 gap> b := 3 / mc;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( mc, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( mc, opposite, a, b );;
 
 gap> a := 0 / mc;;
 gap> b := 2 / mc;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( mc, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( mc, opposite, a, b );;
 
 gap> a := 3 / mc;;
 gap> b := 0 / mc;;
 
-gap> MonoidalCategoriesTensorProductAndUnitTest( mc, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( mc, opposite, a, b );;
 
 ##############################################
 # MonoidalCategoriesTest
@@ -41,21 +42,21 @@ gap> d := 4 / mc;;
 gap> alpha := VectorSpaceMorphism( a, HomalgMatrix( [ 2 .. 7 ], Dimension( a ), Dimension( b ), Q ), b );;
 gap> beta := VectorSpaceMorphism( c, HomalgMatrix( [ 8 .. 31 ], Dimension( c ), Dimension( d ), Q ), d );;
 
-gap> MonoidalCategoriesTest( mc, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( mc, opposite, a, b, c, alpha, beta );;
 
 gap> a := 0 / mc;;
 gap> b := 3 / mc;;
 
 gap> alpha := ZeroMorphism( a, b );;
 
-gap> MonoidalCategoriesTest( mc, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( mc, opposite, a, b, c, alpha, beta );;
 
 gap> a := 3 / mc;;
 gap> b := 0 / mc;;
 
 gap> alpha := ZeroMorphism( a, b );;
 
-gap> MonoidalCategoriesTest( mc, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( mc, opposite, a, b, c, alpha, beta );;
 
 ##############################################
 # AdditiveMonoidalCategoriesTest
@@ -64,17 +65,17 @@ gap> MonoidalCategoriesTest( mc, a, b, c, alpha, beta );;
 gap> a := 2 / mc;;
 gap> L := [ 3 / mc, 4 / mc, 5 / mc ];;
 
-gap> AdditiveMonoidalCategoriesTest( mc, a, L );;
+gap> AdditiveMonoidalCategoriesTest( mc, opposite, a, L );;
 
 gap> a := 0 / mc;;
 gap> L := [ 3 / mc, 4 / mc, 5 / mc ];;
 
-gap> AdditiveMonoidalCategoriesTest( mc, a, L );;
+gap> AdditiveMonoidalCategoriesTest( mc, opposite, a, L );;
 
 gap> a := 2 / mc;;
 gap> L := [ 3 / mc, 0 / mc, 5 / mc ];;
 
-gap> AdditiveMonoidalCategoriesTest( mc, a, L );;
+gap> AdditiveMonoidalCategoriesTest( mc, opposite, a, L );;
 
 ##############################################
 # BraidedMonoidalCategoriesTest
@@ -83,17 +84,17 @@ gap> AdditiveMonoidalCategoriesTest( mc, a, L );;
 gap> a := 2 / mc;;
 gap> b := 3 / mc;;
 
-gap> BraidedMonoidalCategoriesTest( mc, a, b );;
+gap> BraidedMonoidalCategoriesTest( mc, opposite, a, b );;
 
 gap> a := 0 / mc;;
 gap> b := 2 / mc;;
 
-gap> BraidedMonoidalCategoriesTest( mc, a, b );;
+gap> BraidedMonoidalCategoriesTest( mc, opposite, a, b );;
 
 gap> a := 2 / mc;;
 gap> b := 0 / mc;;
 
-gap> BraidedMonoidalCategoriesTest( mc, a, b );;
+gap> BraidedMonoidalCategoriesTest( mc, opposite, a, b );;
 
 ##############################################
 # ClosedMonoidalCategoriesTest
@@ -119,7 +120,7 @@ gap> delta := VectorSpaceMorphism( c_tensor_d, HomalgMatrix( [ 8 .. 31 ], Dimens
 gap> epsilon := VectorSpaceMorphism( u, HomalgMatrix( [ 2 .. 7 ], Dimension( u ), Dimension( hom_ab ), Q ), hom_ab );;
 gap> zeta := VectorSpaceMorphism( u, HomalgMatrix( [ 8 .. 31 ], Dimension( u ), Dimension( hom_cd ), Q ), hom_cd );;
 
-gap> ClosedMonoidalCategoriesTest( mc, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 gap> a = 0 / mc;;
 gap> d = 0 / mc;;
@@ -137,7 +138,7 @@ gap> delta := ZeroMorphism( c_tensor_d, u );;
 gap> epsilon := ZeroMorphism( u, hom_ab );;
 gap> zeta := ZeroMorphism( u, hom_cd );;
 
-gap> ClosedMonoidalCategoriesTest( mc, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 ##############################################
 # CoclosedMonoidalCategoriesTest
@@ -163,7 +164,7 @@ gap> delta := VectorSpaceMorphism( u, HomalgMatrix( [ 8 .. 31 ], Dimension( u ),
 gap> epsilon := VectorSpaceMorphism( cohom_ab, HomalgMatrix( [ 2 .. 7 ], Dimension( cohom_ab ), Dimension( u ), Q ), u );;
 gap> zeta := VectorSpaceMorphism( cohom_cd, HomalgMatrix( [ 8 .. 31 ], Dimension( cohom_cd ), Dimension( u ), Q ), u );;
 
-gap> CoclosedMonoidalCategoriesTest( mc, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 gap> a = 0 / mc;;
 gap> d = 0 / mc;;
@@ -181,7 +182,7 @@ gap> delta := ZeroMorphism( u, c_tensor_d );;
 gap> epsilon := ZeroMorphism( cohom_ab, u );;
 gap> zeta := ZeroMorphism( cohom_cd, u );;
 
-gap> CoclosedMonoidalCategoriesTest( mc, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 ##############################################
 # RigidSymmetricClosedMonoidalCategoriesTest
@@ -194,14 +195,14 @@ gap> d := 4 / mc;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricClosedMonoidalCategoriesTest( mc, a, b, c, d, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha );;
 
 gap> a := 0 / mc;;
 gap> d := 0 / mc;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricClosedMonoidalCategoriesTest( mc, a, b, c, d, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( mc, opposite, a, b, c, d, alpha );;
 
 ##############################################
 # RigidSymmetricCoclosedMonoidalCategoriesTest
@@ -214,14 +215,14 @@ gap> d := 4 / mc;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( mc, a, b, a, b, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( mc, opposite, a, b, a, b, alpha );;
 
 gap> a := 0 / mc;;
 gap> d := 0 / mc;;
 
 gap> alpha := IdentityMorphism( a );;
 
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( mc, a, b, a, b, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( mc, opposite, a, b, a, b, alpha );;
 
 ##############################################
 

--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2023.05-02",
+Version := "2023.05-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/examples/VectorSpacesMonoidalCategory.gi
+++ b/MonoidalCategories/examples/VectorSpacesMonoidalCategory.gi
@@ -822,7 +822,7 @@ AddEvaluationForDualWithGivenTensorProduct( vecspaces,
       
     od;
     
-    if dimension > 0 then 
+    if dimension > 0 then
       
       Add( row, 1 );
       
@@ -855,7 +855,7 @@ AddCoevaluationForDualWithGivenTensorProduct( vecspaces,
       
     od;
     
-    if dimension > 0 then 
+    if dimension > 0 then
       
       Add( row, 1 );
       

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesTest.gi
@@ -6,14 +6,12 @@
 
 InstallGlobalFunction( "AdditiveMonoidalCategoriesTest",
     
-    function( cat, a, L )
+    function( cat, opposite, a, L )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, left_expanding_a_L, left_expanding_a_L_op, left_factoring_a_L, left_factoring_a_L_op, 
               L_op, right_expanding_L_a, right_expanding_L_a_op, right_factoring_L_a, right_factoring_L_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         L_op := List( L, l -> Opposite( opposite, l ) );

--- a/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/BraidedMonoidalCategoriesTest.gi
@@ -6,14 +6,12 @@
 
 InstallGlobalFunction( "BraidedMonoidalCategoriesTest",
     
-    function( cat, a, b )
+    function( cat, opposite, a, b )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, braiding_a_b, braiding_a_b_op, braiding_inverse_a_b, braiding_inverse_a_b_op, 
               b_op, braiding_b_a, braiding_b_a_op, braiding_inverse_b_a, braiding_inverse_b_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gi
@@ -6,9 +6,9 @@
 
 InstallGlobalFunction( "ClosedMonoidalCategoriesTest",
     
-    function( cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
+    function( cat, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -74,8 +74,6 @@ InstallGlobalFunction( "ClosedMonoidalCategoriesTest",
               
               isomorphism_from_a_to_hom, isomorphism_from_hom_to_a, isomorphism_from_a_to_cohom_op, isomorphism_from_cohom_to_a_op,
               isomorphism_from_b_to_hom, isomorphism_from_hom_to_b, isomorphism_from_b_to_cohom_op, isomorphism_from_cohom_to_b_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/CoclosedMonoidalCategoriesTest.gi
@@ -6,9 +6,9 @@
 
 InstallGlobalFunction( "CoclosedMonoidalCategoriesTest",
     
-    function( cat, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
+    function( cat, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta )
     
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -74,8 +74,6 @@ InstallGlobalFunction( "CoclosedMonoidalCategoriesTest",
               
               isomorphism_from_a_to_cohom, isomorphism_from_cohom_to_a, isomorphism_from_a_to_hom_op, isomorphism_from_hom_to_a_op,
               isomorphism_from_b_to_cohom, isomorphism_from_cohom_to_b, isomorphism_from_b_to_hom_op, isomorphism_from_hom_to_b_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTensorProductAndUnitTest.gi
@@ -6,17 +6,15 @@
 
 InstallGlobalFunction( "MonoidalCategoriesTensorProductAndUnitTest",
     
-    function( cat, a, b )
+    function( cat, opposite, a, b )
         
-        local opposite, verbose,
+        local verbose,
               
               u, u_op,
               a_op, b_op,
               
               a_tensor_b, a_tensor_b_op,
               b_tensor_a, b_tensor_a_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gi
@@ -6,9 +6,9 @@
 
 InstallGlobalFunction( "MonoidalCategoriesTest",
     
-    function( cat, a, b, c, alpha, beta )
+    function( cat, opposite, a, b, c, alpha, beta )
     
-        local opposite, verbose,
+        local verbose,
               
               a_op,
               b_op,
@@ -29,8 +29,6 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
               
               associator_left_to_right_abc, associator_left_to_right_abc_op, associator_right_to_left_abc, associator_right_to_left_abc_op,
               associator_left_to_right_cba, associator_left_to_right_cba_op, associator_right_to_left_cba, associator_right_to_left_cba_op;
-        
-        opposite := Opposite( cat );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/MonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/MonoidalCategoriesTest.gi
@@ -41,7 +41,7 @@ InstallGlobalFunction( "MonoidalCategoriesTest",
         
         verbose := ValueOption( "verbose" ) = true;
         
-        if CanCompute( cat, "TensorProductOnMorphisms" ) then 
+        if CanCompute( cat, "TensorProductOnMorphisms" ) then
             
             if verbose then
                 

--- a/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/RigidSymmetricClosedMonoidalCategoriesTest.gi
@@ -6,9 +6,9 @@
 
 InstallGlobalFunction( "RigidSymmetricClosedMonoidalCategoriesTest",
 
-    function( cat, a, b, c, d, alpha )
+    function( cat, opposite, a, b, c, d, alpha )
 
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -34,8 +34,6 @@ InstallGlobalFunction( "RigidSymmetricClosedMonoidalCategoriesTest",
               
               morphism_from_bidual_a, morphism_to_cobidual_a_op,
               morphism_from_bidual_b, morphism_to_cobidual_b_op;
-        
-        opposite := Opposite( cat, "Opposite" );
         
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );

--- a/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gi
+++ b/MonoidalCategories/gap/RigidSymmetricCoclosedMonoidalCategoriesTest.gi
@@ -6,9 +6,9 @@
 
 InstallGlobalFunction( "RigidSymmetricCoclosedMonoidalCategoriesTest",
     
-    function( cat, a, b, c, d, alpha )
+    function( cat, opposite, a, b, c, d, alpha )
         
-        local opposite, verbose,
+        local verbose,
               
               a_op, c_op,
               b_op, d_op,
@@ -35,8 +35,6 @@ InstallGlobalFunction( "RigidSymmetricCoclosedMonoidalCategoriesTest",
               morphism_to_cobidual_a, morphism_from_bidual_a_op,
               morphism_to_cobidual_b, morphism_from_bidual_b_op;
               
-        opposite := Opposite( cat, "Opposite" );
-        
         a_op := Opposite( opposite, a );
         b_op := Opposite( opposite, b );
         c_op := Opposite( opposite, c );

--- a/MonoidalCategories/tst/TerminalCategoryMonoidal.tst
+++ b/MonoidalCategories/tst/TerminalCategoryMonoidal.tst
@@ -11,6 +11,8 @@ true
 
 #
 gap> T := TerminalCategoryWithMultipleObjects( );;
+gap> opposite := Opposite( T, "Opposite with all operations" );;
+gap> opposite_primitive := Opposite( T, "Opposite with primitive operations" : only_primitive_operations := true );;
 
 #
 ##############################################
@@ -21,19 +23,19 @@ gap> a := "a" / T;;
 gap> b := "b" / T;;
 
 #
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, a, b );;
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, a, b : only_primitive_operations := true );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite, a, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite_primitive, a, b );;
 
 #
 gap> z := ZeroObject( T );;
 
 #
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, z, b );;
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, z, b : only_primitive_operations := true );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite, z, b );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite_primitive, z, b );;
 
 #
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, a, z );;
-gap> MonoidalCategoriesTensorProductAndUnitTest( T, a, z : only_primitive_operations := true );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite, a, z );;
+gap> MonoidalCategoriesTensorProductAndUnitTest( T, opposite_primitive, a, z );;
 
 #
 ##############################################
@@ -50,8 +52,8 @@ gap> alpha := MorphismConstructor( a, "f_ab", b );;
 gap> beta := MorphismConstructor( c, "f_cd", d );;
 
 #
-gap> MonoidalCategoriesTest( T, a, b, c, alpha, beta );;
-gap> MonoidalCategoriesTest( T, a, b, c, alpha, beta : only_primitive_operations := true );;
+gap> MonoidalCategoriesTest( T, opposite, a, b, c, alpha, beta );;
+gap> MonoidalCategoriesTest( T, opposite_primitive, a, b, c, alpha, beta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -61,12 +63,12 @@ gap> alpha := UniversalMorphismFromZeroObject( a );;
 gap> beta := UniversalMorphismIntoZeroObject( a );;
 
 #
-gap> MonoidalCategoriesTest( T, z, a, a, alpha, beta );;
-gap> MonoidalCategoriesTest( T, z, a, a, alpha, beta : only_primitive_operations := true );;
+gap> MonoidalCategoriesTest( T, opposite, z, a, a, alpha, beta );;
+gap> MonoidalCategoriesTest( T, opposite_primitive, z, a, a, alpha, beta );;
 
 #
-gap> MonoidalCategoriesTest( T, a, z, z, beta, alpha );;
-gap> MonoidalCategoriesTest( T, a, z, z, beta, alpha : only_primitive_operations := true );;
+gap> MonoidalCategoriesTest( T, opposite, a, z, z, beta, alpha );;
+gap> MonoidalCategoriesTest( T, opposite_primitive, a, z, z, beta, alpha );;
 
 #
 ##############################################
@@ -77,8 +79,8 @@ gap> a := "a" / T;;
 gap> L := [ "b" / T, "c" / T, "d" / T ];;
 
 #
-gap> AdditiveMonoidalCategoriesTest( T, a, L );;
-gap> AdditiveMonoidalCategoriesTest( T, a, L : only_primitive_operations := true );;
+gap> AdditiveMonoidalCategoriesTest( T, opposite, a, L );;
+gap> AdditiveMonoidalCategoriesTest( T, opposite_primitive, a, L );;
 
 #
 ##############################################
@@ -89,23 +91,23 @@ gap> a := "a" / T;;
 gap> b := "b" / T;;
 
 #
-gap> BraidedMonoidalCategoriesTest( T, a, b );;
-gap> BraidedMonoidalCategoriesTest( T, a, b : only_primitive_operations := true );;
+gap> BraidedMonoidalCategoriesTest( T, opposite, a, b );;
+gap> BraidedMonoidalCategoriesTest( T, opposite_primitive, a, b );;
 
 #
-gap> BraidedMonoidalCategoriesTest( T, b, a );;
-gap> BraidedMonoidalCategoriesTest( T, b, a : only_primitive_operations := true );;
+gap> BraidedMonoidalCategoriesTest( T, opposite, b, a );;
+gap> BraidedMonoidalCategoriesTest( T, opposite_primitive, b, a );;
 
 #
 gap> z := ZeroObject( T );;
 
 #
-gap> BraidedMonoidalCategoriesTest( T, z, a );;
-gap> BraidedMonoidalCategoriesTest( T, z, a : only_primitive_operations := true );;
+gap> BraidedMonoidalCategoriesTest( T, opposite, z, a );;
+gap> BraidedMonoidalCategoriesTest( T, opposite_primitive, z, a );;
 
 #
-gap> BraidedMonoidalCategoriesTest( T, a, z );;
-gap> BraidedMonoidalCategoriesTest( T, a, z : only_primitive_operations := true );;
+gap> BraidedMonoidalCategoriesTest( T, opposite, a, z );;
+gap> BraidedMonoidalCategoriesTest( T, opposite_primitive, a, z );;
 
 #
 ##############################################
@@ -137,8 +139,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomab", hom_ab );;
 gap> zeta := MorphismConstructor( u, "f_uhomcd", hom_cd );;
 
 #
-gap> ClosedMonoidalCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> ClosedMonoidalCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> ClosedMonoidalCategoriesTest( T, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( T, opposite_primitive, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -160,8 +162,8 @@ gap> epsilon := MorphismConstructor( u, "f_uhomza", hom_za );;
 gap> zeta := MorphismConstructor( u, "f_uhomaz", hom_az );;
 
 #
-gap> ClosedMonoidalCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> ClosedMonoidalCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> ClosedMonoidalCategoriesTest( T, opposite, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> ClosedMonoidalCategoriesTest( T, opposite_primitive, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 ##############################################
@@ -193,8 +195,8 @@ gap> epsilon := MorphismConstructor( cohom_ab, "f_cohomabu", u );;
 gap> zeta := MorphismConstructor( cohom_cd, "f_cohomcdu", u);;
 
 #
-gap> CoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CoclosedMonoidalCategoriesTest( T, opposite, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( T, opposite_primitive, a, b, c, d, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 gap> z := ZeroObject( T );;
@@ -216,8 +218,8 @@ gap> epsilon := MorphismConstructor( cohom_za, "f_cohomzau", u );;
 gap> zeta := MorphismConstructor( cohom_az, "cohomazu", u );;
 
 #
-gap> CoclosedMonoidalCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
-gap> CoclosedMonoidalCategoriesTest( T, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta : only_primitive_operations := true );;
+gap> CoclosedMonoidalCategoriesTest( T, opposite, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
+gap> CoclosedMonoidalCategoriesTest( T, opposite_primitive, z, a, a, z, alpha, beta, gamma, delta, epsilon, zeta );;
 
 #
 ##############################################
@@ -233,8 +235,8 @@ gap> d := "d" / T;;
 gap> alpha := IdentityMorphism( a );;
 
 #
-gap> RigidSymmetricClosedMonoidalCategoriesTest( T, a, b, c, d, alpha );;
-gap> RigidSymmetricClosedMonoidalCategoriesTest( T, a, b, c, d, alpha : only_primitive_operations := true );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( T, opposite, a, b, c, d, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( T, opposite_primitive, a, b, c, d, alpha );;
 
 #
 gap> z := ZeroObject( T );;
@@ -243,8 +245,8 @@ gap> z := ZeroObject( T );;
 gap> alpha := IdentityMorphism( a );;
 
 #
-gap> RigidSymmetricClosedMonoidalCategoriesTest( T, z, b, c, z, alpha );;
-gap> RigidSymmetricClosedMonoidalCategoriesTest( T, z, b, c, z, alpha : only_primitive_operations := true );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( T, opposite, z, b, c, z, alpha );;
+gap> RigidSymmetricClosedMonoidalCategoriesTest( T, opposite_primitive, z, b, c, z, alpha );;
 
 #
 ##############################################
@@ -260,8 +262,8 @@ gap> d := "d" / T;;
 gap> alpha := IdentityMorphism( a );;
 
 #
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha );;
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha : only_primitive_operations := true );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, opposite, a, b, c, d, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, opposite_primitive, a, b, c, d, alpha );;
 
 #
 gap> z := ZeroObject( T );;
@@ -270,8 +272,8 @@ gap> z := ZeroObject( T );;
 gap> alpha := IdentityMorphism( a );;
 
 #
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha );;
-gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, a, b, c, d, alpha : only_primitive_operations := true );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, opposite, a, b, c, d, alpha );;
+gap> RigidSymmetricCoclosedMonoidalCategoriesTest( T, opposite_primitive, a, b, c, d, alpha );;
 
 #
 ##############################################


### PR DESCRIPTION
This allows to execute those tests in Julia. Creating new categories inside functions and calling operations of these categories in the same function is not possible in Julia: When calling such a function, Julia compiles it in a context where the categorical operations are not available yet.

More places have to be adjusted and I will wait for the current PRs in this context to be merged first.