### PR TITLE
Fix InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism in AdditiveClosure

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-05",
+Version := "2023.12-06",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -1264,46 +1264,52 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             
             ##
             AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( category,
-              function( cat, A, B, morphism )
-                local obj_list_A, obj_list_B, size_i, size_j, listlist, summands;
+              function( cat, B, C, morphism )
+                local size_j, size_s, H_B_C, direct_sums, blocks, listlist;
                 
-                obj_list_A := ObjectList( A );
+                size_j := Length( ObjectList( B ) );
                 
-                obj_list_B := ObjectList( B );
+                size_s := Length( ObjectList( C ) );
                 
-                size_i := Length( obj_list_A );
+                H_B_C :=
+                    List( [ 1 .. size_j ], j ->
+                        List( [ 1 .. size_s ], s ->
+                            HomomorphismStructureOnObjectsExtendedByFullEmbedding( UnderlyingCategory( cat ), range_category, B[j], C[s] )
+                        )
+                    );
                 
-                size_j := Length( obj_list_B );
+                direct_sums := List( [ 1 .. size_j ], j -> DirectSum( range_category, List( [ 1 .. size_s ], s -> H_B_C[j][s] ) ) );
                 
-                summands := 
-                  Concatenation(
-                            List( obj_list_A, obj_i ->
-                                List( obj_list_B, obj_j -> HomomorphismStructureOnObjectsExtendedByFullEmbedding( UnderlyingCategory( cat ), range_category, obj_i, obj_j ) )
+                blocks := List( [ 1 .. size_j ], j ->
+                            ComponentOfMorphismIntoDirectSum( range_category,
+                              morphism,
+                              direct_sums,
+                              j
                             )
                           );
                 
-                listlist := List( [ 1 .. size_i ], i ->
-                            List( [ 1 .. size_j ], j ->
+                listlist := List( [ 1 .. size_j ], j ->
+                            List( [ 1 .. size_s ], s ->
                               ComponentOfMorphismIntoDirectSum( range_category,
-                                morphism,
-                                summands,
-                                size_j * (i - 1) + j
+                                blocks[j],
+                                H_B_C[j],
+                                s
                               )
                             )
                           );
                 
                 return AdditiveClosureMorphism( cat,
-                        A,
-                        List( [ 1 .. size_i ], i ->
-                          List( [ 1 .. size_j ], j ->
+                        B,
+                        List( [ 1 .. size_j ], j ->
+                          List( [ 1 .. size_s ], s ->
                             InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphismExtendedByFullEmbedding( UnderlyingCategory( cat ), range_category,
-                              obj_list_A[i],
-                              obj_list_B[j],
-                              listlist[i][j]
+                              B[j],
+                              C[s],
+                              listlist[j][s]
                             )
                           )
                         ),
-                        B
+                        C
                       );
                 
             end );

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -210,23 +210,24 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_2_1, hoisted_3_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_9_1 := UnderlyingRing( cat_1 );
-    deduped_8_1 := RankOfObject( source_1 );
-    deduped_7_1 := RankOfObject( range_1 );
-    hoisted_6_1 := [ 1 .. deduped_8_1 ];
+    local hoisted_1_1, hoisted_3_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := RankOfObject( source_1 );
+    deduped_8_1 := RankOfObject( range_1 );
+    deduped_7_1 := Length( EntriesOfHomalgColumnVector( deduped_11_1 ) );
+    hoisted_6_1 := [ 1 .. deduped_9_1 ];
     hoisted_3_1 := UnderlyingMatrix( alpha_1 );
-    deduped_2_1 := Length( EntriesOfHomalgColumnVector( deduped_10_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
-                local hoisted_1_2;
-                hoisted_1_2 := deduped_8_1 * (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) - 1);
-                return List( hoisted_6_1, function ( j_3 )
+    hoisted_1_1 := deduped_9_1 * deduped_7_1;
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_8_1 ], function ( j_2 )
+                local deduped_1_2;
+                deduped_1_2 := (CAP_JIT_INCOMPLETE_LOGIC( j_2 ) - 1) * hoisted_1_1;
+                return List( hoisted_6_1, function ( s_3 )
                         local deduped_1_3;
-                        deduped_1_3 := (hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1) * deduped_2_1;
-                        return EntriesOfHomalgMatrix( CoercedMatrix( deduped_9_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_2_1) ] ) ) ) * deduped_10_1 )[1];
+                        deduped_1_3 := (CAP_JIT_INCOMPLETE_LOGIC( s_3 ) - 1) * deduped_7_1;
+                        return EntriesOfHomalgMatrix( CoercedMatrix( deduped_10_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ (deduped_1_2 + (deduped_1_3 + 1)) .. (deduped_1_2 + (deduped_1_3 + deduped_7_1)) ] ) ) ) * deduped_11_1 )[1];
                     end );
-            end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );
+            end ), deduped_8_1, deduped_9_1, deduped_10_1 ) );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -210,23 +210,24 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_2_1, hoisted_3_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_9_1 := UnderlyingRing( cat_1 );
-    deduped_8_1 := RankOfObject( range_1 );
-    deduped_7_1 := RankOfObject( source_1 );
-    hoisted_6_1 := [ 1 .. deduped_8_1 ];
+    local hoisted_1_1, hoisted_3_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
+    deduped_10_1 := UnderlyingRing( cat_1 );
+    deduped_9_1 := RankOfObject( range_1 );
+    deduped_8_1 := RankOfObject( source_1 );
+    deduped_7_1 := Length( EntriesOfHomalgColumnVector( deduped_11_1 ) );
+    hoisted_6_1 := [ 1 .. deduped_9_1 ];
     hoisted_3_1 := UnderlyingMatrix( alpha_1 );
-    deduped_2_1 := Length( EntriesOfHomalgColumnVector( deduped_10_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_7_1 ], function ( i_2 )
-                local hoisted_1_2;
-                hoisted_1_2 := deduped_8_1 * (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) - 1);
-                return List( hoisted_6_1, function ( j_3 )
+    hoisted_1_1 := deduped_9_1 * deduped_7_1;
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, UnderlyingMatrix, HomalgMatrixListList( List( [ 1 .. deduped_8_1 ], function ( j_2 )
+                local deduped_1_2;
+                deduped_1_2 := (CAP_JIT_INCOMPLETE_LOGIC( j_2 ) - 1) * hoisted_1_1;
+                return List( hoisted_6_1, function ( s_3 )
                         local deduped_1_3;
-                        deduped_1_3 := (hoisted_1_2 + CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1) * deduped_2_1;
-                        return EntriesOfHomalgMatrix( CoercedMatrix( deduped_9_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_2_1) ] ) ) ) * deduped_10_1 )[1];
+                        deduped_1_3 := (CAP_JIT_INCOMPLETE_LOGIC( s_3 ) - 1) * deduped_7_1;
+                        return EntriesOfHomalgMatrix( CoercedMatrix( deduped_10_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_3_1, [ (deduped_1_2 + (deduped_1_3 + 1)) .. (deduped_1_2 + (deduped_1_3 + deduped_7_1)) ] ) ) ) * deduped_11_1 )[1];
                     end );
-            end ), deduped_7_1, deduped_8_1, deduped_9_1 ) );
+            end ), deduped_8_1, deduped_9_1, deduped_10_1 ) );
 end
 ########
         


### PR DESCRIPTION
If the range category is not strict, the parentheses in the direct sums are important.
This issue was discovered using CompilerForCAP as a proof assistant.

This is similar to https://github.com/homalg-project/CAP_project/pull/1522, but there only a wrong object was computed, while here `ComponentOfMorphismIntoDirectSum` was called with a potentially invalid input, resulting in undefined behaviour.

The diff looks larger than expected because I also made the notation consistent with `InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure`.