### PR TITLE
Prefix UniqueObject/Morphisms with TerminalCategoryWithSingleObject

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.09-13",
+Version := "2024.09-14",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -494,11 +494,11 @@ AddUniversalMorphismIntoTerminalObjectWithGivenTerminalObject( category,
     
     AddObjectFunction( new_functor,
                        
-                       function( arg ) return UniqueObject( AsCapCategory( terminal_cat ) ); end );
+                       function( arg ) return TerminalCategoryWithSingleObjectUniqueObject( AsCapCategory( terminal_cat ) ); end );
     
     AddMorphismFunction( new_functor,
                          
-                         function( arg ) return UniqueMorphism( AsCapCategory( terminal_cat ) ); end );
+                         function( arg ) return TerminalCategoryWithSingleObjectUniqueMorphism( AsCapCategory( terminal_cat ) ); end );
     
     return new_functor;
     

--- a/CAP/gap/MethodRecordTools.gi
+++ b/CAP/gap/MethodRecordTools.gi
@@ -748,7 +748,6 @@ BindGlobal( "CAP_INTERNAL_CREATE_REDIRECTION",
     with_given_name_function := ValueGlobal( with_given_name );
     
     # Check if `object_function` is declared as an attribute and can actually be used as one in our context.
-    # We do not print a warning if somethings is declared as an attribute but cannot be used as one in our context because this might actually happen, see for example `UniqueMorphism`.
     is_attribute := IsAttribute( object_function ) and Length( object_filter_list ) <= 2 and IsSpecializationOfFilter( IsAttributeStoringRep, CAP_INTERNAL_REPLACED_STRING_WITH_FILTER( Last( object_filter_list ) ) );
     
     if not is_attribute then
@@ -857,7 +856,6 @@ BindGlobal( "CAP_INTERNAL_CREATE_POST_FUNCTION",
     cache_key_length := Length( object_arguments_positions );
     
     # Check if `object_function` is declared as an attribute and can actually be used as one in our context.
-    # We do not print a warning if somethings is declared as an attribute but cannot be used as one in our context because this might actually happen, see for example `UniqueMorphism`.
     is_attribute := IsAttribute( object_function ) and Length( object_filter_list ) <= 2 and IsSpecializationOfFilter( IsAttributeStoringRep, CAP_INTERNAL_REPLACED_STRING_WITH_FILTER( Last( object_filter_list ) ) );
     
     if not is_attribute then

--- a/CAP/gap/TerminalCategory.gd
+++ b/CAP/gap/TerminalCategory.gd
@@ -86,13 +86,13 @@ DeclareGlobalFunction( "CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY" );
 #! @Description
 #!  The unique object in a terminal category with a single object.
 #! @Returns a &CAP; object
-DeclareAttribute( "UniqueObject",
+DeclareAttribute( "TerminalCategoryWithSingleObjectUniqueObject",
                   IsCapTerminalCategoryWithSingleObject );
 
 #! @Description
 #!  The unique morphism in a terminal category with a single object.
 #! @Returns a &CAP; morphism
-DeclareAttribute( "UniqueMorphism",
+DeclareAttribute( "TerminalCategoryWithSingleObjectUniqueMorphism",
                   IsCapTerminalCategoryWithSingleObject );
 
 #########################################

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -237,7 +237,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
     AddMorphismsOfExternalHom( T,
       function( T, object_1, object_2 )
         
-        return [ UniqueMorphism( T ) ];
+        return [ TerminalCategoryWithSingleObjectUniqueMorphism( T ) ];
         
     end );
     
@@ -252,7 +252,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
 end ) );
 
 ##
-InstallMethod( UniqueObject,
+InstallMethod( TerminalCategoryWithSingleObjectUniqueObject,
                [ IsCapTerminalCategoryWithSingleObject ],
                
   function( category )
@@ -265,13 +265,13 @@ InstallMethod( UniqueObject,
 end );
 
 ##
-InstallMethod( UniqueMorphism,
+InstallMethod( TerminalCategoryWithSingleObjectUniqueMorphism,
                [ IsCapTerminalCategoryWithSingleObject ],
                
   function( category )
     local object, morphism;
     
-    object := UniqueObject( category );
+    object := TerminalCategoryWithSingleObjectUniqueObject( category );
     
     morphism := MorphismConstructor( category, object, fail, object );
     
@@ -441,28 +441,28 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects, FunctionWithNamedArg
     AddDistinguishedObjectOfHomomorphismStructure( T,
       function( T )
         
-        return UniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
+        return TerminalCategoryWithSingleObjectUniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
         
     end );
     
     AddHomomorphismStructureOnObjects( T,
       function( T, source, target )
         
-        return UniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
+        return TerminalCategoryWithSingleObjectUniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
         
     end );
     
     AddHomomorphismStructureOnMorphismsWithGivenObjects( T,
       function( T, source, morphism_1, morphism_2, target )
         
-        return UniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
+        return TerminalCategoryWithSingleObjectUniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
         
     end );
     
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( T,
       function( T, distinguished_object, morphism, target )
         
-        return UniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
+        return TerminalCategoryWithSingleObjectUniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
         
     end );
     

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2024.09-03",
+Version := "2024.09-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/ProofAssistant.gi
+++ b/CompilerForCAP/gap/ProofAssistant.gi
@@ -2148,8 +2148,8 @@ BindGlobal( "CAP_JIT_INTERNAL_PROOF_ASSISTANT_ENHANCE_PROPOSITIONS", function ( 
     
     # use a terminal category for plausibility tests
     cat := TerminalCategoryWithSingleObject( );
-    obj := UniqueObject( cat );
-    mor := UniqueMorphism( cat );
+    obj := TerminalCategoryWithSingleObjectUniqueObject( cat );
+    mor := TerminalCategoryWithSingleObjectUniqueMorphism( cat );
     
     # CAP_JIT_INTERNAL_EXPR_CASE has no implementation because it should not be called by regular code
     old_CAP_JIT_INTERNAL_EXPR_CASE := CAP_JIT_INTERNAL_EXPR_CASE;


### PR DESCRIPTION
to avoid confusion with UniqueMorphism for thin categories