### PR TITLE
Fix a logic function potentially producing wrong results

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2024.07-07",
+Version := "2024.07-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/Logic.gi
+++ b/CompilerForCAP/gap/Logic.gi
@@ -170,7 +170,17 @@ CapJitAddLogicFunction( function ( tree )
             # for integers, strings, and chars we can also decide inequality
             elif tree.left.type = "EXPR_INT" or tree.left.type = "EXPR_STRING" or tree.left.type = "EXPR_CHAR" then
                 
-                return rec( type := "EXPR_FALSE" );
+                # CAUTION: One value might have a data type set and the other not -> they might differ with regard to `CapJitIsEqualForEnhancedSyntaxTrees`
+                # despite having equal values. Hence, to decide inequality we have to explicitly check the values again.
+                if tree.left.value = tree.right.value then
+                    
+                    return rec( type := "EXPR_TRUE" );
+                    
+                else
+                    
+                    return rec( type := "EXPR_FALSE" );
+                    
+                fi;
                 
             fi;
             

--- a/CompilerForCAP/tst/Logic.tst
+++ b/CompilerForCAP/tst/Logic.tst
@@ -86,7 +86,18 @@ end
 
 #
 gap> func := function ( x )
->   if 1 = 2 then return 1; elif x = x then return 2; else return 3; fi; end;;
+>   
+>   if 1 = 2 then
+>       return 1;
+>   elif 1 = CapJitTypedExpression( 1, { } -> rec( filter := IsInt ) ) then
+>       return 2;
+>   elif x = x then
+>       return 3;
+>   else
+>       return 4;
+>   fi;
+>   
+>   end;;
 
 #
 gap> tree := ENHANCED_SYNTAX_TREE( func );;
@@ -97,8 +108,10 @@ function ( x_1 )
         return 1;
     elif true then
         return 2;
-    else
+    elif true then
         return 3;
+    else
+        return 4;
     fi;
     return;
 end


### PR DESCRIPTION
in contexts with partial type information

I hope that this has not caused issues in production code due to contexts usually either having full or no type information.