### PR TITLE
Introduce "Target" as an alias of "Range"

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.08-03",
+Version := "2023.08-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryMorphisms.gd
+++ b/CAP/gap/CategoryMorphisms.gd
@@ -43,7 +43,13 @@ DeclareAttribute( "Source",
 DeclareAttribute( "Range",
                   IsCapCategoryMorphism );
 
-# this attribute is also an implied operation
+#! @Description
+#! The argument is a morphism $\alpha: a \rightarrow b$.
+#! The output is its target $b$.
+#! @Returns an object
+#! @Arguments alpha
+DeclareAttribute( "Target",
+                  IsCapCategoryMorphism );
 
 ###################################
 ##

--- a/CAP/gap/CategoryMorphisms.gi
+++ b/CAP/gap/CategoryMorphisms.gi
@@ -58,6 +58,11 @@ InstallValue( PROPAGATION_LIST_FOR_EQUAL_MORPHISMS,
 ##
 ######################################
 
+InstallMethod( Target,
+               [ IsCapCategoryMorphism ],
+               
+  Range );
+
 InstallMethod( Add,
                [ IsCapCategory, IsCapCategoryMorphism ],
                

--- a/CAP/gap/CategoryTwoCells.gd
+++ b/CAP/gap/CategoryTwoCells.gd
@@ -27,6 +27,14 @@ DeclareAttribute( "Source",
 DeclareAttribute( "Range",
                   IsCapCategoryTwoCell );
 
+#! @Description
+#! The argument is a $2$-cell $c: \alpha \rightarrow \beta$.
+#! The output is its target $\beta$.
+#! @Returns a morphism
+#! @Arguments c
+DeclareAttribute( "Target",
+                  IsCapCategoryTwoCell );
+
 ###################################
 ##
 ## Properties

--- a/CAP/gap/CategoryTwoCells.gi
+++ b/CAP/gap/CategoryTwoCells.gi
@@ -8,9 +8,14 @@ BindGlobal( "IsCapCategoryTwoCellRep", IsCapCategoryTwoCell );
 
 ####################################
 ##
-## Add function
+## Operations
 ##
 ####################################
+
+InstallMethod( Target,
+               [ IsCapCategoryTwoCell ],
+               
+  Range );
 
 ##
 InstallMethod( Add,

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.07-01",
+Version := "2023.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -937,6 +937,12 @@ CapJitAddTypeSignature( "Range", [ IsCapCategoryMorphism ], function ( input_typ
     
 end );
 
+CapJitAddTypeSignature( "Target", [ IsCapCategoryMorphism ], function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
+
 # GAP operations
 CapJitAddTypeSignature( "RETURN_TRUE", [ IsObject, IsObject ], IsBool );
 CapJitAddTypeSignature( "Length", [ IsList ], IsInt );

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -509,7 +509,7 @@ CapJitAddLogicFunction( function ( tree )
                     
                     return object.args.2;
                     
-                elif attribute_name = "Range" then
+                elif attribute_name = "Range" or attribute_name = "Target" then
                     
                     return object.args.3;
                     
@@ -723,7 +723,7 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TELESCOPED_ITERATION, function ( tree, r
                     # Source can be recovered from initial_value
                     CapJitIsCallToGlobalFunction( source, "Source" ) and source.args.length = 1 and source.args.1.type = "EXPR_REF_FVAR" and source.args.1.func_id = result_func.id and source.args.1.name = result_func.nams[1] and
                     # Range can be recovered from initial_value
-                    CapJitIsCallToGlobalFunction( range, "Range" ) and range.args.length = 1 and range.args.1.type = "EXPR_REF_FVAR" and range.args.1.func_id = result_func.id and range.args.1.name = result_func.nams[1]
+                    CapJitIsCallToGlobalFunction( range, gvar -> gvar in [ "Range", "Target" ] ) and range.args.length = 1 and range.args.1.type = "EXPR_REF_FVAR" and range.args.1.func_id = result_func.id and range.args.1.name = result_func.nams[1]
                 then
                     
                     case := "from_initial_value";

--- a/CompilerForCAP/gap/LogicTemplates.gi
+++ b/CompilerForCAP/gap/LogicTemplates.gi
@@ -477,9 +477,16 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                 
             fi;
             
-            if template_tree.funcref.type = "EXPR_REF_GVAR" and not IsIdenticalObj( ValueGlobal( tree.funcref.gvar ), ValueGlobal( template_tree.funcref.gvar ) ) then
+            if template_tree.funcref.type = "EXPR_REF_GVAR" then
                 
-                return fail;
+                if
+                    not IsIdenticalObj( ValueGlobal( tree.funcref.gvar ), ValueGlobal( template_tree.funcref.gvar ) ) and
+                    not (template_tree.funcref.gvar in [ "Range", "Target" ] and tree.funcref.gvar in [ "Range", "Target" ] and IsBound( tree.funcref.data_type ) and IsSpecializationOfFilter( IsCapCategoryMorphism, tree.funcref.data_type.signature[1][1].filter ))
+                then
+                    
+                    return fail;
+                    
+                fi;
                 
             fi;
             
@@ -647,6 +654,15 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_TREE_MATCHES_TEMPLATE_TREE, function ( t
                     if debug then
                         # COVERAGE_IGNORE_NEXT_LINE
                         Display( "match: gvars point to identical values" );
+                    fi;
+                    
+                    continue;
+                    
+                elif template_tree.gvar in [ "Range", "Target" ] and tree.gvar in [ "Range", "Target" ] and IsBound( tree.data_type ) and IsSpecializationOfFilter( IsCapCategoryMorphism, tree.data_type.signature[1][1].filter ) then
+                    
+                    if debug then
+                        # COVERAGE_IGNORE_NEXT_LINE
+                        Display( "match: gvars are both Range resp. Target of a morphism" );
                     fi;
                     
                     continue;


### PR DESCRIPTION
Do not declare it as a synonym to avoid conflicts with other GAP packages.

"Target" seems to be used more widely and has typographical advantages:
1. "Target" naturally comes after "Source" when sorting alphabetically.
2. "Source" and "Target" have the same number of letters.
3. It better matches the maps "s" and "t" which are sometimes used to define categories.

@mohamed-barakat I have already talked to @sebastianpos and @kamalsaleh about this and both are in favor of this change. Do you also approve of this idea?