### PR TITLE
Use `CreateCapCategoryWithDataTypes` at more places

### DIFF
--- a/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
+++ b/FreydCategoriesForCAP/gap/CokernelImageClosure.gi
@@ -48,11 +48,17 @@ InstallMethod( CokernelImageClosure,
         
     fi;
     
-    cokernel_image_closure := CreateCapCategory( Concatenation( "Cokernel image closure( ", Name( underlying_category ), " )" ) );
+    cokernel_image_closure := CreateCapCategoryWithDataTypes(
+                                      Concatenation( "Cokernel image closure( ", Name( underlying_category ), " )" ),
+                                      IsCokernelImageClosure,
+                                      IsCokernelImageClosureObject,
+                                      IsCokernelImageClosureMorphism and HasMorphismDatum,
+                                      IsCapCategoryTwoCell,
+                                      fail,
+                                      fail,
+                                      fail );
     
     cokernel_image_closure!.category_as_first_argument := false;
-    
-    SetFilterObj( cokernel_image_closure, IsCokernelImageClosure );
     
     SetIsAdditiveCategory( cokernel_image_closure, true );
     
@@ -64,10 +70,6 @@ InstallMethod( CokernelImageClosure,
         SetIsAbelianCategory( cokernel_image_closure, true );
         
     fi;
-    
-    AddObjectRepresentation( cokernel_image_closure, IsCokernelImageClosureObject );
-    
-    AddMorphismRepresentation( cokernel_image_closure, IsCokernelImageClosureMorphism and HasMorphismDatum );
     
     INSTALL_FUNCTIONS_FOR_COKERNEL_IMAGE_CLOSURE( cokernel_image_closure );
     

--- a/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
+++ b/FreydCategoriesForCAP/gap/ProSetsAsCats.gi
@@ -53,25 +53,28 @@ InstallMethod( ProSetAsCategory,
 
     fi;
 
-    category := CreateCapCategory( "ProSet" : overhead := false );
+    category := CreateCapCategoryWithDataTypes(
+                        "ProSet",
+                        IsProSetAsCategory,
+                        IsProSetAsCategoryObject,
+                        IsProSetAsCategoryMorphism,
+                        IsCapCategoryTwoCell,
+                        IsInt,
+                        fail,
+                        fail
+                        : overhead := false );
     
     category!.category_as_first_argument := false;
     
-    SetFilterObj( category, IsProSetAsCategory );
-
     SetIncidenceMatrix( category, incidence_matrix );
-
-    AddObjectRepresentation( category, IsProSetAsCategoryObject );
-
-    AddMorphismRepresentation( category, IsProSetAsCategoryMorphism );
-
+    
     SetRangeCategoryOfHomomorphismStructure( category, FREYD_CATEGORIES_SkeletalFinSets );
     SetIsEquippedWithHomomorphismStructure( category, true );
     
     INSTALL_FUNCTIONS_FOR_PROSET_AS_CATEGORY( category );
-
+    
     Finalize( category );
-
+    
     return category;
 
 end );

--- a/FreydCategoriesForCAP/gap/Relations.gi
+++ b/FreydCategoriesForCAP/gap/Relations.gi
@@ -19,17 +19,19 @@ InstallMethod( RelCategory,
     
     ## TODO: is underlying_category regular?
     
-    category := CreateCapCategory( Concatenation( "Rel( ", Name( underlying_category )," )" ) );
+    category := CreateCapCategoryWithDataTypes(
+                        Concatenation( "Rel( ", Name( underlying_category )," )" ),
+                        IsRelCategory,
+                        IsRelCategoryObject,
+                        IsRelCategoryMorphism,
+                        IsCapCategoryTwoCell,
+                        fail,
+                        fail,
+                        fail );
     
     category!.category_as_first_argument := false;
     
-    SetFilterObj( category, IsRelCategory );
-    
     SetUnderlyingCategory( category, underlying_category );
-    
-    AddObjectRepresentation( category, IsRelCategoryObject );
-    
-    AddMorphismRepresentation( category, IsRelCategoryMorphism );
     
     INSTALL_FUNCTIONS_FOR_RELATIONS_CATEGORY( category );
     

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByCospans.gi
@@ -355,15 +355,17 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByCospans,
     
     name := Concatenation( "The Serre quotient category of ", name, " by ", function_name );
     
-    serre_category := CreateCapCategory( name );
+    serre_category := CreateCapCategoryWithDataTypes(
+                              name,
+                              IsSerreQuotientCategory,
+                              IsSerreQuotientCategoryByCospansObject,
+                              IsSerreQuotientCategoryByCospansMorphism and HasUnderlyingGeneralizedMorphism,
+                              IsCapCategoryTwoCell,
+                              fail,
+                              fail,
+                              fail );
     
     serre_category!.category_as_first_argument := false;
-    
-    SetFilterObj( serre_category, IsSerreQuotientCategory );
-    
-    AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByCospansObject );
-    
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByCospansMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsBySpans.gi
@@ -422,15 +422,17 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryBySpans,
     
     name := Concatenation( "The Serre quotient category of ", name, " by ", function_name );
     
-    serre_category := CreateCapCategory( name );
+    serre_category := CreateCapCategoryWithDataTypes(
+                              name,
+                              IsSerreQuotientCategory,
+                              IsSerreQuotientCategoryBySpansObject,
+                              IsSerreQuotientCategoryBySpansMorphism and HasUnderlyingGeneralizedMorphism,
+                              IsCapCategoryTwoCell,
+                              fail,
+                              fail,
+                              fail );
     
     serre_category!.category_as_first_argument := false;
-    
-    SetFilterObj( serre_category, IsSerreQuotientCategory );
-    
-    AddObjectRepresentation( serre_category, IsSerreQuotientCategoryBySpansObject );
-    
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryBySpansMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     

--- a/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/SerreQuotientsByThreeArrows.gi
@@ -376,15 +376,17 @@ InstallMethodWithCacheFromObject( SerreQuotientCategoryByThreeArrows,
     
     name := Concatenation( "The Serre quotient category of ", name, " by ", function_name );
     
-    serre_category := CreateCapCategory( name );
+    serre_category := CreateCapCategoryWithDataTypes(
+                              name,
+                              IsSerreQuotientCategory,
+                              IsSerreQuotientCategoryByThreeArrowsObject,
+                              IsSerreQuotientCategoryByThreeArrowsMorphism and HasUnderlyingGeneralizedMorphism,
+                              IsCapCategoryTwoCell,
+                              fail,
+                              fail,
+                              fail );
     
     serre_category!.category_as_first_argument := false;
-    
-    SetFilterObj( serre_category, IsSerreQuotientCategory );
-    
-    AddObjectRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsObject );
-    
-    AddMorphismRepresentation( serre_category, IsSerreQuotientCategoryByThreeArrowsMorphism and HasUnderlyingGeneralizedMorphism );
     
     serre_category!.predicate_logic := category!.predicate_logic;
     

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -14,17 +14,19 @@ InstallMethod( LeftPresentations,
     # Since `FreydCategoriesForCAP` is not deposited, we cannot simply return `LeftPresentationsAsFreydCategoryOfCategoryOfRows( ring )`
     # but have to construct the category manually.
     
-    category := CreateCapCategory( Concatenation( "Category of left presentations of ", RingName( ring ) ) );
+    category := CreateCapCategoryWithDataTypes(
+                        Concatenation( "Category of left presentations of ", RingName( ring ) ),
+                        IsCategoryOfLeftPresentations,
+                        IsLeftPresentation,
+                        IsLeftPresentationMorphism and HasUnderlyingMatrix,
+                        IsCapCategoryTwoCell,
+                        fail,
+                        fail,
+                        fail );
     
     category!.category_as_first_argument := true;
     
-    AddObjectRepresentation( category, IsLeftPresentation );
-    
-    AddMorphismRepresentation( category, IsLeftPresentationMorphism and HasUnderlyingMatrix );
-    
     category!.ring_for_representation_category := ring;
-    
-    SetFilterObj( category, IsCategoryOfLeftPresentations );
     
     SetUnderlyingRing( category, ring );
     
@@ -114,17 +116,19 @@ InstallMethod( RightPresentations,
     # Since `FreydCategoriesForCAP` is not deposited, we cannot simply return `RightPresentationsAsFreydCategoryOfCategoryOfColumns( ring )`
     # but have to construct the category manually.
     
-    category := CreateCapCategory( Concatenation( "Category of right presentations of ", RingName( ring ) ) );
+    category := CreateCapCategoryWithDataTypes(
+                        Concatenation( "Category of right presentations of ", RingName( ring ) ),
+                        IsCategoryOfRightPresentations,
+                        IsRightPresentation,
+                        IsRightPresentationMorphism and HasUnderlyingMatrix,
+                        IsCapCategoryTwoCell,
+                        fail,
+                        fail,
+                        fail );
     
     category!.category_as_first_argument := true;
     
-    AddObjectRepresentation( category, IsRightPresentation );
-    
-    AddMorphismRepresentation( category, IsRightPresentationMorphism and HasUnderlyingMatrix );
-    
     category!.ring_for_representation_category := ring;
-    
-    SetFilterObj( category, IsCategoryOfRightPresentations );
     
     SetUnderlyingRing( category, ring );
     


### PR DESCRIPTION
In particular, get rid of `AddObjectRepresentation` and `AddMorphismRepresentation`.

Step towards #1269.