### PR TITLE
Always inline simple values like integers

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.06-11",
+Version := "2023.06-12",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/InlineBindings.gd
+++ b/CompilerForCAP/gap/InlineBindings.gd
@@ -15,6 +15,7 @@ DeclareGlobalFunction( "CAP_JIT_INTERNAL_INLINED_BINDINGS" );
 #!   Details: Replaces references to local variables of a function by the value of the corresponding binding of the function.
 #!   If the option `inline_var_refs_only` is set to `true`, this is only done if the value is a reference to a (local or global) variable.
 #!   If the option `inline_fully` is NOT set to `true`, wrapped arguments are not inlined (see <Ref Func="CapJitOutlinedWrappedArguments" />).
+#!   Simple values like integers are always inlined.
 #!   Also drops the inlined bindings.
 #! @Returns a record
 #! @Arguments tree

--- a/CompilerForCAP/tst/CapJitInlinedBindings.tst
+++ b/CompilerForCAP/tst/CapJitInlinedBindings.tst
@@ -59,4 +59,31 @@ gap> tree = tree2;
 true
 
 #
+#
+# check that simple values are always inlined
+gap> func := function ( )
+>   local int1, int2, list1, list2;
+>   
+>   int1 := 1;
+>   int2 := int1;
+>   
+>   list1 := [ 1 ];
+>   list2 := list1;
+>   
+>   return NTuple( 2, int2, list2 );
+> end;;
+
+#
+gap> tree := ENHANCED_SYNTAX_TREE( func );;
+
+#
+gap> tree := CapJitInlinedBindingsToVariableReferences( tree );;
+gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
+function (  )
+    local list1_1;
+    list1_1 := [ 1 ];
+    return NTuple( 2, 1, list1_1 );
+end
+
+#
 gap> STOP_TEST( "CapJitInlinedBindings" );


### PR DESCRIPTION
This allows to match NTuple and CreateCapCategory* in logic templates if the arguments are simple values.