### PR TITLE
improved InfoStringOfInstalledOperationsOfCategory

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.08-07",
+Version := "2023.08-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -97,7 +97,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12.1",
-  NeededOtherPackages := [ [ "ToolsForHomalg", ">= 2023.03-01" ],
+  NeededOtherPackages := [ [ "ToolsForHomalg", ">= 2023.07-01" ],
   ],
   SuggestedOtherPackages := [ [ "Browse", ">= 1.5" ],
                               [ "CompilerForCAP", ">= 2021.12-05" ],

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -76,7 +76,7 @@ InstallGlobalFunction( CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY,
     ## can still set IsInitialCategory = true manually, if the doctrine is clear from the context.
     Add( excluded_properties, "IsInitialCategory" );
     
-    properties := Filtered( properties, p -> not ForAny( excluded_properties, e -> e = p or e in ListImpliedFilters( ValueGlobal( p ) ) ) );
+    properties := Filtered( properties, p -> not ForAny( excluded_properties, e -> e in ListImpliedFilters( ValueGlobal( p ) ) ) );
     
     Add( properties, "IsTerminalCategory" );
     

--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2023.08-10",
+Version := "2023.08-11",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
@@ -98,7 +98,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [
-                [ "CAP", ">= 2023.02-09" ],
+                [ "CAP", ">= 2023.08-08" ],
                 ],
   SuggestedOtherPackages := [
                 [ "MonoidalCategories", ">= 2023.02-04" ],

--- a/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
+++ b/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
@@ -18,8 +18,9 @@ InfoOfInstalledOperationsOfCategory( distributive );
 #! 19 primitive operations were used to derive 112 operations for this category \
 #! which algorithmically
 #! * IsBicartesianClosedCategory
+#! and not yet algorithmically
+#! * IsDistributiveCategory
 #! and furthermore mathematically
-#! * IsDistributiveCategory (but not yet algorithmically)
 #! * IsSkeletalCategory
 
 #! @EndExample

--- a/CartesianCategories/examples/InitialCategory.g
+++ b/CartesianCategories/examples/InitialCategory.g
@@ -11,8 +11,9 @@ Display( I );
 #! A CAP category with name InitialCategory( ):
 #! 
 #! 5 primitive operations were used to derive 13 operations for this category \
-#! which mathematically
-#! * IsEquippedWithHomomorphismStructure (but not yet algorithmically)
+#! which not yet algorithmically
+#! * IsEquippedWithHomomorphismStructure
+#! and furthermore mathematically
 #! * IsInitialCategory
 OI := Opposite( I );
 #! Opposite( InitialCategory( ) )
@@ -22,7 +23,8 @@ Display( OI );
 #! A CAP category with name Opposite( InitialCategory( ) ):
 #! 
 #! 17 primitive operations were used to derive 17 operations for this category \
-#! which mathematically
-#! * IsEquippedWithHomomorphismStructure (but not yet algorithmically)
+#! which not yet algorithmically
+#! * IsEquippedWithHomomorphismStructure
+#! and furthermore mathematically
 #! * IsInitialCategory
 #! @EndExample

--- a/GradedModulePresentationsForCAP/PackageInfo.g
+++ b/GradedModulePresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedModulePresentationsForCAP",
 Subtitle := "Presentations for graded modules",
-Version := "2023.08-01",
+Version := "2023.08-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -71,7 +71,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "CAP", ">= 2022.12-06" ],
+                           [ "CAP", ">= 2023.08-08" ],
                            [ "ModulePresentationsForCAP", ">=2019.08.07" ],
                            [ "GradedRingForHomalg", ">=2019.08.07" ],
                            [ "ComplexesAndFilteredObjectsForCAP", ">=2016.09.19" ],

--- a/GradedModulePresentationsForCAP/examples/CohP1.g
+++ b/GradedModulePresentationsForCAP/examples/CohP1.g
@@ -22,8 +22,8 @@ Display( Sgrmod );
 #! which algorithmically
 #! * IsMonoidalCategory
 #! * IsAbelianCategoryWithEnoughProjectives
-#! and furthermore mathematically
-#! * IsSymmetricClosedMonoidalCategory (but not yet algorithmically)
+#! and not yet algorithmically
+#! * IsSymmetricClosedMonoidalCategory
 #ListPrimitivelyInstalledOperationsOfCategory( Sgrmod );
 M := GradedFreeLeftPresentation( 2, S, [ 1, 1 ] );
 #! <An object in The category of graded left f.p. modules over Q[x,y]


### PR DESCRIPTION
~~by additionally excluding all non-algorithmic properties from the list_of_mathematical_properties that are implied by those in list_of_algorithmic_properties~~

by distinguishing three sorts of categorical properties:
1. algorithmic properties
2. not yet algorithmic properties
3. non-algorithmic, mathematical properties