### PR TITLE
Reintroduce optimizations in GeneralizedMorphismsForCAP

### DIFF
--- a/GeneralizedMorphismsForCAP/PackageInfo.g
+++ b/GeneralizedMorphismsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GeneralizedMorphismsForCAP",
 Subtitle := "Implementations of generalized morphisms for the CAP project",
-Version := "2024.09-01",
+Version := "2024.09-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/GeneralizedMorphismsForCAP/examples/VectorSpacesGeneralizedMorphismsCategory.g
+++ b/GeneralizedMorphismsForCAP/examples/VectorSpacesGeneralizedMorphismsCategory.g
@@ -88,7 +88,7 @@ Arrow( composition );
 SourceAid( composition );
 #! <A morphism in Category of matrices over Q>
 RangeAid( composition );
-#! <A morphism in Category of matrices over Q>
+#! <An identity morphism in Category of matrices over Q>
 #! @EndExample
 
 #! Second composition test
@@ -121,7 +121,7 @@ Arrow( composition2 );
 RangeAid( composition2 );
 #! <A morphism in Category of matrices over Q>
 SourceAid( composition2 );
-#! <A split monomorphism in Category of matrices over Q>
+#! <An identity morphism in Category of matrices over Q>
 #! @EndExample
 
 #! Third composition test

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByCospans.gi
@@ -79,6 +79,35 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_GENERALIZED_MORPHISM_CATEGORY_BY_CO
         
     end );
     
+    # the following optimizations probably do not fulfill the specification "equal input gives equal output", see https://github.com/homalg-project/CAP_project/issues/1669
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsReversedArrow, MorphismFilter( category ) and HasIdentityAsReversedArrow ],
+                        
+      function( cat, morphism1, morphism2 )
+          local honest_category, arrow, reversed_arrow;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          arrow := PreCompose( honest_category, Arrow( morphism1 ), Arrow( morphism2 ) );
+
+          return AsGeneralizedMorphismByCospan( arrow );
+
+    end );
+    
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsReversedArrow, MorphismFilter( category ) ],
+                        
+      function( cat, morphism1, morphism2 )
+          local honest_category, arrow;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          arrow := PreCompose( honest_category, Arrow( morphism1 ), Arrow( morphism2 ) );
+
+          return GeneralizedMorphismByCospan( arrow, ReversedArrow( morphism2 ) );
+
+    end );
+    
     
     ## AdditionForMorphisms
     

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryBySpans.gi
@@ -72,7 +72,36 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_GENERALIZED_MORPHISM_CATEGORY_BY_SP
         
     end );
     
+    # the following optimizations probably do not fulfill the specification "equal input gives equal output", see https://github.com/homalg-project/CAP_project/issues/1669
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsReversedArrow, MorphismFilter( category ) and HasIdentityAsReversedArrow ],
+                        
+      function( cat, morphism1, morphism2 )
+          local honest_category, arrow;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          arrow := PreCompose( honest_category, Arrow( morphism1 ), Arrow( morphism2 ) );
+
+          return AsGeneralizedMorphismBySpan( arrow );
+
+    end );
     
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ), MorphismFilter( category ) and HasIdentityAsReversedArrow ],
+                        
+      function( cat, morphism1, morphism2 )
+          local honest_category, arrow;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          arrow := PreCompose( honest_category, Arrow( morphism1 ), Arrow( morphism2 ) );
+
+          return GeneralizedMorphismBySpan( ReversedArrow( morphism1 ), arrow );
+
+    end );
+    
+
     ## AdditionForMorphisms
     
     AddAdditionForMorphisms( category,

--- a/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
+++ b/GeneralizedMorphismsForCAP/gap/GeneralizedMorphismCategoryByThreeArrows.gi
@@ -97,6 +97,74 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_GENERALIZED_MORPHISM_BY_THREE_ARROW
         
     end );
     
+    # the following optimizations probably do not fulfill the specification "equal input gives equal output", see https://github.com/homalg-project/CAP_project/issues/1669
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsRangeAid, MorphismFilter( category ) and HasIdentityAsSourceAid ],
+                        
+      function( cat, mor1, mor2 )
+        
+        return GeneralizedMorphismByThreeArrows( SourceAid( mor1 ),
+                                                 PreCompose( UnderlyingHonestCategory( cat ), Arrow( mor1 ), Arrow( mor2 ) ),
+                                                 RangeAid( mor2 ) );
+        
+    end );
+    
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsRangeAid, MorphismFilter( category ) and HasIdentityAsRangeAid ],
+                        
+      function( cat, mor1, mor2 )
+          local honest_category, category, pullback_diagram, new_source_aid, new_morphism_aid;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          pullback_diagram := [ Arrow( mor1 ), SourceAid( mor2 ) ];
+
+          new_source_aid := PreCompose( honest_category,
+                                        ProjectionInFactorOfFiberProduct( honest_category, pullback_diagram, 1 ),
+                                        SourceAid( mor1 ) );
+
+          new_morphism_aid := PreCompose( honest_category,
+                                          ProjectionInFactorOfFiberProduct( honest_category, pullback_diagram, 2 ),
+                                          Arrow( mor2 ) );
+
+          return GeneralizedMorphismByThreeArrowsWithSourceAid( new_source_aid, new_morphism_aid );
+
+    end );
+    
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsSourceAid, MorphismFilter( category ) and HasIdentityAsSourceAid ],
+                        
+      function( cat, mor1, mor2 )
+          local honest_category, category, diagram, injection_of_cofactor1, injection_of_cofactor2, new_morphism_aid, new_range_aid;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          diagram := [ RangeAid( mor1 ), Arrow( mor2 ) ];
+
+          injection_of_cofactor1 := InjectionOfCofactorOfPushout( honest_category, diagram, 1 );
+
+          injection_of_cofactor2 := InjectionOfCofactorOfPushout( honest_category, diagram, 2 );
+
+          new_morphism_aid := PreCompose( honest_category, Arrow( mor1 ), injection_of_cofactor1 );
+
+          new_range_aid := PreCompose( honest_category, RangeAid( mor2 ), injection_of_cofactor2 );
+
+          return GeneralizedMorphismByThreeArrowsWithRangeAid( new_morphism_aid, new_range_aid );
+
+    end );
+    
+    InstallOtherMethod( PreCompose,
+                        [ CategoryFilter( category ), MorphismFilter( category ) and HasIdentityAsRangeAid and HasIdentityAsSourceAid, MorphismFilter( category ) and HasIdentityAsRangeAid and HasIdentityAsSourceAid ],
+                        
+      function( cat, mor1, mor2 )
+          local honest_category, category;
+
+          honest_category := UnderlyingHonestCategory( cat );
+
+          return AsGeneralizedMorphismByThreeArrows( PreCompose( honest_category, Arrow( mor1 ), Arrow( mor2 ) ) );
+
+    end );
+    
     
     ## AdditionForMorphisms
     


### PR DESCRIPTION
to avoid timeouts in tests in CategoricalTowers

The optimizations probably do not fulfill the specification "equal input gives equal output",
see https://github.com/homalg-project/CAP_project/issues/1669