### PR TITLE
Simplify and improve detection of loops for preconditions in derivations

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.09-05",
+Version := "2023.09-06",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 


### PR DESCRIPTION
1. Add support for `repeat ... until ...;`.
2. Detect "functional" loops by checking if code is inside a literal function. This works because literal functions are only used as input for "loop-like" functions, and, conversely, all inputs for "loop-like" functions are constructed this way.