### PR TITLE
Allow to make non-categorical methods known to CompilerForCAP

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.06-03",
+Version := "2023.06-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -163,9 +163,17 @@ DeclareGlobalFunction( "InstallOtherMethodForCompilerForCAP" );
 
 #! @Description
 #!   Adds a method to the list of methods known to the compiler.
-#!   The first argument of the method must be a CAP category.
-#!   Method selection happens via the number of arguments and the category filter.
-#!   In particular, adding two methods (or a convenience method for a CAP operation)
+#!   If the first filter implies `IsCapCategory`,
+#!   method selection only takes the number of arguments and the first filter into account.
+#!   This allows to resolve operations even in the case that the syntax tree cannot fully be typed.
+#!   If the first filter does not imply `IsCapCategory`,
+#!   method selection takes all filters into account.
+#!   To strictly distinguish between the two cases, `IsCapCategory` must not imply the first filter
+#!   (except if the first filter is equal to `IsCapCategory`).
+#!   Method selection is strict in the sense that two different methods for the same operation
+#!   must not be comparable. That is, they must have a different number of filters or the filters
+#!   at at least one position must not be related via implication.
+#!   In particular, adding two methods with a CAP category as first argument (or a convenience method for a CAP operation)
 #!   with the same number of arguments and one category filter implying the other is not supported.
 #! @Arguments operation, filters, method
 DeclareGlobalFunction( "CapJitAddKnownMethod" );

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1109,14 +1109,7 @@ InstallGlobalFunction( CapJitAddKnownMethod,
     if IsEmpty( filters ) then
         
         # COVERAGE_IGNORE_NEXT_LINE
-        Error( "there must be at least one filter" );
-        
-    fi;
-    
-    if not IsSpecializationOfFilter( IsCapCategory, filters[1] ) then
-        
-        # COVERAGE_IGNORE_NEXT_LINE
-        Error( "the first filter must imply IsCapCategory" );
+        Error( "installing methods without filters is currently not supported" );
         
     fi;
     
@@ -1150,10 +1143,32 @@ InstallGlobalFunction( CapJitAddKnownMethod,
     
     known_methods := CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name);
     
-    if ForAny( known_methods, m -> Length( m.filters ) = Length( filters ) and ( IsSpecializationOfFilter( m.filters[1], filters[1] ) or IsSpecializationOfFilter( filters[1], m.filters[1] ) ) ) then
+    if IsSpecializationOfFilter( "category", filters[1] ) then
         
-        # COVERAGE_IGNORE_NEXT_LINE
-        Error( "there is already a method known for ", operation_name, " with a category filter which implies the current category filter or is implied by it" );
+        if ForAny( known_methods, m -> Length( m.filters ) = Length( filters ) and ( IsSpecializationOfFilter( m.filters[1], filters[1] ) or IsSpecializationOfFilter( filters[1], m.filters[1] ) ) ) then
+            
+            # COVERAGE_IGNORE_NEXT_LINE
+            Error( "there is already a method known for ", operation_name, " with a category filter which implies the current category filter or is implied by it" );
+            
+        fi;
+        
+    else
+        
+        if IsSpecializationOfFilter( filters[1], "category" ) then
+            
+            # COVERAGE_IGNORE_NEXT_LINE
+            Error( "The first filter is implied by `IsCapCategory`, this is not supported." );
+            
+        fi;
+        
+        if ForAny( known_methods,
+            m -> Length( m.filters ) = Length( filters ) and ForAll( [ 1 .. Length( filters ) ], i -> IsSpecializationOfFilter( m.filters[i], filters[i] ) or IsSpecializationOfFilter( filters[i], m.filters[i] ) )
+        ) then
+            
+            # COVERAGE_IGNORE_NEXT_LINE
+            Error( "there is already a method known for ", operation_name, " with a comparable filter list (see documentation of `CapJitAddKnownMethod`)" );
+            
+        fi;
         
     fi;
     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.06-07",
+Version := "2023.06-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/tst/CapJitAddKnownMethod.tst
+++ b/CompilerForCAP/tst/CapJitAddKnownMethod.tst
@@ -11,6 +11,10 @@ gap> DeclareFilter( "IsMyCat2", IsCapCategory );;
 #
 gap> DeclareOperation( "MyOperation", [ IsMyCat1 ] );;
 gap> DeclareOperation( "MyOperation", [ IsMyCat2 ] );;
+gap> DeclareOperation( "MyOperation", [ IsInt, IsString ] );;
+gap> CapJitAddTypeSignature( "MyOperation", [ IsInt, IsString ], IsInt );
+gap> DeclareOperation( "MyOperation", [ IsInt, IsInt ] );;
+gap> CapJitAddTypeSignature( "MyOperation", [ IsInt, IsInt ], IsInt );
 
 #
 gap> InstallMethodForCompilerForCAP( MyOperation, [ IsMyCat1 ], cat -> 1 );
@@ -20,10 +24,13 @@ gap> InstallOtherMethodForCompilerForCAP(
 >     [ IsMyCat2, IsInt ],
 >     { cat, int } -> 3
 > );
+gap> InstallMethodForCompilerForCAP( MyOperation, [ IsInt, IsString ], { int, string } -> 4 );
+gap> InstallMethod( MyOperation, [ IsInt, IsInt ], { int, int2 } -> 5 );
 
 #
 gap> cat1 := CreateCapCategory( "cat1" );;
 gap> cat2 := CreateCapCategory( "cat2" );;
+gap> cat3 := CreateCapCategory( "cat3" );;
 
 #
 gap> SetFilterObj( cat1, IsMyCat1 );
@@ -45,6 +52,32 @@ end
 gap> Display( CapJitCompiledFunction( cat -> MyOperation( cat, 1 ), cat2 ) );
 function ( cat_1 )
     return 3;
+end
+
+#
+gap> Display( CapJitCompiledFunction( cat -> MyOperation( cat ), cat3 ) );
+function ( cat_1 )
+    return MyOperation( cat_1 );
+end
+
+#
+gap> StopCompilationAtCategory( cat1 );
+gap> Display( CapJitCompiledFunction( cat -> MyOperation( cat ), cat1 ) );
+function ( cat_1 )
+    return MyOperation( cat_1 );
+end
+gap> ContinueCompilationAtCategory( cat1 );
+
+#
+gap> Display( CapJitCompiledFunction( {} -> MyOperation( 1, "1" ), [ [ ], fail ] ) );
+function (  )
+    return 4;
+end
+
+#
+gap> Display( CapJitCompiledFunction( {} -> MyOperation( 1, 1 ), [ [ ], fail ] ) );
+function (  )
+    return MyOperation( 1, 1 );
 end
 
 #

--- a/CompilerForCAP/tst/CapJitResolvedOperations.tst
+++ b/CompilerForCAP/tst/CapJitResolvedOperations.tst
@@ -4,6 +4,12 @@ gap> START_TEST( "CapJitResolvedOperations" );
 gap> LoadPackage( "CompilerForCAP", false );
 true
 
+# function call without arguments
+gap> Display( CapJitCompiledFunction( {} -> ReturnTrue( ) ) );
+function (  )
+    return RETURN_TRUE(  );
+end
+
 #
 gap> CapJitEnableProofAssistantMode( );
 

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.06-03",
+Version := "2023.06-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -87,7 +87,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12.1",
-  NeededOtherPackages := [ [ "CAP", ">= 2023.05-03" ],
+  NeededOtherPackages := [ [ "CAP", ">= 2023.06-04" ],
                            [ "MatricesForHomalg", ">= 2023.01-01" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "MonoidalCategories", ">= 2023.02-04" ],

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -287,8 +287,8 @@ end );
 ####################################
 
 ##
-InstallMethod( NrRows,
-               [ IsAdditiveClosureMorphism ],
+InstallMethodForCompilerForCAP( NrRows,
+                                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
     
@@ -297,8 +297,8 @@ InstallMethod( NrRows,
 end );
 
 ##
-InstallMethod( NrCols,
-               [ IsAdditiveClosureMorphism ],
+InstallMethodForCompilerForCAP( NrCols,
+                                [ IsAdditiveClosureMorphism ],
                
   function( morphism )
     
@@ -502,8 +502,8 @@ end );
 ####################################
 
 ##
-InstallMethod( \[\,\],
-               [ IsAdditiveClosureMorphism, IsInt, IsInt ],
+InstallMethodForCompilerForCAP( \[\,\],
+                                [ IsAdditiveClosureMorphism, IsInt, IsInt ],
                
   function( morphism, i, j )
     
@@ -519,8 +519,8 @@ InstallMethod( \[\,\],
 end );
 
 ##
-InstallMethod( \[\],
-               [ IsAdditiveClosureObject, IsInt ],
+InstallMethodForCompilerForCAP( \[\],
+                                [ IsAdditiveClosureObject, IsInt ],
                
   function( object, i )
     local obj_list;

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
@@ -4,46 +4,6 @@
 # Implementations
 #
 
-# additive_closure_object[i] => ObjectList( additive_closure_object )[i]
-CapJitAddLogicTemplate(
-    rec(
-        variable_names := [ "additive_closure_object", "index" ],
-        variable_filters := [ IsAdditiveClosureObject, IsInt ],
-        src_template := "additive_closure_object[index]",
-        dst_template := "ObjectList( additive_closure_object )[index]",
-    )
-);
-
-# additive_closure_morphism[i, j] => MorphismMatrix( additive_closure_morphism )[i, j]
-CapJitAddLogicTemplate(
-    rec(
-        variable_names := [ "additive_closure_morphism", "row", "column" ],
-        variable_filters := [ IsAdditiveClosureMorphism, IsInt, IsInt ],
-        src_template := "additive_closure_morphism[row, column]",
-        dst_template := "MorphismMatrix( additive_closure_morphism )[row][column]",
-    )
-);
-
-# NumberRows( additive_closure_morphism ) => Length( ObjectList( Source( additive_closure_morphism ) ) )
-CapJitAddLogicTemplate(
-    rec(
-        variable_names := [ "additive_closure_morphism" ],
-        variable_filters := [ IsAdditiveClosureMorphism ],
-        src_template := "NumberRows( additive_closure_morphism )",
-        dst_template := "Length( ObjectList( Source( additive_closure_morphism ) ) )",
-    )
-);
-
-# NumberColumns( additive_closure_morphism ) => Length( ObjectList( Range( additive_closure_morphism ) ) )
-CapJitAddLogicTemplate(
-    rec(
-        variable_names := [ "additive_closure_morphism" ],
-        variable_filters := [ IsAdditiveClosureMorphism ],
-        src_template := "NumberColumns( additive_closure_morphism )",
-        dst_template := "Length( ObjectList( Range( additive_closure_morphism ) ) )",
-    )
-);
-
 # UnionOfRowsListList
 CapJitAddLogicTemplate(
     rec(


### PR DESCRIPTION
@mohamed-barakat @kamalsaleh @TKuh One can now install methods for CompilerForCAP which do not get a category as the first argument. Of course, such methods can only be resolved if the tree can be typed.