### PR TITLE
Do not take constructive implication into account in InfoStringOfInstalledOperationsOfCategory

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.06-06",
+Version := "2023.06-07",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -6,7 +6,7 @@
 InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
   
   function( category )
-    local list_of_mathematical_properties, list_of_potential_algorithmic_properties,
+    local MaximalPropertiesWithRegardToImplication, list_of_mathematical_properties, list_of_potential_algorithmic_properties,
           list_of_algorithmic_properties, list_of_maximal_algorithmic_properties, property, result,
           list_of_non_algorithmic_mathematical_properties, list_of_maximal_non_algorithmic_mathematical_properties;
     
@@ -15,15 +15,19 @@ InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
         return;
     fi;
     
+    MaximalPropertiesWithRegardToImplication := function ( list_of_properties )
+        
+        return MaximalObjects( list_of_properties, { p1, p2 } -> p1 in ListImpliedFilters( ValueGlobal( p2 ) ) );
+        
+    end;
+    
     list_of_mathematical_properties := ListKnownCategoricalProperties( category );
     
     list_of_potential_algorithmic_properties := RecNames( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD );
     
     list_of_algorithmic_properties := Filtered( list_of_mathematical_properties, p -> p in list_of_potential_algorithmic_properties and IsEmpty( CheckConstructivenessOfCategory( category, p ) ) );
     
-    list_of_maximal_algorithmic_properties := MaximalObjects( list_of_algorithmic_properties, { p1, p2 } ->
-                                               IsSubset( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p2 ), CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p1 ) ) or
-                                               p1 in ListImpliedFilters( ValueGlobal( p2 ) ) );
+    list_of_maximal_algorithmic_properties := MaximalPropertiesWithRegardToImplication( list_of_algorithmic_properties );
     
     StableSortBy( list_of_maximal_algorithmic_properties, p -> Length( CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.( p ) ) );
     
@@ -41,7 +45,7 @@ InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
     
     list_of_non_algorithmic_mathematical_properties := Difference( list_of_mathematical_properties, list_of_algorithmic_properties );
     
-    list_of_maximal_non_algorithmic_mathematical_properties := MaximalObjects( list_of_non_algorithmic_mathematical_properties, { p1, p2 } -> p1 in ListImpliedFilters( ValueGlobal( p2 ) ) );
+    list_of_maximal_non_algorithmic_mathematical_properties := MaximalPropertiesWithRegardToImplication( list_of_non_algorithmic_mathematical_properties );
     
     if not IsEmpty( list_of_maximal_non_algorithmic_mathematical_properties ) then
         if not IsEmpty( list_of_maximal_algorithmic_properties ) then


### PR DESCRIPTION
Since some time, InfoStringOfInstalledOperationsOfCategory lists all mathematical properties, not only constructive ones. Filtering by constructive implication is unexpected in this setup.

Fixes #1360.