### PR TITLE
Introduce IsIsomorphicForObjects and SomeIsomorphismBetweenObjects

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.08-05",
+Version := "2023.08-06",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/TerminalCategoryWithMultipleObjects.g
+++ b/CAP/examples/TerminalCategoryWithMultipleObjects.g
@@ -10,7 +10,7 @@ T := TerminalCategoryWithMultipleObjects( );
 Display( T );
 #! A CAP category with name TerminalCategoryWithMultipleObjects( ):
 #! 
-#! 63 primitive operations were used to derive 304 operations for this category \
+#! 65 primitive operations were used to derive 306 operations for this category \
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts
@@ -58,14 +58,22 @@ aa := ObjectConstructor( T, "a" );
 #! <A zero object in TerminalCategoryWithMultipleObjects( )>
 Display( aa );
 #! a
-a = aa;
+IsEqualForObjects( a, aa );
+#! true
+IsIsomorphicForObjects( a, aa );
+#! true
+IsIsomorphism( SomeIsomorphismBetweenObjects( a, aa ) );
 #! true
 b := "b" / T;
 #! <A zero object in TerminalCategoryWithMultipleObjects( )>
 Display( b );
 #! b
-a = b;
+IsEqualForObjects( a, b );
 #! false
+IsIsomorphicForObjects( a, b );
+#! true
+IsIsomorphism( SomeIsomorphismBetweenObjects( a, b ) );
+#! true
 t := TensorProduct( a, b );
 #! <A zero object in TerminalCategoryWithMultipleObjects( )>
 Display( t );

--- a/CAP/examples/TerminalCategoryWithSingleObject.g
+++ b/CAP/examples/TerminalCategoryWithSingleObject.g
@@ -10,7 +10,7 @@ T := TerminalCategoryWithSingleObject( );
 Display( T );
 #! A CAP category with name TerminalCategoryWithSingleObject( ):
 #! 
-#! 63 primitive operations were used to derive 304 operations for this category \
+#! 63 primitive operations were used to derive 306 operations for this category \
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts

--- a/CAP/gap/AddFunctions.autogen.gd
+++ b/CAP/gap/AddFunctions.autogen.gd
@@ -2102,6 +2102,25 @@ DeclareOperation( "AddIsInjective",
 #! @Description
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
+#! to the category for the basic operation `IsIsomorphicForObjects`.
+#! $F: ( object_1, object_2 ) \mapsto \mathtt{IsIsomorphicForObjects}(object_1, object_2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddIsIsomorphicForObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddIsIsomorphicForObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddIsIsomorphicForObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddIsIsomorphicForObjects",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
 #! to the category for the basic operation `IsIsomorphism`.
 #! $F: ( arg2 ) \mapsto \mathtt{IsIsomorphism}(arg2)$.
 #! @Returns nothing
@@ -4453,6 +4472,25 @@ DeclareOperation( "AddSomeInjectiveObject",
                   [ IsCapCategory, IsList, IsInt ] );
 
 DeclareOperation( "AddSomeInjectiveObject",
+                  [ IsCapCategory, IsList ] );
+
+#! @Description
+#! The arguments are a category $C$ and a function $F$.
+#! This operation adds the given function $F$
+#! to the category for the basic operation `SomeIsomorphismBetweenObjects`.
+#! $F: ( object_1, object_2 ) \mapsto \mathtt{SomeIsomorphismBetweenObjects}(object_1, object_2)$.
+#! @Returns nothing
+#! @Arguments C, F
+DeclareOperation( "AddSomeIsomorphismBetweenObjects",
+                  [ IsCapCategory, IsFunction ] );
+
+DeclareOperation( "AddSomeIsomorphismBetweenObjects",
+                  [ IsCapCategory, IsFunction, IsInt ] );
+
+DeclareOperation( "AddSomeIsomorphismBetweenObjects",
+                  [ IsCapCategory, IsList, IsInt ] );
+
+DeclareOperation( "AddSomeIsomorphismBetweenObjects",
                   [ IsCapCategory, IsList ] );
 
 #! @Description

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -195,7 +195,7 @@ DeclareProperty( "IsEnrichedOverCommutativeRegularSemigroup", IsCapCategory );
 AddCategoricalProperty( [ "IsEnrichedOverCommutativeRegularSemigroup", "IsEnrichedOverCommutativeRegularSemigroup" ] );
 
 #! @Description
-#!  The property of the category <A>C</A> being skeletal.
+#!  The property of the category <A>C</A> being skeletal, that is, whether `IsEqualForObjects` and `IsIsomorphicForObjects` coincide.
 #! @Arguments C
 DeclareProperty( "IsSkeletalCategory", IsCapCategory );
 

--- a/CAP/gap/CategoryObjects.gd
+++ b/CAP/gap/CategoryObjects.gd
@@ -44,7 +44,7 @@ DeclareGlobalVariable( "PROPAGATION_LIST_FOR_EQUAL_OBJECTS" );
 
 ###################################
 ##
-#! @Section Equality for Objects
+#! @Section Equalities for Objects
 ##
 ###################################
 
@@ -60,6 +60,24 @@ DeclareOperation( "IsEqualForObjects",
 ## adds the given string to PROPAGATION_LIST_FOR_EQUAL_OBJECTS
 DeclareOperation( "AddPropertyToMatchAtIsEqualForObjects",
                   [ IsCapCategory, IsString ] );
+
+#! @Description
+#! The arguments are two objects $a$ and $b$.
+#! The output is <C>true</C> if $a$ and $b$ are isomorphic,
+#! that is, if there exists an isomorphism $a \to b$,
+#! otherwise the output is <C>false</C>.
+#! @Returns a boolean
+#! @Arguments a,b
+DeclareOperation( "IsIsomorphicForObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#! The arguments are two isomorphic objects $a$ and $b$.
+#! The output is an isomorphism $a \to b$.
+#! @Returns an isomorphism in $\mathrm{Hom}(a,b)$
+#! @Arguments a,b
+DeclareOperation( "SomeIsomorphismBetweenObjects",
+                  [ IsCapCategoryObject, IsCapCategoryObject ] );
 
 ###################################
 ##

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -1204,6 +1204,28 @@ end );
 ###########################
 
 ##
+AddDerivationToCAP( IsEqualForObjects,
+                    "skeletality",
+                    [ [ IsIsomorphicForObjects, 1 ] ],
+                    
+  function( cat, object_1, object_2 )
+    
+    return IsIsomorphicForObjects( cat, object_1, object_2 );
+    
+end : CategoryFilter := IsSkeletalCategory );
+
+##
+AddDerivationToCAP( IsIsomorphicForObjects,
+                    "skeletality",
+                    [ [ IsEqualForObjects, 1 ] ],
+                    
+  function( cat, object_1, object_2 )
+    
+    return IsEqualForObjects( cat, object_1, object_2 );
+    
+end : CategoryFilter := IsSkeletalCategory );
+
+##
 AddDerivationToCAP( IsBijectiveObject,
                     "IsBijectiveObject by checking if the object is both projective and injective",
                     [ [ IsProjective, 1 ],
@@ -1713,6 +1735,17 @@ end );
 ## Methods returning a morphism where the source and range can directly be read of from the input
 ##
 ###########################
+
+##
+AddDerivationToCAP( SomeIsomorphismBetweenObjects,
+                    "skeletality",
+                    [ [ IdentityMorphism, 1 ] ],
+                    
+  function( cat, object_1, object_2 )
+    
+    return IdentityMorphism( cat, object_1 );
+    
+end : CategoryFilter := IsSkeletalCategory );
 
 ##
 AddDerivationToCAP( ZeroMorphism,

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1237,7 +1237,46 @@ IsEqualForCacheForMorphisms := rec(
   return_type := "bool",
   compatible_with_congruence_of_morphisms := false,
 ),
-  
+
+IsIsomorphicForObjects := rec(
+  filter_list := [ "category", "object", "object" ],
+  input_arguments_names := [ "cat", "object_1", "object_2" ],
+  return_type := "bool",
+  dual_operation := "IsIsomorphicForObjects",
+  # The witness SomeIsomorphismBetweenObjects needs reversed arguments.
+  # This shows that reversing the arguments is the correct dualization,
+  # even if the relation is symmetric.
+  dual_arguments_reversed := true,
+  redirect_function := function( cat, object_1, object_2 )
+    
+    # As any CAP operation, IsIsomorphicForObjects must be compatible with IsEqualForObjects.
+    # This implies that IsIsomorphicForObjects must be coarser than IsEqualForObjects:
+    # One can see this by first choosing object_2 := object_1 and the varying one argument with regard to IsEqualForObjects.
+    if IsEqualForObjects( object_1, object_2 ) then
+        
+        return [ true, true ];
+        
+    else
+        
+        return [ false ];
+        
+    fi;
+    
+  end,
+),
+
+SomeIsomorphismBetweenObjects := rec(
+  filter_list := [ "category", "object", "object" ],
+  input_arguments_names := [ "cat", "object_1", "object_2" ],
+  return_type := "morphism",
+  output_source_getter_string := "object_1",
+  output_source_getter_preconditions := [ ],
+  output_range_getter_string := "object_2",
+  output_range_getter_preconditions := [ ],
+  dual_operation := "SomeIsomorphismBetweenObjects",
+  dual_arguments_reversed := true,
+),
+
 IsZeroForMorphisms := rec(
   filter_list := [ "category", "morphism" ],
   return_type := "bool",

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -399,6 +399,22 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
         
     end );
     
+    ##
+    AddIsIsomorphicForObjects( T,
+      function( T, object_1, object_2 )
+        
+        return true;
+        
+    end );
+    
+    ##
+    AddSomeIsomorphismBetweenObjects( T,
+      function( T, object_1, object_2 )
+        
+        return MorphismConstructor( T, object_1, "SomeIsomorphismBetweenObjects", object_2 );
+        
+    end );
+    
     Finalize( T );
     
     return T;

--- a/CartesianCategories/PackageInfo.g
+++ b/CartesianCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CartesianCategories",
 Subtitle := "Cartesian and cocartesian categories and various subdoctrines",
-Version := "2023.08-01",
+Version := "2023.08-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
+++ b/CartesianCategories/examples/InfoStringOfInstalledOperationsOfCategory.g
@@ -15,7 +15,7 @@ distributive := DummyCategory( rec(
   properties := [ "IsBicartesianClosedCategory", "IsSkeletalCategory" ] ) );;
 
 InfoOfInstalledOperationsOfCategory( distributive );
-#! 19 primitive operations were used to derive 110 operations for this category \
+#! 19 primitive operations were used to derive 112 operations for this category \
 #! which algorithmically
 #! * IsBicartesianClosedCategory
 #! and furthermore mathematically

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.07-02",
+Version := "2023.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -11,6 +11,12 @@ R := HomalgRingOfIntegers();;
 cat := CategoryOfRows( R );;
 obj1 := CategoryOfRowsObject( 1, cat );;
 obj2 := CategoryOfRowsObject( 2, cat );;
+IsIsomorphicForObjects( obj1, obj2 );
+#! false
+IsIsomorphicForObjects( obj2, obj2 );
+#! true
+IsIsomorphism( SomeIsomorphismBetweenObjects( obj2, obj2 ) );
+#! true
 id := IdentityMorphism( obj2 );;
 alpha := CategoryOfRowsMorphism( obj1, HomalgMatrix( [ [ 1, 2 ] ], 1, 2, R ), obj2 );;
 beta := CategoryOfRowsMorphism( obj2, HomalgMatrix( [ [ 1, 2 ], [ 3, 4 ] ], 2, 2, R ), obj2 );;

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.autogen.gd
@@ -254,6 +254,7 @@
 #! * <Ref BookName="MonoidalCategories" Func="InternalHomOnMorphismsWithGivenInternalHoms" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="InternalHomOnObjects" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="InternalHomToTensorProductAdjunctionMap" Label="for Is" />
+#! * <Ref BookName="CAP" Func="IsIsomorphicForObjects" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="IsomorphismFromCoDualObjectToInternalCoHomFromTensorUnit" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="IsomorphismFromDualObjectToInternalHomIntoTensorUnit" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="IsomorphismFromInternalCoHomFromTensorUnitToCoDualObject" Label="for Is" />
@@ -313,6 +314,7 @@
 #! * <Ref BookName="MonoidalCategories" Func="RightUnitorInverse" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="RightUnitorInverseWithGivenTensorProduct" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="RightUnitorWithGivenTensorProduct" Label="for Is" />
+#! * <Ref BookName="CAP" Func="SomeIsomorphismBetweenObjects" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="TensorProductDualityCompatibilityMorphism" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="TensorProductDualityCompatibilityMorphismWithGivenObjects" Label="for Is" />
 #! * <Ref BookName="MonoidalCategories" Func="TensorProductInternalHomCompatibilityMorphism" Label="for Is" />

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory.gi
@@ -19,7 +19,36 @@ InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
     
     ring_as_category := RING_AS_CATEGORY( homalg_ring : FinalizeCategory := true );
     
-    add := ADDITIVE_CLOSURE( ring_as_category : FinalizeCategory := true );
+    add := ADDITIVE_CLOSURE( ring_as_category : FinalizeCategory := false );
+    
+    # Depending on the properties `HasInvariantBasisProperty` and `IsFieldForHomalg` of `homalg_ring`,
+    # the additive closure is skeletal and/or Abelian.
+    # These ring properties should actually be propagated to some categorical properties of `ring_as_category`
+    # which the AdditiveClosure can use generically.
+    # However, such categorical properties do not (yet) exist, so we have to set the categorical properties
+    # a posteriori here. Afterwards, we have to reevaluate the derivations because they might have changed
+    # by setting the properties.
+    if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then
+        
+        SetIsSkeletalCategory( add, true );
+        
+    fi;
+    
+    if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring ) then
+        
+        SetIsAbelianCategory( add, true );
+        
+        SetIsAbelianCategoryWithEnoughProjectives( add, true );
+        
+        SetIsAbelianCategoryWithEnoughInjectives( add, true );
+        
+    fi;
+    
+    Reevaluate( add!.derivations_weight_list );
+    
+    Finalize( add : FinalizeCategory := true );
+    
+    
     
     object_constructor := function ( cat, rank )
         
@@ -223,22 +252,6 @@ InstallMethod( CategoryOfRowsAsAdditiveClosureOfRingAsCategory,
         SetBasisOfRingOverBaseFieldAsColumnVector( wrapper, BasisOverBaseFieldAsColumnVector( ring_as_category ) );
         
         Add( wrapper!.compiler_hints.category_attribute_names, "BasisOfRingOverBaseFieldAsColumnVector" );
-        
-    fi;
-    
-    if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then
-        
-        SetIsSkeletalCategory( wrapper, true );
-        
-    fi;
-    
-    if HasIsFieldForHomalg( homalg_ring ) and IsFieldForHomalg( homalg_ring ) then
-        
-        SetIsAbelianCategory( wrapper, true );
-        
-        SetIsAbelianCategoryWithEnoughProjectives( wrapper, true );
-        
-        SetIsAbelianCategoryWithEnoughInjectives( wrapper, true );
         
     fi;
     

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2023.06-02",
+Version := "2023.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -2365,6 +2365,17 @@ end
     , 100 );
     
     ##
+    AddIsIsomorphicForObjects( cat,
+        
+########
+function ( cat_1, object_1_1, object_2_1 )
+    return Dimension( object_1_1 ) = Dimension( object_2_1 );
+end
+########
+        
+    , 101 : IsPrecompiledDerivation := true );
+    
+    ##
     AddIsIsomorphism( cat,
         
 ########
@@ -5155,6 +5166,17 @@ end
 ########
         
     , 100 );
+    
+    ##
+    AddSomeIsomorphismBetweenObjects( cat,
+        
+########
+function ( cat_1, object_1_1, object_2_1 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, object_1_1, object_1_1, UnderlyingMatrix, HomalgIdentityMatrix( Dimension( object_1_1 ), UnderlyingRing( cat_1 ) ) );
+end
+########
+        
+    , 101 : IsPrecompiledDerivation := true );
     
     ##
     AddSomeProjectiveObject( cat,


### PR DESCRIPTION
@sebastianpos Is there a reason why `IsIsomorphicForObjects` was not added before? I'm asking because it seems like a very obvious operation :D But maybe it simply was never needed? In fact, I also have no concrete application, I just want to make `IsSkeletalCategory` precise, which can now be defined as `IsEqualForObjects` and `IsIsomorphicForObjects` coinciding.