### PR TITLE
Preserve data type during hoisting and deduplication

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2023.12-10",
+Version := "2023.12-11",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/DeduplicateExpressions.gi
+++ b/CompilerForCAP/gap/DeduplicateExpressions.gi
@@ -142,6 +142,12 @@ InstallGlobalFunction( CapJitDeduplicatedExpressions, function ( tree )
                             name := new_variable_name,
                         );
                         
+                        if IsBound( expr.data_type ) then
+                            
+                            info2.parent.(info2.key).data_type := expr.data_type;
+                            
+                        fi;
+                        
                         if i > 1 then
                             
                             Add( ignored_paths, info2.path );

--- a/CompilerForCAP/gap/HoistExpressions.gi
+++ b/CompilerForCAP/gap/HoistExpressions.gi
@@ -214,6 +214,12 @@ InstallGlobalFunction( CAP_JIT_INTERNAL_HOISTED_EXPRESSIONS_OR_BINDINGS, functio
                                 name := new_variable_name,
                             );
                             
+                            if IsBound( expr.data_type ) then
+                                
+                                info2.parent.(info2.key).data_type := expr.data_type;
+                                
+                            fi;
+                            
                         fi;
                         
                         Add( to_delete, i );


### PR DESCRIPTION
Data types are now taken into account when comparing syntax trees, so for optimal deduplication we have to preserve them.