### PR TITLE
Introduce IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.12-07",
+Version := "2023.12-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/OppositeCategory.g
+++ b/CAP/examples/OppositeCategory.g
@@ -8,15 +8,17 @@ QQ := HomalgFieldOfRationals();;
 vec := MatrixCategory( QQ );;
 op := Opposite( vec );;
 ListKnownCategoricalProperties( op );
-#! [ "IsAbCategory", "IsAbelianCategory", "IsAbelianCategoryWithEnoughInjectives",
-#!   "IsAbelianCategoryWithEnoughProjectives", "IsAdditiveCategory",
-#!   "IsBraidedMonoidalCategory", "IsClosedMonoidalCategory",
-#!   "IsCoclosedMonoidalCategory", "IsEnrichedOverCommutativeRegularSemigroup",
-#!   "IsEquippedWithHomomorphismStructure", "IsLinearCategoryOverCommutativeRing",
-#!   "IsMonoidalCategory", "IsPreAbelianCategory",
-#!   "IsRigidSymmetricClosedMonoidalCategory",
-#!   "IsRigidSymmetricCoclosedMonoidalCategory", "IsSkeletalCategory",
-#!   "IsStrictMonoidalCategory", "IsSymmetricClosedMonoidalCategory",
+#! [ "IsAbCategory", "IsAbelianCategory", "IsAbelianCategoryWithEnoughInjectives"
+#!     , "IsAbelianCategoryWithEnoughProjectives", "IsAdditiveCategory", 
+#!   "IsBraidedMonoidalCategory", "IsClosedMonoidalCategory", 
+#!   "IsCoclosedMonoidalCategory", "IsEnrichedOverCommutativeRegularSemigroup", 
+#!   "IsEquippedWithHomomorphismStructure", "IsLinearCategoryOverCommutativeRing"
+#!     , 
+#!   "IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms", 
+#!   "IsMonoidalCategory", "IsPreAbelianCategory", 
+#!   "IsRigidSymmetricClosedMonoidalCategory", 
+#!   "IsRigidSymmetricCoclosedMonoidalCategory", "IsSkeletalCategory", 
+#!   "IsStrictMonoidalCategory", "IsSymmetricClosedMonoidalCategory", 
 #!   "IsSymmetricCoclosedMonoidalCategory", "IsSymmetricMonoidalCategory" ]
 V1 := Opposite( TensorUnit( vec ) );;
 V2 := DirectSum( V1, V1 );;

--- a/CAP/examples/TerminalCategoryWithMultipleObjects.g
+++ b/CAP/examples/TerminalCategoryWithMultipleObjects.g
@@ -21,6 +21,7 @@ Display( T );
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! and furthermore mathematically
+#! * IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
 #! * IsTerminalCategory

--- a/CAP/examples/TerminalCategoryWithSingleObject.g
+++ b/CAP/examples/TerminalCategoryWithSingleObject.g
@@ -21,6 +21,7 @@ Display( T );
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! and furthermore mathematically
+#! * IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
 #! * IsSkeletalCategory

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -216,6 +216,14 @@ DeclareProperty( "IsLinearCategoryOverCommutativeRing", IsCapCategory );
 AddCategoricalProperty( [ "IsLinearCategoryOverCommutativeRing", "IsLinearCategoryOverCommutativeRing" ] );
 
 #! @Description
+#!  The property of the category <A>C</A> being linear over a commutative ring $k$
+#!  such that all external homs are finitely generated free $k$-modules.
+#! @Arguments C
+DeclareProperty( "IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms", IsCapCategory );
+
+AddCategoricalProperty( [ "IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms", "IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms" ] );
+
+#! @Description
 #!  The property of the category <A>C</A> being additive.
 #! @Arguments C
 DeclareProperty( "IsAdditiveCategory", IsCapCategory );

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -29,6 +29,8 @@ InstallTrueMethod( IsEnrichedOverCommutativeRegularSemigroup, IsAbCategory );
 
 InstallTrueMethod( IsAbCategory, IsLinearCategoryOverCommutativeRing );
 
+InstallTrueMethod( IsLinearCategoryOverCommutativeRing, IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms );
+
 InstallTrueMethod( IsAbCategory, IsAdditiveCategory );
 
 InstallTrueMethod( IsAdditiveCategory, IsPreAbelianCategory );

--- a/CAP/gap/ConstructiveCategoriesRecord.gi
+++ b/CAP/gap/ConstructiveCategoriesRecord.gi
@@ -65,6 +65,14 @@ CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsLinearCategoryOverCommutativeRing 
     ]
 );
 
+CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsLinearCategoryOverCommutativeRingWithFiniteFreeHomSpaces := Concatenation(
+    CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsLinearCategoryOverCommutativeRing,
+    [
+        "BasisOfExternalHom",
+        "CoefficientsOfMorphism",
+    ]
+);
+
 CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsAdditiveCategory := Concatenation(
     CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsAbCategory,
     [

--- a/CAP/gap/DerivedMethods.gi
+++ b/CAP/gap/DerivedMethods.gi
@@ -3351,7 +3351,7 @@ AddFinalDerivationBundle( "Adding BasisOfExternalHom and CoefficientsOfMorphism 
     function( cat )
       local range_cat, required_methods;
       
-      if not ( HasIsLinearCategoryOverCommutativeRing( cat ) and IsLinearCategoryOverCommutativeRing( cat ) ) then
+      if not ( HasIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( cat ) and IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( cat ) ) then
         
         return false;
         
@@ -3371,7 +3371,7 @@ AddFinalDerivationBundle( "Adding BasisOfExternalHom and CoefficientsOfMorphism 
         
       fi;
       
-      if not ( HasIsLinearCategoryOverCommutativeRing( range_cat ) and IsLinearCategoryOverCommutativeRing( range_cat ) ) then
+      if not ( HasIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( range_cat ) and IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( range_cat ) ) then
         
         return false;
         

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2023.12-11",
+Version := "2023.12-12",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -111,13 +111,23 @@ InstallMethod( ADDITIVE_CLOSURE,
     
     SetUnderlyingCategory( category, underlying_category );
     
-    if HasIsLinearCategoryOverCommutativeRing( underlying_category ) and
+    if HasIsLinearCategoryOverCommutativeRing( underlying_category ) and IsLinearCategoryOverCommutativeRing( underlying_category ) and
         HasCommutativeRingOfLinearCategory( underlying_category ) then
         
         SetIsLinearCategoryOverCommutativeRing( category, true );
         
         SetCommutativeRingOfLinearCategory( category, CommutativeRingOfLinearCategory( underlying_category ) );
-    
+        
+        if HasIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( underlying_category ) and
+           IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( underlying_category ) then
+            
+            SetIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( category, true );
+            
+            # BasisOfExternalHom and CoefficientsOfMorphism can possibly be derived from the hom structure
+            # see https://github.com/homalg-project/CAP_project/pull/652 for a primitive implementation
+            
+        fi;
+        
     fi;
     
     INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE( category );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -931,7 +931,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS,
     
     if HasIsCommutative( ring ) and IsCommutative( ring ) then
         
-        Assert( 0, IsLinearCategoryOverCommutativeRing( category ) );
+        Assert( 0, IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( category ) );
         
         Assert( 0, IsIdenticalObj( CommutativeRingOfLinearCategory( category ), ring ) );
         
@@ -1447,7 +1447,7 @@ AddFinalDerivationBundle( "Using BasisOfExternalHom and CoefficientsOfMorphism t
          (HasIsEquippedWithHomomorphismStructure and IsEquippedWithHomomorphismStructure)( cat ) and
          HasRangeCategoryOfHomomorphismStructure( cat ) and
          IsCategoryOfRows( RangeCategoryOfHomomorphismStructure( cat ) ) and
-         HasIsLinearCategoryOverCommutativeRing( cat ) and IsLinearCategoryOverCommutativeRing( cat ) and
+         HasIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( cat ) and IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( cat ) and
          HasCommutativeRingOfLinearCategory( cat ) and IsHomalgRing( CommutativeRingOfLinearCategory( cat ) ) then
           
           return true;

--- a/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
+++ b/FreydCategoriesForCAP/gap/RingsAsAbCats.gi
@@ -214,7 +214,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
     
     if HasIsCommutative( ring ) and IsCommutative( ring ) then
         
-        SetIsLinearCategoryOverCommutativeRing( category, true );
+        SetIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( category, true );
         
         SetCommutativeRingOfLinearCategory( category, ring );
         
@@ -300,7 +300,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_RING_AS_CATEGORY,
         
         field := BaseRing( ring );
         
-        SetIsLinearCategoryOverCommutativeRing( category, true );
+        SetIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( category, true );
         
         SetCommutativeRingOfLinearCategory( category, field );
         

--- a/FreydCategoriesForCAP/tst/add_hom_structure_using_external_hom.tst
+++ b/FreydCategoriesForCAP/tst/add_hom_structure_using_external_hom.tst
@@ -8,7 +8,7 @@ gap> dummy := DummyCategory( rec(
 >                    "IsCongruentForMorphisms",
 >                    "PreComposeList",
 >                    "SumOfMorphisms" ],
->                properties := [ "IsLinearCategoryOverCommutativeRing" ] ) : FinalizeCategory := false );;
+>                properties := [ "IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms" ] ) : FinalizeCategory := false );;
 gap> field := HomalgFieldOfRationals( );
 Q
 gap> SetCommutativeRingOfLinearCategory( dummy, field );

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2023.12-03",
+Version := "2023.12-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
+++ b/LinearAlgebraForCAP/gap/LinearAlgebraForCAP.gi
@@ -64,7 +64,7 @@ InstallGlobalFunction( MATRIX_CATEGORY,
     
     SetIsStrictMonoidalCategory( category, true );
     
-    SetIsLinearCategoryOverCommutativeRing( category, true );
+    SetIsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( category, true );
     
     SetCommutativeRingOfLinearCategory( category, homalg_field );
     


### PR DESCRIPTION
I would like to introduce a property for categories having `BasisOfExternalHom` and `CoefficientsOfExternalHom`. My first suggestion is
```
IsLinearCategoryOverCommutativeRingWithFiniteFreeHomSpaces
```
There are various possible alternatives:
* `...WithFinitelyGeneratedFree...`: is a bit longer but more precise
* `...HomSets`: to avoid a connection to vector spaces
* `...ExternalHoms`: matches `BasisOfExternalHom`

I don't have a strong preference. @mohamed-barakat @kamalsaleh What would be your preference?