### PR TITLE
Make sure data_type of arguments is known when resolving known non-categorical methods

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.06-08",
+Version := "2023.06-09",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -253,7 +253,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
             fi;
             
             # resolve known non-categorical methods
-            if resolved_tree = fail and IsBound( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name) ) and IsBound( tree.data_type ) and not IsSpecializationOfFilter( "category", tree.args.1.data_type.filter ) then
+            if resolved_tree = fail and IsBound( CAP_JIT_INTERNAL_KNOWN_METHODS.(operation_name) ) and ForAll( tree.args, a -> IsBound( a.data_type ) ) and not IsSpecializationOfFilter( "category", tree.args.1.data_type.filter ) then
                 
                 Info( InfoCapJit, 1, "####" );
                 Info( InfoCapJit, 1, Concatenation( "Try to resolve ", operation_name, " by searching for known non-categorical methods." ) );


### PR DESCRIPTION
Ensuring that the function call has a data type is not enough because the arguments might have changed since the last application of CapJitInferredDataTypes.

@mohamed-barakat This should fix the CI of CategoricalTowers.