### PR TITLE
Do not pass type signature as an option to ENHANCED_SYNTAX_TREE

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2023.12-12",
+Version := "2023.12-13",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/CompilerForCAP.gi
+++ b/CompilerForCAP/gap/CompilerForCAP.gi
@@ -179,7 +179,7 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
                 
             else
                 
-                type_signature := [ arguments_data_types, return_data_type ];
+                type_signature := Pair( arguments_data_types, return_data_type );
                 
             fi;
             
@@ -199,11 +199,22 @@ InstallGlobalFunction( CapJitCompiledFunctionAsEnhancedSyntaxTree, function ( fu
     
     if category_as_first_argument then
         
-        tree := ENHANCED_SYNTAX_TREE( func : globalize_hvars := true, given_arguments := [ category ], type_signature := type_signature );
+        tree := ENHANCED_SYNTAX_TREE( func : globalize_hvars := true, given_arguments := [ category ] );
         
     else
         
-        tree := ENHANCED_SYNTAX_TREE( func : globalize_hvars := true, type_signature := type_signature );
+        tree := ENHANCED_SYNTAX_TREE( func : globalize_hvars := true );
+        
+    fi;
+    
+    if type_signature <> fail then
+        
+        Assert( 0, IsList( type_signature ) and Length( type_signature ) = 2 and IsList( type_signature[1] ) and Length( type_signature[1] ) = tree.narg and (type_signature[2] = fail or IsRecord( type_signature[2] )) );
+        
+        tree.data_type := rec(
+            filter := IsFunction,
+            signature := type_signature
+        );
         
     fi;
     

--- a/CompilerForCAP/gap/EnhancedSyntaxTree.gi
+++ b/CompilerForCAP/gap/EnhancedSyntaxTree.gi
@@ -41,7 +41,7 @@ BindGlobal( "CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS", rec(
 Assert( 0, Length( RecNames( CAP_JIT_INTERNAL_SYNTAX_TREE_TO_OPERATION_TRANSLATIONS ) ) = Length( RecNames( CAP_JIT_INTERNAL_OPERATION_TO_SYNTAX_TREE_TRANSLATIONS ) ) );
 
 InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
-  local WarnWithFuncLocation, ErrorWithFuncLocation, globalize_hvars, only_if_CAP_JIT_RESOLVE_FUNCTION, given_arguments, type_signature, remove_depth_numbering, tree, orig_tree, pre_func, result_func, additional_arguments_func;
+  local WarnWithFuncLocation, ErrorWithFuncLocation, globalize_hvars, only_if_CAP_JIT_RESOLVE_FUNCTION, given_arguments, remove_depth_numbering, tree, orig_tree, pre_func, result_func, additional_arguments_func;
     
     WarnWithFuncLocation := function ( args... )
         
@@ -874,25 +874,6 @@ InstallGlobalFunction( ENHANCED_SYNTAX_TREE, function ( func )
     end;
     
     tree := CapJitIterateOverTree( tree, pre_func, result_func, additional_arguments_func, [ [ ], [ ] ] );
-    
-    type_signature := ValueOption( "type_signature" );
-    
-    if type_signature = fail then
-        
-        #Error( "you must provide a type signature" );
-        
-    else
-        
-        if not IsList( type_signature ) or Length( type_signature ) <> 2 or not IsList( type_signature[1] ) or Length( type_signature[1] ) <> NumberArgumentsFunction( func ) then
-            
-            # COVERAGE_IGNORE_NEXT_LINE
-            Error( "the option \"type_signature\" must be a pair with a list of length equal to the number of function arguments as the first entry" );
-            
-        fi;
-        
-        tree.data_type := rec( filter := IsFunction, signature := type_signature );
-        
-    fi;
     
     return tree;
     

--- a/CompilerForCAP/tst/ENHANCED_SYNTAX_TREE.tst
+++ b/CompilerForCAP/tst/ENHANCED_SYNTAX_TREE.tst
@@ -277,7 +277,8 @@ true
 
 # test CAP_JIT_INTERNAL_EXPR_CASE
 gap> func := { } -> CAP_JIT_INTERNAL_EXPR_CASE( 1 <> 1, 1, true, 2 );;
-gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := [ [ ], rec( filter := IsInt ) ] );;
+gap> tree := ENHANCED_SYNTAX_TREE( func );;
+gap> tree.data_type := rec( filter := IsFunction, signature := Pair( [ ], rec( filter := IsInt ) ) );;
 gap> CapJitPrettyPrintSyntaxTree( tree );
 rec(
   0_type := "EXPR_DECLARATIVE_FUNC",

--- a/CompilerForCAP/tst/Logic.tst
+++ b/CompilerForCAP/tst/Logic.tst
@@ -205,7 +205,8 @@ end
 gap> func := { } -> Concatenation( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( CapJitDataTypeOfListOf( IsInt ) ) ) );;
 
 #
-gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
+gap> tree := ENHANCED_SYNTAX_TREE( func );;
+gap> tree.data_type := rec( filter := IsFunction, signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
 gap> tree := CapJitInferredDataTypes( tree );;
 gap> tree := CapJitAppliedLogic( tree );;
 gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
@@ -217,7 +218,8 @@ end
 gap> func := { } -> Concatenation( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ), CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ) );;
 
 #
-gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
+gap> tree := ENHANCED_SYNTAX_TREE( func );;
+gap> tree.data_type := rec( filter := IsFunction, signature := Pair( [ ], CapJitDataTypeOfListOf( IsInt ) ) );;
 gap> tree := CapJitInferredDataTypes( tree );;
 gap> tree := CapJitAppliedLogic( tree );;
 gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );
@@ -229,7 +231,8 @@ end
 gap> func := { } -> List( CapJitTypedExpression( [ ], { } -> CapJitDataTypeOfListOf( IsInt ) ), x -> [ x ] );;
 
 #
-gap> tree := ENHANCED_SYNTAX_TREE( func : type_signature := Pair( [ ], CapJitDataTypeOfListOf( CapJitDataTypeOfListOf( IsInt ) ) ) );;
+gap> tree := ENHANCED_SYNTAX_TREE( func );;
+gap> tree.data_type := rec( filter := IsFunction, signature := Pair( [ ], CapJitDataTypeOfListOf( CapJitDataTypeOfListOf( IsInt ) ) ) );;
 gap> tree := CapJitInferredDataTypes( tree );;
 gap> tree := CapJitAppliedLogic( tree );;
 gap> Display( ENHANCED_SYNTAX_TREE_CODE( tree ) );

--- a/CompilerForCAP/tst/LogicTemplates.tst
+++ b/CompilerForCAP/tst/LogicTemplates.tst
@@ -35,19 +35,27 @@ gap> IsIdenticalObj( Remove( CAP_JIT_LOGIC_TEMPLATES ), template1 );
 true
 
 #
-gap> applied_logic_template_to_func :=
->     { func, template, type_signature } ->
->         ENHANCED_SYNTAX_TREE_CODE(
->             CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATES(
->                 CapJitInferredDataTypes(
->                     ENHANCED_SYNTAX_TREE(
->                         func :
->                         type_signature := type_signature
->                     )
->                 ),
->                 [ template ]
->             )
->         );;
+gap> applied_logic_template_to_func := function ( func, template, type_signature )
+>   local tree;
+>   
+>   tree := ENHANCED_SYNTAX_TREE( func );
+>   
+>   if type_signature <> fail then
+>       
+>       tree.data_type := rec(
+>           filter := IsFunction,
+>           signature := type_signature
+>       );
+>       
+>   fi;
+>   
+>   tree := CapJitInferredDataTypes( tree );
+>   
+>   tree := CAP_JIT_INTERNAL_APPLIED_LOGIC_TEMPLATES( tree, [ template ] );
+>   
+>   return ENHANCED_SYNTAX_TREE_CODE( tree );
+>   
+> end;;
 
 # some general example
 gap> template := rec(


### PR DESCRIPTION
ENHANCED_SYNTAX_TREE does not deal with the type signature in any way except attaching it to the tree. Doing this outside of ENHANCED_SYNTAX_TREE is more explicit.
