### PR TITLE
Fix HomomorphismStructureOnObjects in AdditiveClosure

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-02",
+Version := "2023.12-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -1037,9 +1037,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
               function( cat, object_1, object_2 )
                 
                 return DirectSum( range_category,
-                          Concatenation(
-                            List( ObjectList( object_1 ), obj_i ->
-                              List( ObjectList( object_2 ), obj_j -> HomomorphismStructureOnObjectsExtendedByFullEmbedding( UnderlyingCategory( cat ), range_category, obj_i, obj_j ) )
+                          List( [ 1 .. Length( ObjectList( object_1 ) ) ], j ->
+                            DirectSum( range_category,
+                              List( [ 1 .. Length( ObjectList( object_2 ) ) ], s -> HomomorphismStructureOnObjectsExtendedByFullEmbedding( UnderlyingCategory( cat ), range_category, ObjectList( object_1 )[j], ObjectList( object_2 )[s] ) )
                             )
                           )
                         );

--- a/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRowsAsAdditiveClosureOfRingAsCategory_CompilerLogic.gi
@@ -457,3 +457,13 @@ CapJitAddLogicTemplate(
         needed_packages := [ [ "MatricesForHomalg", ">= 2020.06.27" ] ],
     )
 );
+
+# Sum( ListWithIdenticalEntries( n, entry ) ) -> n * entry
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "n", "entry" ],
+        variable_filters := [ "IsInt", "IsInt" ],
+        src_template := "Sum( ListWithIdenticalEntries( n, entry ) )",
+        dst_template := "n * entry",
+    )
+);

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -145,7 +145,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, Sum( ListWithIdenticalEntries( RankOfObject( arg3_1 ) * RankOfObject( arg2_1 ), Length( EntriesOfHomalgColumnVector( BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) ) ) ) );
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, RankOfObject( arg3_1 ) * (RankOfObject( arg2_1 ) * Length( EntriesOfHomalgColumnVector( BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) )) );
 end
 ########
         
@@ -223,7 +223,7 @@ function ( cat_1, source_1, range_1, alpha_1 )
                 hoisted_1_2 := deduped_8_1 * (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) - 1);
                 return List( hoisted_6_1, function ( j_3 )
                         local deduped_1_3;
-                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1, deduped_2_1 ) ) + 1;
+                        deduped_1_3 := (hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1) * deduped_2_1 + 1;
                         return EntriesOfHomalgMatrix( CoercedMatrix( deduped_9_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_2_1) ] ) ) ) * deduped_10_1 )[1];
                     end );
             end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -145,7 +145,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, Sum( ListWithIdenticalEntries( RankOfObject( arg2_1 ) * RankOfObject( arg3_1 ), Length( EntriesOfHomalgColumnVector( BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) ) ) ) );
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), RankOfObject, RankOfObject( arg2_1 ) * (RankOfObject( arg3_1 ) * Length( EntriesOfHomalgColumnVector( BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) )) );
 end
 ########
         
@@ -223,7 +223,7 @@ function ( cat_1, source_1, range_1, alpha_1 )
                 hoisted_1_2 := deduped_8_1 * (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) - 1);
                 return List( hoisted_6_1, function ( j_3 )
                         local deduped_1_3;
-                        deduped_1_3 := Sum( ListWithIdenticalEntries( hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1, deduped_2_1 ) ) + 1;
+                        deduped_1_3 := (hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1) * deduped_2_1 + 1;
                         return EntriesOfHomalgMatrix( CoercedMatrix( deduped_9_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_2_1) ] ) ) ) * deduped_10_1 )[1];
                     end );
             end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );


### PR DESCRIPTION
If the range category is not strict, the parentheses in the direct sums are important.
This issue was discovered using CompilerForCAP as a proof assistant.
It can also be seen using the following code:
```
LoadPackage( "FreydCategoriesForCAP" );;
QQ := HomalgFieldOfRationalsInSingular();;
R := QQ * "x,y,z";;
EEE := KoszulDualRing( R );;
CEEE := RingAsCategory( EEE );
LoadPackage( "LazyCategories" );
lazy := LazyCategory( CEEE : optimize := 0, lazify_range_of_hom_structure := true );
RangeCategoryOfHomomorphismStructure( lazy )!.supports_empty_limits := false;
add := AdditiveClosure( lazy );
mor := 1 / CEEE / lazy / add;
H_mor_mor := HomomorphismStructureOnMorphisms( mor, mor );
Display( Source( H_mor_mor ) = HomomorphismStructureOnObjects( Range( mor ), Source( mor ) ) );
```