### PR TITLE
Improve compilability of LinearClosure and other improvements

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.09-03",
+Version := "2023.10-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -866,37 +866,25 @@ CapJitAddTypeSignature( "CapFixpoint", [ IsFunction, IsFunction, IsObject ], fun
 end );
 
 # CreateCapCategory*WithAttributes
-CapJitAddTypeSignature( "CreateCapCategoryObjectWithAttributes", [ IsCapCategory ], function ( input_types )
+CapJitAddTypeSignature( "CreateCapCategoryObjectWithAttributes", "any", function ( input_types )
+    
+    Assert( 0, Length( input_types ) >= 1 );
+    Assert( 0, IsOddInt( Length( input_types ) ) );
+    Assert( 0, IsSpecializationOfFilter( IsCapCategory, input_types[1].filter ) );
+    Assert( 0, ForAll( [ 2, 4 .. Length( input_types ) - 1 ], i -> IsSpecializationOfFilter( IsFunction, input_types[i].filter ) ) );
     
     return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
     
 end );
 
-CapJitAddTypeSignature( "CreateCapCategoryObjectWithAttributes", [ IsCapCategory, IsFunction, IsObject ], function ( input_types )
+CapJitAddTypeSignature( "CreateCapCategoryMorphismWithAttributes", "any", function ( input_types )
     
-    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
-    
-end );
-
-CapJitAddTypeSignature( "CreateCapCategoryObjectWithAttributes", [ IsCapCategory, IsFunction, IsObject, IsFunction, IsObject ], function ( input_types )
-    
-    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
-    
-end );
-
-CapJitAddTypeSignature( "CreateCapCategoryObjectWithAttributes", [ IsCapCategory, IsFunction, IsObject, IsFunction, IsObject, IsFunction, IsObject ], function ( input_types )
-    
-    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
-    
-end );
-
-CapJitAddTypeSignature( "CreateCapCategoryMorphismWithAttributes", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject ], function ( input_types )
-    
-    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
-    
-end );
-
-CapJitAddTypeSignature( "CreateCapCategoryMorphismWithAttributes", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryObject, IsFunction, IsObject ], function ( input_types )
+    Assert( 0, Length( input_types ) >= 3 );
+    Assert( 0, IsOddInt( Length( input_types ) ) );
+    Assert( 0, IsSpecializationOfFilter( IsCapCategory, input_types[1].filter ) );
+    Assert( 0, IsSpecializationOfFilter( IsCapCategoryObject, input_types[2].filter ) );
+    Assert( 0, IsSpecializationOfFilter( IsCapCategoryObject, input_types[3].filter ) );
+    Assert( 0, ForAll( [ 4, 6 .. Length( input_types ) - 1 ], i -> IsSpecializationOfFilter( IsFunction, input_types[i].filter ) ) );
     
     return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
     

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.09-03",
+Version := "2023.10-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -901,7 +901,7 @@ InstallMethod( ViewString,
 
   function( obj )
     
-    return Concatenation( "LinearClosure(", ViewString( UnderlyingOriginalObject( obj ) ), ")" );
+    return Concatenation( "LinearClosureObject(", ViewString( UnderlyingOriginalObject( obj ) ), ")" );
     
 end );
 

--- a/FreydCategoriesForCAP/gap/LinearClosure.gi
+++ b/FreydCategoriesForCAP/gap/LinearClosure.gi
@@ -267,13 +267,20 @@ InstallMethod( LinearClosureMorphismNC,
     
     category := CapCategory( source );
     
-    ## this is a "compiled" version of ObjectifyMorphismForCAPWithAttributes
-    return ObjectifyWithAttributes( rec( ), category!.morphism_type,
-        Source, source,
-        Range, range,
+    return LinearClosureMorphismNC( category, source, coefficients, support_morphisms, range );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( LinearClosureMorphismNC,
+                                     [ IsLinearClosure, IsLinearClosureObject, IsList, IsList, IsLinearClosureObject ],
+  function( category, source, coefficients, support_morphisms, range )
+    
+    return CreateCapCategoryMorphismWithAttributes( category,
+        source, range,
         CoefficientsList, coefficients,
-        SupportMorphisms, support_morphisms,
-        CapCategory, category );
+        SupportMorphisms, support_morphisms
+    );
     
 end );
 
@@ -358,7 +365,7 @@ end );
 
 InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
     function( category )
-        local ring, underlying_category, sorting_function, mul_coeffs, mul_supp, one, zero, minus_one, with_nf,
+        local ring, underlying_category, sorting_function, mul_coeffs, mul_supp, with_nf,
               equality_func, finsets, rows, t_obj, t_finsets, FunctorMor, FunctorObj, cocycle;
     
     ring := UnderlyingRing( category );
@@ -372,12 +379,6 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
         sorting_function := category!.sorting_function;
         
     fi;
-    
-    one := One( ring );
-    
-    zero := Zero( ring );
-    
-    minus_one := MinusOne( ring );
     
     ##
     AddIsEqualForObjects( category, {cat, a, b} -> IsEqualForObjects( UnderlyingOriginalObject( a ), UnderlyingOriginalObject( b ) ) );
@@ -544,7 +545,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
     AddIdentityMorphism( category,
       function( cat, object )
         
-        return LinearClosureMorphismNC( object, [ one ], [ IdentityMorphism( UnderlyingOriginalObject( object ) ) ], object );
+        return LinearClosureMorphismNC( cat, object, [ One( ring ) ], [ IdentityMorphism( UnderlyingCategory( cat ), UnderlyingOriginalObject( object ) ) ], object );
         
     end );
     
@@ -552,7 +553,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
     AddZeroMorphism( category,
       function( cat, a, b )
         
-        return LinearClosureMorphismNC( a, [ ], [ ], b );
+        return LinearClosureMorphismNC( cat, a, [ ], [ ], b );
         
     end );
     
@@ -595,7 +596,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
       function( cat, alpha )
         return LinearClosureMorphism(
             Source( alpha ),
-            List( CoefficientsList( alpha ), c -> minus_one * c ),
+            List( CoefficientsList( alpha ), c -> MinusOne( ring ) * c ),
             SupportMorphisms( alpha ),
             Range( alpha )
         );
@@ -606,7 +607,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_LINEAR_CLOSURE,
       function( cat, alpha, beta )
         return LinearClosureMorphism(
             Source( alpha ),
-            Concatenation( CoefficientsList( alpha ), List( CoefficientsList( beta ), c -> minus_one * c ) ),
+            Concatenation( CoefficientsList( alpha ), List( CoefficientsList( beta ), c -> MinusOne( ring ) * c ) ),
             Concatenation( SupportMorphisms( alpha ), SupportMorphisms( beta ) ),
             Range( alpha )
         );


### PR DESCRIPTION
I have checked that the changes cause no significant performance regressions in the examples `MatricesOverZG.g` and `MatricesOverProsets.g`.