### PR TITLE
Allow to specify weights of operations in CategoryConstructor

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.08-02",
+Version := "2024.08-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryConstructor.gd
+++ b/CAP/gap/CategoryConstructor.gd
@@ -36,6 +36,7 @@ DeclareInfoClass( "InfoCategoryConstructor" );
 #!  * `morphism_constructor` (optional): function added as an installation of <Ref Oper="MorphismConstructor" Label="for IsCapCategoryObject, IsObject, IsCapCategoryObject" /> to the category
 #!  * `morphism_datum` (optional): function added as an installation of <Ref Oper="MorphismDatum" Label="for IsCapCategoryMorphism" /> to the category
 #!  * `list_of_operations_to_install` (mandatory): a list of names of &CAP; operations which should be installed for the category
+#!  * `operation_weights` (optional): a record mapping operations in `list_of_operations_to_install` to their weights
 #!  * `is_computable` (optional): whether the category can decide `IsCongruentForMorphisms`
 #!  * `supports_empty_limits` (optional): whether the category supports empty lists in inputs to operations of limits and colimits
 #!  * `underlying_category_getter_string` (optional): see below

--- a/CAP/gap/CategoryConstructor.gi
+++ b/CAP/gap/CategoryConstructor.gi
@@ -27,6 +27,7 @@ InstallMethod( CategoryConstructor,
         morphism_constructor := IsFunction,
         morphism_datum := IsFunction,
         list_of_operations_to_install := IsList,
+        operation_weights := IsRecord,
         is_computable := IsBool,
         supports_empty_limits := IsBool,
         underlying_category_getter_string := IsString,
@@ -501,7 +502,15 @@ InstallMethod( CategoryConstructor,
         
         func := EvalString( func_string );
         
-        add( CC, func );
+        if IsBound( options.operation_weights ) and IsBound( options.operation_weights.(name) ) then
+            
+            add( CC, func, options.operation_weights.(name) );
+            
+        else
+            
+            add( CC, func );
+            
+        fi;
         
     od;
     

--- a/CAP/gap/ReinterpretationOfCategory.gi
+++ b/CAP/gap/ReinterpretationOfCategory.gi
@@ -14,7 +14,7 @@ InstallMethod( ReinterpretationOfCategory,
     [ "FinalizeCategory", true ],
   ],
   function( CAP_NAMED_ARGUMENTS, C, options )
-    local known_options_with_filters, filter, mandatory_options, category_constructor_options, list_of_operations_to_install, D, operations_of_homomorphism_structure, HC, object_function, morphism_function, object_function_inverse, morphism_function_inverse, option_name, option;
+    local known_options_with_filters, filter, mandatory_options, category_constructor_options, list_of_operations_to_install, D, operations_of_homomorphism_structure, HC, object_function, morphism_function, object_function_inverse, morphism_function_inverse, option_name, option, operation;
     
     ## check given options
     known_options_with_filters := rec(
@@ -140,6 +140,14 @@ InstallMethod( ReinterpretationOfCategory,
     
     category_constructor_options.list_of_operations_to_install := list_of_operations_to_install;
     
+    category_constructor_options.operation_weights := rec( );
+    
+    for operation in list_of_operations_to_install do
+        
+        category_constructor_options.operation_weights.(operation) := CurrentOperationWeight( C!.derivations_weight_list, operation );
+        
+    od;
+    
     if IsBound( C!.supports_empty_limits ) then
         
         category_constructor_options.supports_empty_limits := C!.supports_empty_limits;
@@ -220,7 +228,7 @@ InstallMethod( ReinterpretationOfCategory,
             return List( MorphismsOfExternalHom( ModelingCategory( cat ), ModelingObject( cat, a ), ModelingObject( cat, b ) ),
                          mor -> ReinterpretationOfMorphism( cat, a, mor, b ) );
             
-        end );
+        end, CurrentOperationWeight( C!.derivations_weight_list, "MorphismsOfExternalHom" ) );
         
     fi;
     
@@ -232,7 +240,7 @@ InstallMethod( ReinterpretationOfCategory,
             return List( BasisOfExternalHom( ModelingCategory( cat ), ModelingObject( cat, a ), ModelingObject( cat, b ) ),
                          mor -> ReinterpretationOfMorphism( cat, a, mor, b ) );
             
-        end );
+        end, CurrentOperationWeight( C!.derivations_weight_list, "BasisOfExternalHom" ) );
         
     fi;
     
@@ -243,7 +251,7 @@ InstallMethod( ReinterpretationOfCategory,
             
             return CoefficientsOfMorphism( ModelingCategory( cat ), ModelingMorphism( cat, alpha ) );
             
-        end );
+        end, CurrentOperationWeight( C!.derivations_weight_list, "CoefficientsOfMorphism" ) );
         
     fi;
     
@@ -324,7 +332,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return DistinguishedObjectOfHomomorphismStructureExtendedByFullEmbedding( ModelingCategory( cat ), HC );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "DistinguishedObjectOfHomomorphismStructure" ) );
         fi;
         
         if "HomomorphismStructureOnObjects" in list_of_operations_to_install then
@@ -333,7 +341,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return HomomorphismStructureOnObjectsExtendedByFullEmbedding( ModelingCategory( cat ), HC, ModelingObject( cat, a ), ModelingObject( cat, b ) );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "HomomorphismStructureOnObjects" ) );
         fi;
         
         if "HomomorphismStructureOnMorphisms" in list_of_operations_to_install then
@@ -342,7 +350,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return HomomorphismStructureOnMorphismsExtendedByFullEmbedding( ModelingCategory( cat ), HC, ModelingMorphism( cat, alpha ), ModelingMorphism( cat, beta ) );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "HomomorphismStructureOnMorphisms" ) );
         fi;
         
         if "HomomorphismStructureOnMorphismsWithGivenObjects" in list_of_operations_to_install then
@@ -351,7 +359,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return HomomorphismStructureOnMorphismsWithGivenObjectsExtendedByFullEmbedding( ModelingCategory( cat ), HC, s, ModelingMorphism( cat, alpha ), ModelingMorphism( cat, beta ), r );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "HomomorphismStructureOnMorphismsWithGivenObjects" ) );
         fi;
         
         if "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" in list_of_operations_to_install then
@@ -360,7 +368,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureExtendedByFullEmbedding( ModelingCategory( cat ), HC, ModelingMorphism( cat, alpha ) );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" ) );
         fi;
         
         if "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects" in list_of_operations_to_install then
@@ -369,7 +377,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjectsExtendedByFullEmbedding( ModelingCategory( cat ), HC, s, ModelingMorphism( cat, alpha ), r );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects" ) );
         fi;
         
         if "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" in list_of_operations_to_install then
@@ -378,7 +386,7 @@ InstallMethod( ReinterpretationOfCategory,
                 
                 return ReinterpretationOfMorphism( cat, a, InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphismExtendedByFullEmbedding( ModelingCategory( cat ), HC, ModelingObject( cat, a ), ModelingObject( cat, b ), iota ), b );
                 
-            end );
+            end, CurrentOperationWeight( C!.derivations_weight_list, "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" ) );
         fi;
         
     fi;

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2024.08-02",
+Version := "2024.08-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumns_as_Opposite_CategoryOfRows_Field_precompiled.gi
+++ b/FreydCategoriesForCAP/gap/precompiled_categories/CategoryOfColumns_as_Opposite_CategoryOfRows_Field_precompiled.gi
@@ -472,7 +472,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsLiftable( cat,
@@ -494,7 +494,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,

--- a/LinearAlgebraForCAP/PackageInfo.g
+++ b/LinearAlgebraForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearAlgebraForCAP",
 Subtitle := "Category of Matrices over a Field for CAP",
-Version := "2024.08-03",
+Version := "2024.08-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategory_precompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/MatrixCategory_precompiled.gi
@@ -2616,7 +2616,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 201 : IsPrecompiledDerivation := true );
+    , 3 : IsPrecompiledDerivation := true );
     
     ##
     AddIsCodominating( cat,
@@ -2823,7 +2823,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsIsomorphicForObjects( cat,
@@ -2902,7 +2902,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsSplitEpimorphism( cat,

--- a/LinearAlgebraForCAP/gap/precompiled_categories/Opposite_MatrixCategory_precompiled.gi
+++ b/LinearAlgebraForCAP/gap/precompiled_categories/Opposite_MatrixCategory_precompiled.gi
@@ -504,7 +504,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsLiftable( cat,
@@ -526,7 +526,7 @@ function ( cat_1, arg2_1 )
 end
 ########
         
-    , 100 );
+    , 1 );
     
     ##
     AddIsWellDefinedForMorphisms( cat,


### PR DESCRIPTION
and use this to preserve weights when constructing reinterpretations

@mohamed-barakat With this PR, providing the weights is optional. I suggest to make the weights mandatory to make sure that we always preserve the weights whenever we use CategoryConstructor. Do you agree?