### PR TITLE
Make weight checks in AddCapOperation stricter

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.09-09",
+Version := "2024.09-10",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -94,10 +94,8 @@ InstallMethod( AddCapOperation,
     # If there already is a faster method: do nothing but display a warning because this should not happen usually.
     if weight > CurrentOperationWeight( category!.derivations_weight_list, function_name ) then
         
-        # * Not all derivations are properly dualized, so it can happen that a derivation for the dual of an operation is cheaper then the operation.
-        #   This would automatically be fixed by https://github.com/homalg-project/CAP_project/issues/1078.
-        # * There are some derivations of weight 1 for thin categories which are triggered immediately and which CategoryConstructor tries to overwrite with weight 100.
-        if not WasCreatedAsOppositeCategory( category ) and CurrentOperationWeight( category!.derivations_weight_list, function_name ) <> 1 then
+        # There are some derivations of weight 1 for thin categories which are triggered immediately and which CategoryConstructor tries to overwrite with weight 100.
+        if CurrentOperationWeight( category!.derivations_weight_list, function_name ) <> 1 then
             
             Print( "WARNING: Ignoring a function added for ", function_name, " with weight ", weight, " to \"", category_name, "\" because there already is a function installed with weight ", CurrentOperationWeight( category!.derivations_weight_list, function_name ), "." );
             
@@ -118,22 +116,15 @@ InstallMethod( AddCapOperation,
     # Display a warning when overwriting primitive operations with derivations.
     if (is_derivation or is_final_derivation or is_precompiled_derivation) and IsBound( category!.primitive_operations.( function_name ) ) and category!.primitive_operations.( function_name ) then
         
-        # * Not all derivations are properly dualized, so it can happen that a derivation for the dual of an operation is cheaper then the operation.
-        #   This would automatically be fixed by https://github.com/homalg-project/CAP_project/issues/1078.
-        # * There is a test in Locales creating a category via CategoryConstructor (which uses weight 100) and then installs a really cheap method for UniqueMorphism which triggers a bunch of cheap derivations.
-        if not WasCreatedAsOppositeCategory( category ) and weight > 4 then
+        Print( "WARNING: Overriding a function for ", function_name, " primitively added to \"", category_name, "\" with a derivation." );
+        
+        if is_precompiled_derivation then
             
-            Print( "WARNING: Overriding a function for ", function_name, " primitively added to \"", category_name, "\" with a derivation." );
-            
-            if is_precompiled_derivation then
-                
-                Print( " Probably you have to rerun the precompilation to adjust the weights in the precompiled code." );
-                
-            fi;
-            
-            Print( "\n" );
+            Print( " Probably you have to rerun the precompilation to adjust the weights in the precompiled code." );
             
         fi;
+        
+        Print( "\n" );
         
     fi;
     


### PR DESCRIPTION
A single exception remains due to issues in CategoricalTowers.