### PR TITLE
Exclude NTuple from generalized hoisting

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.05-01",
+Version := "2023.05-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/HoistExpressions.gi
+++ b/CompilerForCAP/gap/HoistExpressions.gi
@@ -276,7 +276,7 @@ InstallGlobalFunction( CapJitExtractedExpensiveOperationsFromLoops, function ( t
                         
                     fi;
                     
-                elif ForAny( tree.args, a -> a.type = "EXPR_DECLARATIVE_FUNC" ) and not tree.funcref.gvar in [ "ListN", "ListX", "Iterated", "CapFixpoint", "LazyHList" ] then
+                elif ForAny( tree.args, a -> a.type = "EXPR_DECLARATIVE_FUNC" ) and not tree.funcref.gvar in [ "ListN", "ListX", "Iterated", "CapFixpoint", "LazyHList", "NTuple" ] then
                     
                     # COVERAGE_IGNORE_NEXT_LINE
                     Print( "WARNING: Could not detect domain of function in call of ", tree.funcref.gvar, ". Please write a bug report including this message.\n" );


### PR DESCRIPTION
We cannot detect the domain of functions appearing in NTuple.

Fixes #1325.