### PR TITLE
Use "and" for filters in GAP

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.05-07",
+Version := "2023.05-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -57,7 +57,12 @@ function( name, target_op, used_op_names_with_multiples_and_category_getters, we
     
     if IsProperty( category_filter ) then
         
+        # for Julia
         wrapped_category_filter := cat -> Tester( category_filter )( cat ) and category_filter( cat );
+        
+        #= comment for Julia
+        wrapped_category_filter := Tester( category_filter ) and category_filter;
+        # =#
         
     else
         


### PR DESCRIPTION
otherwise the output of DerivationsOfMethodByCategory is not readable
