### PR TITLE
Replace operation_weights in CategoryConstructor by a better mechanism

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.10-08",
+Version := "2024.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoryConstructor.gd
+++ b/CAP/gap/CategoryConstructor.gd
@@ -36,10 +36,10 @@ DeclareInfoClass( "InfoCategoryConstructor" );
 #!  * `morphism_constructor` (optional): function added as an installation of <Ref Oper="MorphismConstructor" Label="for IsCapCategoryObject, IsObject, IsCapCategoryObject" /> to the category
 #!  * `morphism_datum` (optional): function added as an installation of <Ref Oper="MorphismDatum" Label="for IsCapCategoryMorphism" /> to the category
 #!  * `list_of_operations_to_install` (mandatory): a list of names of &CAP; operations which should be installed for the category
-#!  * `operation_weights` (optional): a record mapping operations in `list_of_operations_to_install` to their weights
 #!  * `is_computable` (optional): whether the category can decide `IsCongruentForMorphisms`
 #!  * `supports_empty_limits` (optional): whether the category supports empty lists in inputs to operations of limits and colimits
 #!  * `underlying_category_getter_string` (optional): see below
+#!  * `underlying_category` (optional): see below
 #!  * `underlying_object_getter_string` (optional): see below
 #!  * `underlying_morphism_getter_string` (optional): see below
 #!  * `top_object_getter_string` (optional): see below
@@ -53,8 +53,9 @@ DeclareInfoClass( "InfoCategoryConstructor" );
 #!
 #!  The values of the keys `create_func_*` should be either the string `"default`" or functions which accept the category and the name of a &CAP; operation
 #!  of the corresponding `return_type`. Values for return types occuring for operations in `list_of_operations_to_install` are mandatory.
-#!  The functions must return strings, which (after some replacements described below) will be evaluated and added as an installation of the corresponding operation to the category.
-#!  The value `"default"` chooses a suitable default string, see the implementation for details.
+#!  The functions must return either strings or pairs of a string and an integer:
+#!  The strings (after some replacements described below) will be evaluated and added as installations of the corresponding operations to the category with weights given by the integer (if provided).
+#!  The value `"default"` chooses a suitable default string (see the implementation for details) and gets the weights from `underlying_category`.
 #!  The following placeholders may be used in the strings and are replaced automatically:
 #!  * `operation_name` will be replaced by the name of the operation
 #!  * `input_arguments...` will be replaced by the `input_arguments_names` specified in the method name record (see <Ref Sect="Section_method_name_record_entries" />)

--- a/CAP/gap/DummyImplementations.gi
+++ b/CAP/gap/DummyImplementations.gi
@@ -166,13 +166,13 @@ InstallMethod( DummyCategory,
         
     fi;
     
-    dummy_function := { operation_name, dummy } -> """
+    dummy_function := { operation_name, dummy } -> Pair( """
         function ( input_arguments... )
             
             Error( "this is a dummy category without actual implementation" );
             
         end
-    """;
+    """, 1 );
     
     category_constructor_options.create_func_bool := dummy_function;
     category_constructor_options.create_func_object := dummy_function;

--- a/CAP/gap/ReinterpretationOfCategory.gi
+++ b/CAP/gap/ReinterpretationOfCategory.gi
@@ -85,6 +85,7 @@ InstallMethod( ReinterpretationOfCategory,
     # the methods for ModelingObject et al. will be installed later once we have a category instance filter
     category_constructor_options := rec(
         underlying_category_getter_string := "ModelingCategory",
+        underlying_category := C,
         underlying_object_getter_string := "ModelingObject",
         underlying_morphism_getter_string := "ModelingMorphism",
         top_object_getter_string := "ReinterpretationOfObject",
@@ -137,14 +138,6 @@ InstallMethod( ReinterpretationOfCategory,
     fi;
     
     category_constructor_options.list_of_operations_to_install := list_of_operations_to_install;
-    
-    category_constructor_options.operation_weights := rec( );
-    
-    for operation in list_of_operations_to_install do
-        
-        category_constructor_options.operation_weights.(operation) := OperationWeight( C, operation );
-        
-    od;
     
     if IsBound( C!.supports_empty_limits ) then
         

--- a/CAP/gap/TerminalCategory.gi
+++ b/CAP/gap/TerminalCategory.gi
@@ -24,7 +24,7 @@ BindGlobal( "IsCapTerminalCategoryMorphismRep", IsMorphismInCapTerminalCategoryW
 
 InstallGlobalFunction( CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY,
   function( input_record )
-    local completed_record, list_of_operations_to_install, skip, info, properties, excluded_properties, T, operation_name;
+    local completed_record, list_of_operations_to_install, skip, info, properties, excluded_properties, T, operation_name, operation;
     
     completed_record := ShallowCopy( input_record );
     
@@ -104,7 +104,7 @@ InstallGlobalFunction( CAP_INTERNAL_CONSTRUCTOR_FOR_TERMINAL_CATEGORY,
         ## equality of source and target is part of the specification of the input and checked by the pre-function
         return true;
         
-    end );
+    end, 1 );
     
     return T;
     
@@ -147,13 +147,13 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
     create_func_object :=
         function( name, T )
             
-            return """
+            return Pair( """
                 function( input_arguments... )
                     
                     return ObjectConstructor( cat, fail );
                     
                 end
-            """;
+            """, 1 );
             
         end;
     
@@ -161,13 +161,13 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
     create_func_morphism :=
         function( name, T )
             
-            return """
+            return Pair( """
                 function( input_arguments... )
                     
                     return MorphismConstructor( cat, top_source, fail, top_range );
                     
                 end
-            """;
+            """, 1 );
             
         end;
     
@@ -211,7 +211,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
         
         return true;
         
-    end );
+    end, 1 );
     
     ##
     AddIsWellDefinedForMorphisms( T,
@@ -219,7 +219,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
         
         return true;
         
-    end );
+    end, 1 );
     
     ##
     AddIsEqualForObjects( T,
@@ -227,7 +227,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
         
         return true;
         
-    end );
+    end, 1 );
     
     ##
     AddIsEqualForMorphisms( T,
@@ -235,7 +235,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
         
         return true;
         
-    end );
+    end, 1 );
     
     ##
     AddMorphismsOfExternalHom( T,
@@ -243,7 +243,7 @@ InstallGlobalFunction( TerminalCategoryWithSingleObject, FunctionWithNamedArgume
         
         return [ TerminalCategoryWithSingleObjectUniqueMorphism( T ) ];
         
-    end );
+    end, 2 );
     
     if CAP_NAMED_ARGUMENTS.FinalizeCategory then
         
@@ -321,13 +321,13 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects, FunctionWithNamedArg
     create_func_object :=
         function( name, T )
             
-            return """
+            return Pair( """
                 function( input_arguments... )
                     
                     return ObjectConstructor( cat, "operation_name" );
                     
                 end
-            """;
+            """, 1 );
             
         end;
     
@@ -335,13 +335,13 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects, FunctionWithNamedArg
     create_func_morphism :=
         function( name, T )
             
-            return """
+            return Pair( """
                 function( input_arguments... )
                     
                     return MorphismConstructor( cat, top_source, "operation_name", top_range );
                     
                 end
-            """;
+            """, 1 );
             
         end;
     
@@ -432,7 +432,7 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects, FunctionWithNamedArg
         
         return true;
         
-    end );
+    end, 1 );
     
     ##
     AddSomeIsomorphismBetweenObjects( T,
@@ -440,42 +440,42 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects, FunctionWithNamedArg
         
         return MorphismConstructor( T, object_1, "SomeIsomorphismBetweenObjects", object_2 );
         
-    end );
+    end, 1 );
     
     AddDistinguishedObjectOfHomomorphismStructure( T,
       function( T )
         
         return TerminalCategoryWithSingleObjectUniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
         
-    end );
+    end, 2 );
     
     AddHomomorphismStructureOnObjects( T,
       function( T, source, target )
         
         return TerminalCategoryWithSingleObjectUniqueObject( RangeCategoryOfHomomorphismStructure( T ) );
         
-    end );
+    end, 2 );
     
     AddHomomorphismStructureOnMorphismsWithGivenObjects( T,
       function( T, source, morphism_1, morphism_2, target )
         
         return TerminalCategoryWithSingleObjectUniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
         
-    end );
+    end, 2 );
     
     AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( T,
       function( T, distinguished_object, morphism, target )
         
         return TerminalCategoryWithSingleObjectUniqueMorphism( RangeCategoryOfHomomorphismStructure( T ) );
         
-    end );
+    end, 2 );
     
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( T,
       function( T, source, target, iota  )
         
         return MorphismConstructor( T, source, "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism", target );
         
-    end );
+    end, 1 );
     
     if CAP_NAMED_ARGUMENTS.FinalizeCategory then
         

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2024.10-06",
+Version := "2024.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/tst/300_proof_AdditiveClosure_hom_structure.tst
+++ b/CompilerForCAP/tst/300_proof_AdditiveClosure_hom_structure.tst
@@ -33,9 +33,7 @@ gap> dummy_range := DummyCategory( rec(
 >     properties := [
 >         "IsAdditiveCategory",
 >     ],
-> ) : FinalizeCategory := false );;
-gap> AddMorphismBetweenDirectSums( dummy_range, { cat, source_diagram, matrix, target_diagram } -> fail );
-gap> Finalize( dummy_range );;
+> ) );;
 
 #
 gap> dummy := DummyCategory( rec(


### PR DESCRIPTION
When using the string "default" for create_func_\*, one must now set the option `underlying_category`, from which the weight is determined. If create_func_\* is a function, one can (optionally) set a weight by returning a pair of a string and an integer (instead of only a string).

@mohamed-barakat This PR partially implements a suggestion you had: You suggested to pass an underlying category to CategoryConstructor from which the weights can be taken. I argued that this does not make sense in general. However, while working with the weights, I noticed that it indeed does make sense in a specific case, namely when using the string "default" for create_func_\*. This PR now requires to set the option `underlying_category` when using the string "default". This sets the correct weights, which probably requires changes like recompiling code. Please tell me when I can merge, i.e. when you have to time to adjust things in CategoricalTowers.