### PR TITLE
Include first morphism in check in prefunctions for (Co)Equalizer

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.08-13",
+Version := "2023.08-14",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/MethodRecord.gi
+++ b/CAP/gap/MethodRecord.gi
@@ -1576,7 +1576,7 @@ Equalizer := rec(
         
     fi;
     
-    for current_morphism in diagram{[ 2 .. Length( diagram ) ]} do
+    for current_morphism in diagram{[ 1 .. Length( diagram ) ]} do
         
         if not IsEqualForObjects( cat, Source( current_morphism ), cobase ) then
             return [ false, "the given morphisms of the equalizer diagram must have equal sources" ];
@@ -1666,7 +1666,7 @@ UniversalMorphismIntoEqualizer := rec(
         
     fi;
     
-    for current_morphism in diagram{[ 2 .. Length( diagram ) ]} do
+    for current_morphism in diagram{[ 1 .. Length( diagram ) ]} do
         
         if not IsEqualForObjects( cat, Source( current_morphism ), cobase ) then
             return [ false, "the given morphisms of the equalizer diagram must have equal sources" ];
@@ -2004,7 +2004,7 @@ Coequalizer := rec(
         
     od;
     
-    for current_morphism in diagram{[ 2 .. Length( diagram ) ]} do
+    for current_morphism in diagram{[ 1 .. Length( diagram ) ]} do
         
         if not IsEqualForObjects( cat, Range( current_morphism ), cobase ) then
             return [ false, "the given morphisms of the coequalizer diagram must have equal ranges" ];
@@ -2094,7 +2094,7 @@ UniversalMorphismFromCoequalizer := rec(
         
     od;
     
-    for current_morphism in diagram{[ 2 .. Length( diagram ) ]} do
+    for current_morphism in diagram{[ 1 .. Length( diagram ) ]} do
         
         if not IsEqualForObjects( cat, Range( current_morphism ), cobase ) then
             return [ false, "the given morphisms of the coequalizer diagram must have equal ranges" ];


### PR DESCRIPTION
I have missed this in c644a8f7c6e2eca97063a1bd915de20d7c5849a2.