### PR TITLE
Improve various IsWellDefinedFor*

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-07",
+Version := "2023.12-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -581,7 +581,11 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         AddIsWellDefinedForObjects( category,
           function( cat, object )
             
-            if not ForAll( ObjectList( object ), obj -> IsIdenticalObj( UnderlyingCategory( cat ), CapCategory( obj ) ) and IsWellDefinedForObjects( UnderlyingCategory( cat ), obj ) ) then
+            if not IsList( ObjectList( object ) ) then
+                
+                return false;
+                
+            elif not ForAll( ObjectList( object ), obj -> IsWellDefinedForObjects( UnderlyingCategory( cat ), obj ) ) then
                 
                 return false;
                 
@@ -599,24 +603,31 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         ##
         AddIsWellDefinedForMorphisms( category,
           function( cat, morphism )
-            local nr_rows, nr_cols, source_list, range_list;
-            
-            nr_rows := Length( ObjectList( Source( morphism ) ) );
-            
-            nr_cols := Length( ObjectList( Range( morphism ) ) );
+            local source_list, range_list, nr_rows, nr_cols;
             
             source_list := ObjectList( Source( morphism ) );
-            
             range_list := ObjectList( Range( morphism ) );
             
-            if IsMatrixObj( MorphismMatrix( morphism ) ) and not ( nr_rows = NrRows( MorphismMatrix( morphism ) ) and nr_cols = NrCols( MorphismMatrix( morphism ) ) ) then
+            nr_rows := Length( source_list );
+            nr_cols := Length( range_list );
+            
+            # we currently allow m x 0 matrices to be encoded as empty lists
+            if nr_cols = 0 and MorphismMatrix( morphism ) = [ ] then
+                
+                return true;
+                
+            elif not (IsList( MorphismMatrix( morphism ) ) and Length( MorphismMatrix( morphism ) ) = nr_rows) then
+                
+                return false;
+                
+            elif not ForAll( [ 1 .. nr_rows ], i -> IsList( MorphismMatrix( morphism )[i] ) and Length( MorphismMatrix( morphism )[i] ) = nr_cols ) then
                 
                 return false;
                 
             elif not ForAll( [ 1 .. nr_rows ], i ->
                      ForAll( [ 1 .. nr_cols ], j ->
                        # is a well-defined CAP category morphism from `source_list[i]` to `range_list[j]` in the underlying category
-                       IsCapCategoryMorphism( morphism[i, j] ) and IsIdenticalObj( UnderlyingCategory( cat ), CapCategory( morphism[i, j] ) ) and IsWellDefinedForMorphismsWithGivenSourceAndRange( UnderlyingCategory( cat ), source_list[i], morphism[i, j], range_list[j] )
+                       IsWellDefinedForMorphismsWithGivenSourceAndRange( UnderlyingCategory( cat ), source_list[i], morphism[i, j], range_list[j] )
                      )
                    ) then
                 

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -312,10 +312,14 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
     AddIsWellDefinedForObjects( category,
       function( cat, object )
         
-        if RankOfObject( object ) < 0 then
-          
-          return false;
-          
+        if not IsInt( RankOfObject( object ) ) then
+            
+            return false;
+            
+        elif not (RankOfObject( object ) >= 0) then
+            
+            return false;
+            
         fi;
         
         # all tests passed, so it is well-defined
@@ -327,14 +331,18 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
     AddIsWellDefinedForMorphisms( category,
       function( cat, morphism )
         
-        if NrRows( UnderlyingMatrix( morphism ) ) <> RankOfObject( Source( morphism ) ) then
-          
-          return false;
-          
-        elif NrColumns( UnderlyingMatrix( morphism ) ) <> RankOfObject( Range( morphism ) ) then
-          
-          return false;
-          
+        if not IsHomalgMatrix( UnderlyingMatrix( morphism ) ) then
+            
+            return false;
+            
+        elif not (NrRows( UnderlyingMatrix( morphism ) ) = RankOfObject( Source( morphism ) )) then
+            
+            return false;
+            
+        elif not (NrColumns( UnderlyingMatrix( morphism ) ) = RankOfObject( Range( morphism ) )) then
+            
+            return false;
+            
         fi;
         
         # all tests passed, so it is well-defined

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -131,7 +131,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
     AddIsCongruentForMorphisms( category, equality_func );
     
     ##
-    AddIsWellDefinedForObjects( category, {cat, x} -> IsIdenticalObj( category, CapCategory( x ) ) );
+    AddIsWellDefinedForObjects( category, {cat, x} -> true );
     
     ##
     AddIsWellDefinedForMorphisms( category,

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfArbitraryRingPrecompiled.gi
@@ -211,9 +211,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -229,7 +231,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -402,9 +402,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -420,7 +422,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -503,9 +503,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -521,7 +523,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -295,9 +295,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -313,7 +315,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfArbitraryRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfArbitraryRingPrecompiled.gi
@@ -211,9 +211,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -229,7 +231,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfCommutativeRingPrecompiled.gi
@@ -402,9 +402,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -420,7 +422,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfFieldPrecompiled.gi
@@ -503,9 +503,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -521,7 +523,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfRowsAsAdditiveClosureOfRingAsCategoryOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -295,9 +295,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> RankOfObject( Source( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> RankOfObject( Range( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = RankOfObject( Source( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = RankOfObject( Range( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -313,7 +315,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if RankOfObject( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := RankOfObject( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2023.12-02",
+Version := "2023.12-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategoryPrecompiled.gi
@@ -2528,9 +2528,11 @@ end
 function ( cat_1, alpha_1 )
     local deduped_1_1;
     deduped_1_1 := UnderlyingMatrix( alpha_1 );
-    if NumberRows( deduped_1_1 ) <> Dimension( Source( alpha_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> Dimension( Range( alpha_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = Dimension( Source( alpha_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = Dimension( Range( alpha_1 ) ) then
         return false;
     else
         return true;
@@ -2551,9 +2553,11 @@ function ( cat_1, source_1, alpha_1, range_1 )
     deduped_2_1 := Dimension( Range( alpha_1 ) );
     deduped_1_1 := Dimension( Source( alpha_1 ) );
     return CAP_JIT_EXPR_CASE_WRAPPER( function (  )
-                  if NumberRows( deduped_3_1 ) <> deduped_1_1 then
+                  if not IsHomalgMatrix( deduped_3_1 ) then
                       return false;
-                  elif NumberColumns( deduped_3_1 ) <> deduped_2_1 then
+                  elif not NumberRows( deduped_3_1 ) = deduped_1_1 then
+                      return false;
+                  elif not NumberColumns( deduped_3_1 ) = deduped_2_1 then
                       return false;
                   else
                       return true;
@@ -2570,7 +2574,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if Dimension( arg2_1 ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := Dimension( arg2_1 );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -550,9 +550,11 @@ function ( cat_1, alpha_1 )
     local deduped_1_1, deduped_2_1;
     deduped_2_1 := Opposite( alpha_1 );
     deduped_1_1 := UnderlyingMatrix( deduped_2_1 );
-    if NumberRows( deduped_1_1 ) <> Dimension( Source( deduped_2_1 ) ) then
+    if not IsHomalgMatrix( deduped_1_1 ) then
         return false;
-    elif NumberColumns( deduped_1_1 ) <> Dimension( Range( deduped_2_1 ) ) then
+    elif not NumberRows( deduped_1_1 ) = Dimension( Source( deduped_2_1 ) ) then
+        return false;
+    elif not NumberColumns( deduped_1_1 ) = Dimension( Range( deduped_2_1 ) ) then
         return false;
     else
         return true;
@@ -568,7 +570,11 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    if Dimension( Opposite( arg2_1 ) ) < 0 then
+    local deduped_1_1;
+    deduped_1_1 := Dimension( Opposite( arg2_1 ) );
+    if not IsInt( deduped_1_1 ) then
+        return false;
+    elif not deduped_1_1 >= 0 then
         return false;
     else
         return true;


### PR DESCRIPTION
according to the following rules:
1. Always check the data type of the object/morphism datum.
2. Never check the data type of the object/morphism itself. This should be done generically.
3. Never check IsCapCategoryObject/Morphism or CapCategory of underlying objects/morphisms. This should be done generically via IsWellDefined* in the underlying category.

Regarding well-definedness of morphisms in CategoryOfRows and RingAsCategory: To handle this cleanly, we would need two new operations IsWellDefinedForMatrices and IsWellDefinedForRingElements.

I have developed these rules in the context of using CompilerForCAP as a proof assistant. We can of course discuss the rules, but for now at least we have some rules, while currently every package does something slightly different.