### PR TITLE
Restore the previous behavior of only_primitive_operations for Opposite

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.07-03",
+Version := "2024.07-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/OppositeCategory.gi
+++ b/CAP/gap/OppositeCategory.gi
@@ -83,8 +83,8 @@ end );
 
 BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
   
-  function( opposite_category, category, only_primitive_operations )
-    local recnames, list_of_underlying_operations,
+  function( opposite_category, category, only_primitive_operations, only_primitive_operations_and_hom_structure )
+    local recnames, list_of_underlying_operations, operations_of_homomorphism_structure,
           installed_operations_of_homomorphism_structure_and_external_hom, H,
           current_recname, current_entry, dual_operation_name, filter_list, input_arguments_names, return_type, func_string,
           preprocessor_string, dual_arguments, tmp,
@@ -119,39 +119,59 @@ BindGlobal( "CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY",
                           "VerticalPostCompose",
                           "IdenticalTwoCell" ] );
     
-    if only_primitive_operations then
+    if only_primitive_operations or only_primitive_operations_and_hom_structure then
         list_of_underlying_operations := ListPrimitivelyInstalledOperationsOfCategory( category );
     else
         list_of_underlying_operations := ListInstalledOperationsOfCategory( category );
     fi;
     
-    installed_operations_of_homomorphism_structure_and_external_hom :=
-      Intersection( ListInstalledOperationsOfCategory( category ),
-              [ "DistinguishedObjectOfHomomorphismStructure",
-                "HomomorphismStructureOnObjects",
-                "HomomorphismStructureOnMorphisms",
-                "HomomorphismStructureOnMorphismsWithGivenObjects",
-                "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure",
-                "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
-                "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
-                "MorphismsOfExternalHom",
-                "BasisOfExternalHom",
-                "CoefficientsOfMorphism",
-                ] );
+    operations_of_homomorphism_structure :=
+      [ "DistinguishedObjectOfHomomorphismStructure",
+        "HomomorphismStructureOnObjects",
+        "HomomorphismStructureOnMorphisms",
+        "HomomorphismStructureOnMorphismsWithGivenObjects",
+        "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure",
+        "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
+        "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
+        ];
     
-    ## the opposite category has the same enrichment as the original category:
-    if HasRangeCategoryOfHomomorphismStructure( category ) then
+    if not IsEmpty( Intersection( list_of_underlying_operations, operations_of_homomorphism_structure ) ) then
         
-        H := RangeCategoryOfHomomorphismStructure( category );
+        SetRangeCategoryOfHomomorphismStructure( opposite_category, RangeCategoryOfHomomorphismStructure( category ) );
         
-        SetRangeCategoryOfHomomorphismStructure( opposite_category, H );
+    fi;
+    
+    if only_primitive_operations_and_hom_structure then
         
-        ## be sure the above assignment succeeded:
-        Assert( 0, IsIdenticalObj( H, RangeCategoryOfHomomorphismStructure( opposite_category ) ) );
+        installed_operations_of_homomorphism_structure_and_external_hom :=
+          Intersection( ListInstalledOperationsOfCategory( category ),
+                  [ "DistinguishedObjectOfHomomorphismStructure",
+                    "HomomorphismStructureOnObjects",
+                    "HomomorphismStructureOnMorphisms",
+                    "HomomorphismStructureOnMorphismsWithGivenObjects",
+                    "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure",
+                    "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects",
+                    "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
+                    "MorphismsOfExternalHom",
+                    "BasisOfExternalHom",
+                    "CoefficientsOfMorphism",
+                    ] );
         
-        list_of_underlying_operations := Concatenation( list_of_underlying_operations, installed_operations_of_homomorphism_structure_and_external_hom );
-        
-        list_of_underlying_operations := Set( list_of_underlying_operations );
+        ## the opposite category has the same enrichment as the original category:
+        if HasRangeCategoryOfHomomorphismStructure( category ) then
+            
+            H := RangeCategoryOfHomomorphismStructure( category );
+            
+            SetRangeCategoryOfHomomorphismStructure( opposite_category, H );
+            
+            ## be sure the above assignment succeeded:
+            Assert( 0, IsIdenticalObj( H, RangeCategoryOfHomomorphismStructure( opposite_category ) ) );
+            
+            list_of_underlying_operations := Concatenation( list_of_underlying_operations, installed_operations_of_homomorphism_structure_and_external_hom );
+            
+            list_of_underlying_operations := Set( list_of_underlying_operations );
+            
+        fi;
         
     fi;
     
@@ -389,6 +409,7 @@ InstallMethod( Opposite,
  FunctionWithNamedArguments(
   [
     [ "only_primitive_operations", false ],
+    [ "only_primitive_operations_and_hom_structure", false ],
   ],
   function( CAP_NAMED_ARGUMENTS, category, name )
     local opposite_category, known_properties, opposite_property_pairs, pair;
@@ -553,7 +574,7 @@ InstallMethod( Opposite,
         
     end );
     
-    CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY( opposite_category, category, CAP_NAMED_ARGUMENTS.only_primitive_operations );
+    CAP_INTERNAL_INSTALL_OPPOSITE_ADDS_FROM_CATEGORY( opposite_category, category, CAP_NAMED_ARGUMENTS.only_primitive_operations, CAP_NAMED_ARGUMENTS.only_primitive_operations_and_hom_structure );
     
     Finalize( opposite_category );
     

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2024.07-02",
+Version := "2024.07-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfCommutativeRingPrecompiled.gi
@@ -258,20 +258,6 @@ end
     , 100 );
     
     ##
-    AddHomomorphismStructureOnMorphisms( cat,
-        
-########
-function ( cat_1, alpha_1, beta_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := KroneckerMat( TransposedMatrix( UnderlyingMatrix( beta_1 ) ), UnderlyingMatrix( alpha_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberRows( morphism_attr_1_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
-end
-########
-        
-    , 100 );
-    
-    ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
         
 ########
@@ -327,20 +313,6 @@ function ( cat_1, objects_1, k_1, P_1 )
     deduped_2_1 := List( objects_1, RankOfObject );
     deduped_1_1 := deduped_2_1[k_1];
     return CreateCapCategoryMorphismWithAttributes( cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( deduped_2_1{[ 1 .. k_1 - 1 ]} ), deduped_1_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_3_1 ), HomalgZeroMatrix( Sum( deduped_2_1{[ k_1 + 1 .. Length( objects_1 ) ]} ), deduped_1_1, deduped_3_1 ) ) );
-end
-########
-        
-    , 100 );
-    
-    ##
-    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
-        
-########
-function ( cat_1, alpha_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := ConvertMatrixToRow( UnderlyingMatrix( alpha_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfFieldPrecompiled.gi
@@ -315,20 +315,6 @@ end
     , 100 );
     
     ##
-    AddHomomorphismStructureOnMorphisms( cat,
-        
-########
-function ( cat_1, alpha_1, beta_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := KroneckerMat( TransposedMatrix( UnderlyingMatrix( beta_1 ) ), UnderlyingMatrix( alpha_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberRows( morphism_attr_1_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
-end
-########
-        
-    , 100 );
-    
-    ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
         
 ########
@@ -406,20 +392,6 @@ function ( cat_1, objects_1, k_1, P_1 )
     deduped_2_1 := List( objects_1, RankOfObject );
     deduped_1_1 := deduped_2_1[k_1];
     return CreateCapCategoryMorphismWithAttributes( cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( deduped_2_1{[ 1 .. k_1 - 1 ]} ), deduped_1_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_3_1 ), HomalgZeroMatrix( Sum( deduped_2_1{[ k_1 + 1 .. Length( objects_1 ) ]} ), deduped_1_1, deduped_3_1 ) ) );
-end
-########
-        
-    , 100 );
-    
-    ##
-    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
-        
-########
-function ( cat_1, alpha_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := ConvertMatrixToRow( UnderlyingMatrix( alpha_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumnsAsOppositeOfCategoryOfRowsOfHomalgExteriorRingOverFieldPrecompiled.gi
@@ -39,54 +39,6 @@ end
     , 100 );
     
     ##
-    AddBasisOfExternalHom( cat,
-        
-########
-function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, deduped_5_1, hoisted_7_1, hoisted_8_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1;
-    deduped_16_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_15_1 := RankOfObject( arg2_1 );
-    deduped_14_1 := RankOfObject( arg3_1 );
-    deduped_13_1 := Length( EntriesOfHomalgColumnVector( deduped_16_1 ) );
-    deduped_12_1 := deduped_15_1 * deduped_13_1;
-    deduped_11_1 := deduped_14_1 * deduped_12_1;
-    hoisted_8_1 := [ 1 .. deduped_14_1 ];
-    hoisted_7_1 := [ 1 .. deduped_15_1 ];
-    deduped_5_1 := UnderlyingRing( cat_1 );
-    hoisted_1_1 := HomalgIdentityMatrix( deduped_11_1, CommutativeRingOfLinearCategory( cat_1 ) );
-    return List( [ 1 .. deduped_11_1 ], function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := ConvertRowToMatrix( CertainRows( hoisted_1_1, [ i_2 ] ), 1, deduped_11_1 );
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, UnderlyingMatrix, HomalgMatrixListList( List( hoisted_8_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := (CAP_JIT_INCOMPLETE_LOGIC( j_3 ) - 1) * deduped_12_1;
-                        return List( hoisted_7_1, function ( s_4 )
-                                local deduped_1_4;
-                                deduped_1_4 := (CAP_JIT_INCOMPLETE_LOGIC( s_4 ) - 1) * deduped_13_1;
-                                return EntriesOfHomalgMatrix( CoercedMatrix( deduped_5_1, CAP_JIT_INCOMPLETE_LOGIC( CertainColumns( hoisted_1_2, [ (deduped_1_3 + (deduped_1_4 + 1)) .. (deduped_1_3 + (deduped_1_4 + deduped_13_1)) ] ) ) ) * deduped_16_1 )[1];
-                            end );
-                    end ), deduped_14_1, deduped_15_1, deduped_5_1 ) );
-        end );
-end
-########
-        
-    , 100 );
-    
-    ##
-    AddCoefficientsOfMorphism( cat,
-        
-########
-function ( cat_1, arg2_1 )
-    local deduped_1_1, deduped_2_1;
-    deduped_2_1 := UnderlyingMatrix( arg2_1 );
-    deduped_1_1 := UnderlyingRing( cat_1 );
-    return EntriesOfHomalgMatrix( CoercedMatrix( deduped_1_1, CommutativeRingOfLinearCategory( cat_1 ), CoefficientsWithGivenMonomials( ConvertMatrixToRow( deduped_2_1 ), DiagMat( deduped_1_1, ListWithIdenticalEntries( NumberRows( deduped_2_1 ), DiagMat( deduped_1_1, ListWithIdenticalEntries( NumberColumns( deduped_2_1 ), BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) ) ) ) ) ) );
-end
-########
-        
-    , 100 );
-    
-    ##
     AddColift( cat,
         
 ########
@@ -170,26 +122,6 @@ end
     , 100 );
     
     ##
-    AddHomomorphismStructureOnMorphisms( cat,
-        
-########
-function ( cat_1, alpha_1, beta_1 )
-    local morphism_attr_1_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
-    deduped_7_1 := UnderlyingMatrix( alpha_1 );
-    deduped_6_1 := BasisOfRingOverBaseFieldAsColumnVector( cat_1 );
-    deduped_5_1 := UnderlyingMatrix( beta_1 );
-    deduped_4_1 := UnderlyingRing( cat_1 );
-    deduped_3_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := CoercedMatrix( deduped_4_1, CommutativeRingOfLinearCategory( cat_1 ), CoefficientsWithGivenMonomials( KroneckerMat( TransposedMatrix( deduped_5_1 ), DualKroneckerMat( UnionOfRows( deduped_4_1, NumberColumns( deduped_6_1 ), List( EntriesOfHomalgColumnVector( deduped_6_1 ), function ( x_2 )
-                      return COMPILATION_HELPER_HomalgMatrixFromRingElement( x_2, deduped_4_1 );
-                  end ) ), deduped_7_1 ) ), DiagMat( deduped_4_1, ListWithIdenticalEntries( NumberRows( deduped_5_1 ), DiagMat( deduped_4_1, ListWithIdenticalEntries( NumberColumns( deduped_7_1 ), deduped_6_1 ) ) ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_3_1, CreateCapCategoryObjectWithAttributes( deduped_3_1, RankOfObject, NumberRows( morphism_attr_1_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_3_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
-end
-########
-        
-    , 100 );
-    
-    ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
         
 ########
@@ -252,22 +184,6 @@ function ( cat_1, objects_1, k_1, P_1 )
     deduped_2_1 := List( objects_1, RankOfObject );
     deduped_1_1 := deduped_2_1[k_1];
     return CreateCapCategoryMorphismWithAttributes( cat_1, objects_1[k_1], P_1, UnderlyingMatrix, UnionOfRows( HomalgZeroMatrix( Sum( deduped_2_1{[ 1 .. k_1 - 1 ]} ), deduped_1_1, deduped_3_1 ), HomalgIdentityMatrix( deduped_1_1, deduped_3_1 ), HomalgZeroMatrix( Sum( deduped_2_1{[ k_1 + 1 .. Length( objects_1 ) ]} ), deduped_1_1, deduped_3_1 ) ) );
-end
-########
-        
-    , 100 );
-    
-    ##
-    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
-        
-########
-function ( cat_1, alpha_1 )
-    local morphism_attr_1_1, deduped_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := UnderlyingMatrix( alpha_1 );
-    deduped_3_1 := UnderlyingRing( cat_1 );
-    deduped_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    morphism_attr_1_1 := CoercedMatrix( deduped_3_1, CommutativeRingOfLinearCategory( cat_1 ), CoefficientsWithGivenMonomials( ConvertMatrixToRow( deduped_4_1 ), DiagMat( deduped_3_1, ListWithIdenticalEntries( NumberRows( deduped_4_1 ), DiagMat( deduped_3_1, ListWithIdenticalEntries( NumberColumns( deduped_4_1 ), BasisOfRingOverBaseFieldAsColumnVector( cat_1 ) ) ) ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 );
 end
 ########
         

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2024.07-02",
+Version := "2024.07-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/OppositeOfMatrixCategoryPrecompiled.gi
@@ -350,20 +350,6 @@ end
     , 100 );
     
     ##
-    AddHomomorphismStructureOnMorphisms( cat,
-        
-########
-function ( cat_1, alpha_1, beta_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := OppositeCategory( cat_1 );
-    morphism_attr_1_1 := KroneckerMat( TransposedMatrix( AsHomalgMatrix( Opposite( beta_1 ) ) ), AsHomalgMatrix( Opposite( alpha_1 ) ) );
-    return AsCapCategoryMorphism( deduped_2_1, AsCapCategoryObject( deduped_2_1, NumberRows( morphism_attr_1_1 ) ), morphism_attr_1_1, AsCapCategoryObject( deduped_2_1, NumberColumns( morphism_attr_1_1 ) ) );
-end
-########
-        
-    , 301 );
-    
-    ##
     AddHomomorphismStructureOnMorphismsWithGivenObjects( cat,
         
 ########
@@ -439,20 +425,6 @@ end
 ########
         
     , 100 );
-    
-    ##
-    AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat,
-        
-########
-function ( cat_1, alpha_1 )
-    local morphism_attr_1_1, deduped_2_1;
-    deduped_2_1 := OppositeCategory( cat_1 );
-    morphism_attr_1_1 := ConvertMatrixToRow( AsHomalgMatrix( Opposite( alpha_1 ) ) );
-    return AsCapCategoryMorphism( deduped_2_1, AsCapCategoryObject( deduped_2_1, 1 ), morphism_attr_1_1, AsCapCategoryObject( deduped_2_1, NumberColumns( morphism_attr_1_1 ) ) );
-end
-########
-        
-    , 301 );
     
     ##
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( cat,


### PR DESCRIPTION
to keep the symmetry between CategoryOfRows and CategoryOfColumns. The new behavior is still available via the option
`only_primitive_operations_and_hom_structure`.

reference: 7a336a073d77073df405a923671bfaa2cbc7a6ce