### PR TITLE
Only load FreydCategoriesForCAP when testing without precompiled code

### DIFF
--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2024.04-01",
+Version := "2024.04-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/tst/200_FreydCategoriesForCAP.tst
+++ b/LinearAlgebraForCAP/tst/200_FreydCategoriesForCAP.tst
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # LinearAlgebraForCAP: Category of Matrices over a Field for CAP
 #
-# This file tests if the package can be loaded without errors or warnings.
-#
-# do not load suggested dependencies automatically
+# tests without precompiled code need FreydCategoriesForCAP
+#@if ValueOption( "no_precompiled_code" ) = true
 gap> PushOptions( rec( OnlyNeeded := true ) );
 gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
-gap> LoadPackage( "LinearAlgebraForCAP", false );
+gap> LoadPackage( "FreydCategoriesForCAP", false );
 true
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
-gap> LoadPackage( "LinearAlgebraForCAP" );
+gap> LoadPackage( "FreydCategoriesForCAP" );
 true
 gap> SetInfoLevel( InfoPackageLoading, package_loading_info_level );;
+#@fi


### PR DESCRIPTION
FreydCategoriesForCAP is not deposited, so it cannot be loaded in GAP's CI.