### PR TITLE
Defer installation of derivations to `Finalize`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.02-04",
+Version := "2024.02-05",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -478,11 +478,9 @@ BindGlobal( "TryToInstallDerivation", function ( owl, d )
 
     if new_weight < current_weight or (new_weight = current_weight and current_derivation <> fail and new_pos < current_pos) then
         
-        if not IsIdenticalObj( current_derivation, d ) then
-            
-            InstallDerivationForCategory( d, new_weight, CategoryOfOperationWeightList( owl ) );
-            
-        fi;
+        # Previously, `InstallDerivationForCategory` was called at this point.
+        # However, this could lead to methods being overwritten if cheaper derivations become available while adding primitive installations to a category.
+        # Hence, we now install the derivations in `Finalize`.
         
         owl!.operation_weights.( target ) := new_weight;
         owl!.operation_derivations.( target ) := d;

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -302,7 +302,7 @@ InstallMethod( Finalize,
     [ "FinalizeCategory", true ],
   ],
   function( CAP_NAMED_ARGUMENTS, category )
-    local derivation_list, weight_list, current_install, current_final_derivation, weight, old_weights, categorical_properties, diff, properties_with_logic, property, i, derivation, property_name;
+    local derivation_list, weight_list, current_install, current_final_derivation, weight, old_weights, categorical_properties, diff, properties_with_logic, property, i, derivation, operation, property_name;
     
     if IsFinalized( category ) then
         
@@ -461,6 +461,17 @@ InstallMethod( Finalize,
         fi;
         
     fi;
+    
+    # actually install normal derivations
+    for operation in Operations( DerivationGraph( weight_list ) ) do
+        
+        if DerivationOfOperation( weight_list, operation ) <> fail then
+            
+            InstallDerivationForCategory( DerivationOfOperation( weight_list, operation ), CurrentOperationWeight( weight_list, operation ), category );
+            
+        fi;
+        
+    od;
     
     SetIsFinalized( category, true );
     


### PR DESCRIPTION
This avoids overwriting GAP methods if cheaper derivations become available while adding primitive installations to a category. The only difference to the previous behavior should be that derivations cannot be called anymore before a category is finalized.

@mohamed-barakat @sebastianpos I think derivations were previously installed immediately for didactical purposes. However, this causes issues in Julia, where methods may not be overwritten during precompilation. I do not think the original purpose is too important anymore, so I will merge if you do not oppose :-)