### PR TITLE
Turn identifier lists in type checking functions into identifier getters

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.08-07",
+Version := "2024.08-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -340,6 +340,8 @@ InstallGlobalFunction( "CreateCapCategoryWithDataTypes", FunctionWithNamedArgume
     
     obj!.add_primitive_output := false;
     
+    obj!.input_sanity_check_functions := rec( );
+    
     # convenience for Julia lists
     if IsPackageMarkedForLoading( "JuliaInterface", ">= 0.2" ) then
         

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -84,38 +84,40 @@ DeclareGlobalFunction( "CAP_INTERNAL_FIND_APPEARANCE_OF_SYMBOL_IN_FUNCTION" );
 #!  lists only contains this pair once, with the higher multiple from both lists.
 DeclareGlobalFunction( "CAP_INTERNAL_MERGE_PRECONDITIONS_LIST" );
 
-#! @Arguments data_type, human_readable_identifier_list
+#! @Arguments data_type, human_readable_identifier_getter
+#! @Returns a function
 #! @Description
-#!  Returns a unary function which throws an error if its argument is not of type <A>data_type</A>.
-#!  <A>human_readable_identifier_list</A> is a list of arguments passed to `Error` to refer to the argument of the unary function in the error message.
+#!  Returns a function `f` which throws an error if its first argument is not of type <A>data_type</A>.
+#!  <A>human_readable_identifier_getter</A> is a function returning a string which is used to refer to the first argument of `f` in the error message.
+#!  The arguments of `f` except the first argument are passed on to <A>human_readable_identifier_getter</A>.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER" );
 
-#! @Arguments cell, category, human_readable_identifier_list
+#! @Arguments cell, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>cell</A> is not a cell of <A>category</A>.
 #!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier_list</A> is a list of arguments passed to `Error` to refer to <A>cell</A> in the error message.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY" );
 
-#! @Arguments object, category, human_readable_identifier_list
+#! @Arguments object, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>object</A> is not an object of <A>category</A>.
 #!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier_list</A> is a list of arguments passed to `Error` to refer to <A>object</A> in the error message.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY" );
 
-#! @Arguments morphism, category, human_readable_identifier_list
+#! @Arguments morphism, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>morphism</A> is not a morphism of <A>category</A>.
 #!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier_list</A> is a list of arguments passed to `Error` to refer to <A>morphism</A> in the error message.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY" );
 
-#! @Arguments two_cell, category, human_readable_identifier_list
+#! @Arguments two_cell, category, human_readable_identifier_getter
 #! @Description
 #!  The function throws an error if <A>two_cell</A> is not a $2$-cell of <A>category</A>.
 #!  If <A>category</A> is the boolean <C>false</C>, only general checks not specific to a concrete category are performed.
-#!  <A>human_readable_identifier_list</A> is a list of arguments passed to `Error` to refer to <A>two_cell</A> in the error message.
+#!  <A>human_readable_identifier_getter</A> is a 0-ary function returning a string which is used to refer to <A>cell</A> in the error message.
 DeclareGlobalFunction( "CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY" );
 
 DeclareGlobalFunction( "ListKnownCategoricalProperties" );

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -405,8 +405,8 @@ end );
 
 InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
   
-  function( data_type, human_readable_identifier_list )
-    local generic_help_string, filter, asserts_value_is_of_element_type, generic_assert_value_is_of_element_type;
+  function( data_type, human_readable_identifier_getter )
+    local generic_help_string, filter, asserts_value_is_of_element_type, assert_value_is_of_element_type;
     
     generic_help_string := " You can access the value via the local variable 'value' in a break loop.";
     
@@ -415,11 +415,11 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
     # `IsBool( fail ) = true`, but we do not want to include `fail`
     if IsSpecializationOfFilter( IsBool, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not (value = true or value = false) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " is neither `true` nor `false`.", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " is neither `true` nor `false`.", generic_help_string );
                 
             fi;
             
@@ -427,17 +427,17 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
         
     elif IsSpecializationOfFilter( IsFunction, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
             if NumberArgumentsFunction( value ) >= 0 and NumberArgumentsFunction( value ) <> Length( data_type.signature[1] ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has ", NumberArgumentsFunction( value ), " arguments but ", Length( data_type.signature[1] ), " were expected.", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " has ", NumberArgumentsFunction( value ), " arguments but ", Length( data_type.signature[1] ), " were expected.", generic_help_string );
                 
             fi;
             
@@ -445,20 +445,14 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
         
     elif IsSpecializationOfFilter( IsList, filter ) then
         
-        # In principle, we have to create an assertion function for each integer to get the human readable identifier correct.
-        # The "correct" approach would be to generate those on demand but that would imply that we have to create assertion functions at runtime.
-        # Thus, we take the pragmatic approach: We generate an assertion function for the first few entries, and a generic assertion function for all other entries.
-        # For nested lists the number of assertion functions grows exponentially, so we choose a quite small number (4).
-        asserts_value_is_of_element_type := List( [ 1 .. 4 ], i -> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( data_type.element_type, Concatenation( [ "the ", i, "-th entry of " ], human_readable_identifier_list ) ) );
+        assert_value_is_of_element_type := CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( data_type.element_type, { i, outer_args } -> Concatenation( "the ", String( i ), "-th entry of ", CallFuncList( human_readable_identifier_getter, outer_args ) ) );
         
-        generic_assert_value_is_of_element_type := CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( data_type.element_type, Concatenation( [ "some entry of " ], human_readable_identifier_list )  );
-        
-        return function( value )
+        return function( value, args... )
           local i;
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
@@ -468,20 +462,12 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
                 # Julia does not have non-dense lists
                 if not IsBound( value[i] ) then
                     
-                    CallFuncList( Error, Concatenation( [ "the ", i, "-th entry of " ], human_readable_identifier_list, [ " is not bound.", generic_help_string ] ) );
+                    Error( "the ", i, "-th entry of ", CallFuncList( human_readable_identifier_getter, args ), " is not bound.", generic_help_string );
                     
                 fi;
                 # =#
                 
-                if i <= 4 then
-                    
-                    asserts_value_is_of_element_type[i]( value[i] );
-                    
-                else
-                    
-                    generic_assert_value_is_of_element_type( value[i] );
-                    
-                fi;
+                assert_value_is_of_element_type( value[i], i, args );
                 
             od;
             
@@ -489,27 +475,27 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
         
     elif IsSpecializationOfFilter( IsNTuple, filter ) then
         
-        asserts_value_is_of_element_type := List( [ 1 .. Length( data_type.element_types ) ], i -> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( data_type.element_types[i], Concatenation( [ "the ", i, "-th entry of " ], human_readable_identifier_list ) ) );
+        asserts_value_is_of_element_type := List( [ 1 .. Length( data_type.element_types ) ], i -> CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER( data_type.element_types[i], { outer_args } -> Concatenation( "the ", String( i ), "-th entry of ", CallFuncList( human_readable_identifier_getter, outer_args ) ) ) );
         
-        return function( value )
+        return function( value, args... )
           local i;
             
             # tuples are modeled as lists
             if not IsDenseList( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter IsDenseList (implementation filter of IsNTuple).", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter IsDenseList (implementation filter of IsNTuple).", generic_help_string );
                 
             fi;
             
             if Length( value ) <> Length( data_type.element_types ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has length ", Length( value ), " but ", Length( data_type.element_types ), " was expected.", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " has length ", Length( value ), " but ", Length( data_type.element_types ), " was expected.", generic_help_string );
                 
             fi;
             
             for i in [ 1 .. Length( value ) ] do
                 
-                asserts_value_is_of_element_type[i]( value[i] );
+                asserts_value_is_of_element_type[i]( value[i], args );
                 
             od;
             
@@ -517,17 +503,17 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
         
     elif IsSpecializationOfFilter( IsCapCategory, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
             if not IsIdenticalObj( value, data_type.category ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " is not the expected category although it lies in the category filter of the expected category. This should never happen, please report this using the CAP_project's issue tracker.", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " is not the expected category although it lies in the category filter of the expected category. This should never happen, please report this using the CAP_project's issue tracker.", generic_help_string );
                 
             fi;
             
@@ -535,53 +521,53 @@ InstallGlobalFunction( "CAP_INTERNAL_ASSERT_VALUE_IS_OF_TYPE_GETTER",
         
     elif IsSpecializationOfFilter( IsCapCategoryObject, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
-            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( value, data_type.category, human_readable_identifier_list );
+            CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( value, data_type.category, {} -> CallFuncList( human_readable_identifier_getter, args ) );
             
         end;
         
     elif IsSpecializationOfFilter( IsCapCategoryMorphism, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
-            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( value, data_type.category, human_readable_identifier_list );
+            CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( value, data_type.category, {} -> CallFuncList( human_readable_identifier_getter, args ) );
             
         end;
         
     elif IsSpecializationOfFilter( IsCapCategoryTwoCell, filter ) then
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
-            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( value, data_type.category, human_readable_identifier_list );
+            CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY( value, data_type.category, {} -> CallFuncList( human_readable_identifier_getter, args ) );
             
         end;
         
     else
         
-        return function( value )
+        return function( value, args... )
             
             if not filter( value ) then
                 
-                CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the expected filter ", filter, ".", generic_help_string ] ) );
+                Error( CallFuncList( human_readable_identifier_getter, args ), " does not lie in the expected filter ", filter, ".", generic_help_string );
                 
             fi;
             
@@ -1984,21 +1970,21 @@ fi;
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_CELL_OF_CATEGORY,
   
-  function( cell, category, human_readable_identifier_list )
+  function( cell, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the category cell and category via the local variables 'cell' and 'category' in a break loop.";
     
     if not IsCapCategoryCell( cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the filter IsCapCategoryCell.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the filter IsCapCategoryCell.", generic_help_string );
     fi;
     
     if not HasCapCategory( cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no CAP category.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no CAP category.", generic_help_string );
     fi;
     
     if category <> false and not IsIdenticalObj( CapCategory( cell ), category ) then
-        CallFuncList( Error, Concatenation( [ "The CapCategory of " ], human_readable_identifier_list, [ " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( "The CapCategory of ", human_readable_identifier_getter( ), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
 end );
@@ -2006,25 +1992,25 @@ end );
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY,
   
-  function( object, category, human_readable_identifier_list )
+  function( object, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the object and category via the local variables 'object' and 'category' in a break loop.";
     
     if not IsCapCategoryObject( object ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the filter IsCapCategoryObject.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the filter IsCapCategoryObject.", generic_help_string );
     fi;
     
     if not HasCapCategory( object ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no CAP category.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no CAP category.", generic_help_string );
     fi;
     
     if category <> false and not IsIdenticalObj( CapCategory( object ), category ) then
-        CallFuncList( Error, Concatenation( [ "The CapCategory of " ], human_readable_identifier_list, [ " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( "The CapCategory of ", human_readable_identifier_getter( ), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
     if category <> false and not ObjectFilter( category )( object ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the object filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the object filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
 end );
@@ -2032,76 +2018,76 @@ end );
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY,
   
-  function( morphism, category, human_readable_identifier_list )
+  function( morphism, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the morphism and category via the local variables 'morphism' and 'category' in a break loop.";
     
     if not IsCapCategoryMorphism( morphism ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the filter IsCapCategoryMorphism.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the filter IsCapCategoryMorphism.", generic_help_string );
     fi;
     
     if not HasCapCategory( morphism ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no CAP category.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no CAP category.", generic_help_string );
     fi;
     
     if category <> false and not IsIdenticalObj( CapCategory( morphism ), category ) then
-        CallFuncList( Error, Concatenation( [ "the CAP-category of " ], human_readable_identifier_list, [ " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( "the CAP-category of ", human_readable_identifier_getter( ), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
     if category <> false and not MorphismFilter( category )( morphism ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the morphism filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the morphism filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
     if not HasSource( morphism ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no source.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no source.", generic_help_string );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, Concatenation( [ "the source of " ], human_readable_identifier_list ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Source( morphism ), category, {} -> Concatenation( "the source of ", human_readable_identifier_getter( ) ) );
     
     if not HasRange( morphism ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no range.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no range.", generic_help_string );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, Concatenation( [ "the range of " ], human_readable_identifier_list ) );
+    CAP_INTERNAL_ASSERT_IS_OBJECT_OF_CATEGORY( Range( morphism ), category, {} -> Concatenation( "the range of ", human_readable_identifier_getter( ) ) );
     
 end );
 
 ##
 InstallGlobalFunction( CAP_INTERNAL_ASSERT_IS_TWO_CELL_OF_CATEGORY,
   
-  function( two_cell, category, human_readable_identifier_list )
+  function( two_cell, category, human_readable_identifier_getter )
     local generic_help_string;
     
     generic_help_string := " You can access the 2-cell and category via the local variables 'two_cell' and 'category' in a break loop.";
     
     if not IsCapCategoryTwoCell( two_cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the filter IsCapCategoryTwoCell.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the filter IsCapCategoryTwoCell.", generic_help_string );
     fi;
     
     if not HasCapCategory( two_cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no CAP category.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no CAP category.", generic_help_string );
     fi;
     
     if category <> false and not IsIdenticalObj( CapCategory( two_cell ), category ) then
-        CallFuncList( Error, Concatenation( [ "the CapCategory of " ], human_readable_identifier_list, [ " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( "the CapCategory of ", human_readable_identifier_getter( ), " is not identical to the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
     if category <> false and not TwoCellFilter( category )( two_cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " does not lie in the 2-cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " does not lie in the 2-cell filter of the category named \033[1m", Name( category ), "\033[0m.", generic_help_string );
     fi;
     
     if not HasSource( two_cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no source.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no source.", generic_help_string );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, Concatenation( [ "the source of " ], human_readable_identifier_list ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Source( two_cell ), category, {} -> Concatenation( "the source of ", human_readable_identifier_getter( ) ) );
     
     if not HasRange( two_cell ) then
-        CallFuncList( Error, Concatenation( human_readable_identifier_list, [ " has no range.", generic_help_string ] ) );
+        Error( human_readable_identifier_getter( ), " has no range.", generic_help_string );
     fi;
     
-    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, Concatenation( [ "the range of " ], human_readable_identifier_list ) );
+    CAP_INTERNAL_ASSERT_IS_MORPHISM_OF_CATEGORY( Range( two_cell ), category, {} -> Concatenation( "the range of ", human_readable_identifier_getter( ) ) );
     
 end );
 


### PR DESCRIPTION
This partially reverts 50a472de302106894b47ee08a3e5e680da5fdae3, but now the identifier getters for input sanity checks are cached. This improves the performance in both GAP and Julia.
