### PR TITLE
Introduce CAP_JIT_EXPR_CASE_WRAPPER which explicitly wraps functions for Julia

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.11-03",
+Version := "2023.12-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -331,6 +331,12 @@ DeclareGlobalFunction( "HandlePrecompiledTowers" );
 DeclareGlobalFunction( "CAP_JIT_INCOMPLETE_LOGIC" );
 
 #! @Description
+#!   Simply returns <A>func</A>, which must be a literal function without arguments only containing an `if-elif-else` statement with each branch consisting of a single `return` statement.
+#!   Used to write expressions of the form `function() if-elif-else end()` as `CAP_JIT_EXPR_CASE_WRAPPER(function() if-elif-else end)()` because the former is not valid in Julia.
+#! @Arguments func
+DeclareGlobalFunction( "CAP_JIT_EXPR_CASE_WRAPPER" );
+
+#! @Description
 #!   Same as `List( <A>list</A>, <A>func</A> )` but <A>func</A> gets both the key `i` and `<A>list</A>[i]` as arguments.
 #! @Arguments list, func
 #! @Returns a list

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1631,6 +1631,7 @@ InstallGlobalFunction( HandlePrecompiledTowers, function ( category, underlying_
 end );
 
 InstallGlobalFunction( CAP_JIT_INCOMPLETE_LOGIC, IdFunc );
+InstallGlobalFunction( CAP_JIT_EXPR_CASE_WRAPPER, IdFunc );
 
 ##
 #= comment for Julia

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up computations in CAP categories",
-Version := "2023.12-01",
+Version := "2023.12-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -755,6 +755,21 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
             
         fi;
         
+        # drop CAP_JIT_EXPR_CASE_WRAPPER
+        # must be done after introduction of "EXPR_CASE"
+        if tree.type = "EXPR_FUNCCALL" and CapJitIsCallToGlobalFunction( tree.funcref, "CAP_JIT_EXPR_CASE_WRAPPER" ) then
+            
+            Assert( 0, tree.args.length = 0 );
+            Assert( 0, tree.funcref.args.length = 1 );
+            Assert( 0, tree.funcref.args.1.type = "EXPR_DECLARATIVE_FUNC" );
+            Assert( 0, tree.funcref.args.1.narg = 0 );
+            Assert( 0, tree.funcref.args.1.bindings.names = [ "RETURN_VALUE" ] );
+            Assert( 0, tree.funcref.args.1.bindings.BINDING_RETURN_VALUE.type = "EXPR_CASE" );
+            
+            tree := tree.funcref.args.1.bindings.BINDING_RETURN_VALUE;
+            
+        fi;
+        
         return tree;
         
     end;
@@ -1328,8 +1343,8 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
             
             if tree.type = "EXPR_CASE" then
                 
-                # code as IdFunc( function( ) if ... then return ...; else return ...; fi; end )()
-                # the IdFunc is required because the GAP syntax `function() return ...; end()` is not valid in Julia
+                # code as CAP_JIT_EXPR_CASE_WRAPPER( function( ) if ... then return ...; else return ...; fi; end )()
+                # the wrapper is necessary because the GAP syntax `function() return ...; end()` is not valid in Julia
                 tree := rec(
                     type := "EXPR_FUNCCALL_0ARGS",
                     args := AsSyntaxTreeList( [ ] ),
@@ -1337,7 +1352,7 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE_CODE, function ( tree )
                         type := "EXPR_FUNCCALL",
                         funcref := rec(
                             type := "EXPR_REF_GVAR",
-                            gvar := "IdFunc",
+                            gvar := "CAP_JIT_EXPR_CASE_WRAPPER",
                         ),
                         args := AsSyntaxTreeList( [ rec(
                             type := "EXPR_FUNC",

--- a/CompilerForCAP/tst/EXPR_CASE.tst
+++ b/CompilerForCAP/tst/EXPR_CASE.tst
@@ -33,7 +33,6 @@ gap> tree2 := rec(
 >     variadic := false,
 >     bindings := rec(
 >         type := "FVAR_BINDING_SEQ",
->         length := 1,
 >         names := [ "RETURN_VALUE" ],
 >         BINDING_RETURN_VALUE := rec(
 >             type := "EXPR_FUNCCALL",
@@ -76,7 +75,7 @@ gap> tree2 := rec(
 gap> coded_func2 := ENHANCED_SYNTAX_TREE_CODE( tree2 );;
 gap> Display( coded_func2 );
 function (  )
-    return MY_ID_FUNC( IdFunc( function (  )
+    return MY_ID_FUNC( CAP_JIT_EXPR_CASE_WRAPPER( function (  )
                 if false then
                     return 1;
                 else
@@ -89,6 +88,10 @@ end
 #
 gap> coded_func2();
 2
+
+#
+gap> ENHANCED_SYNTAX_TREE( coded_func2 ).bindings = tree2.bindings;
+true
 
 #
 #


### PR DESCRIPTION
Previously, simply `IdFunc` was used. This had two downsides:
1. A user might be surprised by the `IdFunc`s and might try to remove them with logic templates.
2. It is desirable to have `ENHANCED_SYNTAX_TREE( ENHANCED_SYNTAX_TREE_CODE( tree ) ) = tree` (up to change of function IDs). So we have to remove the artificial `IdFunc`s again, but cannot distinguish them from regular `IdFunc`s appearing in the original code.