### PR TITLE
renamed CheckConstructivenessOfCategory -> MissingOperationsForConstructivenessOfCategory

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2023.12-10",
+Version := "2023.12-11",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gd
+++ b/CAP/gap/CAP.gd
@@ -577,7 +577,7 @@ DeclareOperation( "CanCompute",
 #! If $s$ is not a categorical property, an error is raised.
 #! @Returns a list
 #! @Arguments C,s
-DeclareOperation( "CheckConstructivenessOfCategory",
+DeclareOperation( "MissingOperationsForConstructivenessOfCategory",
                   [ IsCapCategory, IsString ] );
 
 #############################################

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -582,7 +582,7 @@ InstallMethod( CanCompute,
 end );
 
 ##
-InstallMethod( CheckConstructivenessOfCategory,
+InstallMethod( MissingOperationsForConstructivenessOfCategory,
                [ IsCapCategory, IsString ],
                
   function( category, string )
@@ -609,6 +609,8 @@ InstallMethod( CheckConstructivenessOfCategory,
     return result_list;
     
 end );
+
+InstallDeprecatedAlias( "CheckConstructivenessOfCategory", "MissingOperationsForConstructivenessOfCategory", "2024.12.18" );
 
 ####################################
 ##

--- a/CAP/gap/PrintingFunctions.gi
+++ b/CAP/gap/PrintingFunctions.gi
@@ -40,7 +40,7 @@ InstallGlobalFunction( InfoStringOfInstalledOperationsOfCategory,
     
     list_of_algorithmic_and_not_yet_algorithmic_properties := Intersection( list_of_mathematical_properties, list_of_potential_algorithmic_properties );
     
-    list_of_algorithmic_properties := Filtered( list_of_algorithmic_and_not_yet_algorithmic_properties, p -> IsEmpty( CheckConstructivenessOfCategory( category, p ) ) );
+    list_of_algorithmic_properties := Filtered( list_of_algorithmic_and_not_yet_algorithmic_properties, p -> IsEmpty( MissingOperationsForConstructivenessOfCategory( category, p ) ) );
     
     list_of_maximal_algorithmic_properties := MaximalPropertiesWithRegardToImplication( list_of_algorithmic_properties );
     

--- a/CAP/help_for_CAP.md
+++ b/CAP/help_for_CAP.md
@@ -3,7 +3,7 @@
 * CanCompute( category, string )
   Returns true if the operation with name <string> is computable in <category>.
 
-* CheckConstructivenessOfCategory( category, string )
+* MissingOperationsForConstructivenessOfCategory( category, string )
   Returns a list of names of basic operations which are not computable in <category> but
   needed to have the categorical property <string> completely constructive.
 


### PR DESCRIPTION
as a more suggestive name for CheckConstructivenessOfCategory
