### PR TITLE
Make well-definedness of morphisms in AdditiveClosure more tight

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-09",
+Version := "2023.12-10",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -611,12 +611,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             nr_rows := Length( source_list );
             nr_cols := Length( range_list );
             
-            # we currently allow m x 0 matrices to be encoded as empty lists
-            if nr_cols = 0 and MorphismMatrix( morphism ) = [ ] then
-                
-                return true;
-                
-            elif not (IsList( MorphismMatrix( morphism ) ) and Length( MorphismMatrix( morphism ) ) = nr_rows) then
+            if not (IsList( MorphismMatrix( morphism ) ) and Length( MorphismMatrix( morphism ) ) = nr_rows) then
                 
                 return false;
                 


### PR DESCRIPTION
Currently, we allow to encode $m \times 0$ matrices as empty lists instead of  lists with $m$ empty lists. I suggest to drop this exception: I don't see why cleanly written code would give an empty matrix in the degenerate case. The only example I know of where this ever lead to a problem was in the context of `TransposedMat`, but we have `TransposedMatWithGivenDimensions` for this.

@mohamed-barakat @kamalsaleh Do you have any doubts about this?