### PR TITLE
Simplify AttributeCategory

### DIFF
--- a/AttributeCategoryForCAP/PackageInfo.g
+++ b/AttributeCategoryForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "AttributeCategoryForCAP",
 Subtitle := "Automatic enhancement with attributes of a CAP category",
-Version := "2023.05-01",
+Version := "2023.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 


### PR DESCRIPTION
by using `output_source/range_getter` instead of `CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS`