### PR TITLE
Use `RingFilter` and `RingElementFilter`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.10-07",
+Version := "2023.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -97,7 +97,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12.1",
-  NeededOtherPackages := [ [ "ToolsForHomalg", ">= 2023.07-01" ],
+  NeededOtherPackages := [ [ "ToolsForHomalg", ">= 2023.11-01" ],
   ],
   SuggestedOtherPackages := [ [ "Browse", ">= 1.5" ],
                               [ "CompilerForCAP", ">= 2021.12-05" ],

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -166,9 +166,9 @@ InstallGlobalFunction( "CAP_INTERNAL_GET_DATA_TYPE_FROM_STRING", function ( stri
             
             ring := CommutativeRingOfLinearCategory( category );
             
-            if IsBoundGlobal( "IsHomalgRing" ) and ValueGlobal( "IsHomalgRing" )( ring ) then
+            if HasRingElementFilter( ring ) then
                 
-                is_ring_element := ValueGlobal( "IsHomalgRingElement" );
+                is_ring_element := RingElementFilter( ring );
                 
             else
                 
@@ -198,9 +198,9 @@ InstallGlobalFunction( "CAP_INTERNAL_GET_DATA_TYPE_FROM_STRING", function ( stri
             
             ring := CommutativeRingOfLinearCategory( category );
             
-            if IsBoundGlobal( "IsHomalgRing" ) and ValueGlobal( "IsHomalgRing" )( ring ) then
+            if HasRingElementFilter( ring ) then
                 
-                is_ring_element := ValueGlobal( "IsHomalgRingElement" );
+                is_ring_element := RingElementFilter( ring );
                 
             else
                 
@@ -292,11 +292,6 @@ InstallGlobalFunction( CAP_INTERNAL_REPLACED_STRING_WITH_FILTER,
         # `IsNTuple` deliberately does not imply `IsList` because we want to treat tuples and lists in different ways in CompilerForCAP.
         # However, on the GAP level tuples are just dense lists.
         return IsDenseList;
-        
-    elif IsBoundGlobal( "IsHomalgRingElement" ) and IsSpecializationOfFilter( ValueGlobal( "IsHomalgRingElement" ), data_type.filter ) then
-        
-        # Some things (e.g. integers) do not lie in the filter `IsHomalgRingElement` but are actually elements of homalg rings (e.g. `HomalgRingOfIntegers( )`).
-        return IsRingElement;
         
     else
         
@@ -555,19 +550,6 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
             fi;
             
             CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( value, data_type.category, human_readable_identifier_list );
-            
-        end;
-        
-    elif IsBoundGlobal( "IsHomalgRingElement" ) and IsSpecializationOfFilter( ValueGlobal( "IsHomalgRingElement" ), filter ) then
-        
-        return function( value )
-            
-            # Some things (e.g. integers) do not lie in the filter `IsHomalgRingElement` but are actually elements of homalg rings (e.g. `HomalgRingOfIntegers( )`).
-            if not IsRingElement( value ) then
-                
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter IsRingElement.", generic_help_string ] ) );
-                
-            fi;
             
         end;
         

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.10-05",
+Version := "2023.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/examples/PrecompileMatrixCategoryAsCategoryOfRows.g
+++ b/CompilerForCAP/examples/PrecompileMatrixCategoryAsCategoryOfRows.g
@@ -12,7 +12,7 @@ LoadPackage( "LinearAlgebraForCAP", false );
 ReadPackage( "LinearAlgebraForCAP", "gap/CompilerLogic.gi" );
 #! true
 
-QQ := HomalgFieldOfRationals( );;
+QQ := HomalgFieldOfRationalsInSingular( );;
 
 category_constructor := field -> MatrixCategoryAsCategoryOfRows( field );;
 given_arguments := [ QQ ];;

--- a/CompilerForCAP/examples/PrecompileOppositeOfMatrixCategory.g
+++ b/CompilerForCAP/examples/PrecompileOppositeOfMatrixCategory.g
@@ -7,7 +7,7 @@
 LoadPackage( "LinearAlgebraForCAP", false );
 #! true
 
-QQ := HomalgFieldOfRationals( );;
+QQ := HomalgFieldOfRationalsInSingular( );;
 
 # be careful not to use `MatrixCategory` because attributes are not supported
 category_constructor := function( field )

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -909,9 +909,9 @@ CapJitAddTypeSignature( "CommutativeRingOfLinearCategory", [ IsCapCategory ], fu
     
     ring := CommutativeRingOfLinearCategory( input_types[1].category );
     
-    if IsBoundGlobal( "IsHomalgRing" ) and ValueGlobal( "IsHomalgRing" )( ring ) then
+    if HasRingFilter( ring ) then
         
-        return rec( filter := ValueGlobal( "IsHomalgRing" ) );
+        return rec( filter := RingFilter( ring ) );
         
     else
         
@@ -1569,6 +1569,8 @@ CapJitAddTypeSignature( "Iterated", [ IsList, IsFunction, IsObject, IsObject ], 
 end );
 
 # homalg operations
+# These rules only hold for external homalg rings.
+# For example, `Zero( HomalgRingOfIntegers( ) )` does not lie in `IsHomalgRingElement`.
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "ZeroImmutable", [ "IsHomalgRing" ], "IsHomalgRingElement" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "OneImmutable", [ "IsHomalgRing" ], "IsHomalgRingElement" );
 
@@ -1576,21 +1578,21 @@ CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgMatrix", [ "IsList",
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgMatrixListList", [ "IsList", "IsInt", "IsInt", "IsHomalgRing" ], """function( input_types )
     
     Assert( 0, input_types[1].element_type.filter = IsList );
-    Assert( 0, input_types[1].element_type.element_type.filter in [ IsHomalgRingElement, IsInt, IsRat ] );
+    Assert( 0, input_types[1].element_type.element_type.filter = IsHomalgRingElement );
     
     return rec( filter := IsHomalgMatrix );
     
 end""" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgRowVector", [ "IsList", "IsInt", "IsHomalgRing" ], """function( input_types )
     
-    Assert( 0, input_types[1].element_type.filter in [ IsHomalgRingElement, IsInt, IsRat ] );
+    Assert( 0, input_types[1].element_type.filter = IsHomalgRingElement );
     
     return rec( filter := IsHomalgMatrix );
     
 end""" );
 CapJitAddTypeSignatureDeferred( "MatricesForHomalg", "HomalgColumnVector", [ "IsList", "IsInt", "IsHomalgRing" ], """function( input_types )
     
-    Assert( 0, input_types[1].element_type.filter in [ IsHomalgRingElement, IsInt, IsRat ] );
+    Assert( 0, input_types[1].element_type.filter = IsHomalgRingElement );
     
     return rec( filter := IsHomalgMatrix );
     

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.11-03",
+Version := "2023.11-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gd
@@ -63,9 +63,9 @@ DeclareAttribute( "UnderlyingRingElement",
                   IsRingAsCategoryMorphism );
 CapJitAddTypeSignature( "UnderlyingRingElement", [ IsRingAsCategoryMorphism ], function ( input_types )
     
-    if IsHomalgRing( UnderlyingRing( input_types[1].category ) ) then
+    if HasRingElementFilter( UnderlyingRing( input_types[1].category ) ) then
         
-        return rec( filter := IsHomalgRingElement );
+        return rec( filter := RingElementFilter( UnderlyingRing( input_types[1].category ) ) );
         
     else
         
@@ -80,9 +80,9 @@ DeclareAttribute( "UnderlyingRing",
 
 CapJitAddTypeSignature( "UnderlyingRing", [ IsRingAsCategory ], function ( input_types )
     
-    if IsHomalgRing( UnderlyingRing( input_types[1].category ) ) then
+    if HasRingFilter( UnderlyingRing( input_types[1].category ) ) then
         
-        return rec( filter := IsHomalgRing );
+        return rec( filter := RingFilter( UnderlyingRing( input_types[1].category ) ) );
         
     else
         


### PR DESCRIPTION
This might break compilation of categories using internal homalg rings. However, this is not a real regression but simply brings to light that the handling of internal homalg rings was already inconsistent before. As a solution, we can simply use external homalg rings for compilation for now.