### PR TITLE
terminal category constructor now ignores operations returning list_of_objects

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.01-06",
+Version := "2024.02-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -54,7 +54,12 @@ InstallGlobalFunction( CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY,
         if info.return_type = "bool" then
             Add( skip, operation_name );
         fi;
-      
+        
+        # Do not install operations returning a list of objects since the length of the list is unknown to us
+        if info.return_type = "list_of_objects" then
+            Add( skip, operation_name );
+        fi;
+        
     od;
     
     list_of_operations_to_install := Difference( list_of_operations_to_install, skip );


### PR DESCRIPTION
since the length of the list is not known apriori
