### PR TITLE
Defer triggering derivations until `Finalize`

### DIFF
--- a/ActionsForCAP/PackageInfo.g
+++ b/ActionsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ActionsForCAP",
 Subtitle := "Actions and Coactions for CAP",
-Version := "2024.08-02",
+Version := "2024.09-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ActionsForCAP/examples/IndirectionTest.g
+++ b/ActionsForCAP/examples/IndirectionTest.g
@@ -91,7 +91,6 @@ category_with_attributes_record := rec(
 triple := EnhancementWithAttributes( category_with_attributes_record );;
 indirection_category := triple[1];;
 SetIsAbelianCategory( indirection_category, true );;
-Reevaluate( indirection_category!.derivations_weight_list );
 AddIsEqualForObjects( indirection_category, function( cat, obj1, obj2 ) return UnderlyingCell( obj1 ) = UnderlyingCell( obj2 ); end );;
 AddIsEqualForMorphisms( indirection_category, function( cat, mor1, mor2 ) return IsIdenticalObj( mor1, mor2 ); end );;
 AddIsCongruentForMorphisms( indirection_category, function( cat, mor1, mor2 ) return UnderlyingCell( mor1 ) = UnderlyingCell( mor2 ); end );;

--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.09-24",
+Version := "2024.09-25",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Derivations.gi
+++ b/CAP/gap/Derivations.gi
@@ -538,13 +538,6 @@ function( owl, op_name, new_weight )
     owl!.operation_weights.( op_name ) := new_weight;
     owl!.operation_derivations.( op_name ) := fail;
     
-    # if the weight has not changed, there is no need to re-trigger the chain of derivations
-    if new_weight <> current_weight then
-        
-        InstallDerivationsUsingOperation( owl, op_name );
-        
-    fi;
-    
 end );
 
 InstallMethod( PrintDerivationTree,

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -47,15 +47,6 @@ InstallMethod( AddCapOperation,
         
     fi;
     
-    # prepare for the checks in Finalize
-    if not IsBound( category!.initially_known_categorical_properties ) then
-        
-        category!.initially_known_categorical_properties := ShallowCopy( ListKnownCategoricalProperties( category ) );
-        
-        InstallDerivationsUsingOperation( category!.derivations_weight_list, "none" );
-        
-    fi;
-    
     if weight = -1 then
         weight := 100;
     fi;

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2024.09-08",
+Version := "2024.09-09",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gi
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gi
@@ -1070,7 +1070,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         SetRangeCategoryOfHomomorphismStructure( category, range_category );
         SetIsEquippedWithHomomorphismStructure( category, true );
         
-        if ForAll( [ "DirectSum" ], f -> CanCompute( range_category, f ) ) and
+        if (ForAll( [ "DirectSum" ], f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category )) and
            ForAll( [ "HomomorphismStructureOnObjects" ], f -> CanCompute( underlying_category, f ) ) then
             
             ##
@@ -1090,7 +1090,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         fi;
         
         # legacy
-        if ForAll( [ "MorphismBetweenDirectSumsWithGivenDirectSums" ], f -> CanCompute( range_category, f ) ) and
+        if (ForAll( [ "MorphismBetweenDirectSumsWithGivenDirectSums" ], f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category )) and
            ForAll( [ "HomomorphismStructureOnMorphismsWithGivenObjects" ], f -> CanCompute( underlying_category, f ) ) and
            not (IsBound( range_category!.supports_empty_limits ) and range_category!.supports_empty_limits = true) then
             
@@ -1130,7 +1130,7 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             
         fi;
         
-        if ForAll( [ "MorphismBetweenDirectSumsWithGivenDirectSums" ], f -> CanCompute( range_category, f ) )
+        if (ForAll( [ "MorphismBetweenDirectSumsWithGivenDirectSums" ], f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category ))
            and ForAll( [ "HomomorphismStructureOnMorphismsWithGivenObjects" ], f -> CanCompute( underlying_category, f ) )
            and IsBound( range_category!.supports_empty_limits ) and range_category!.supports_empty_limits = true then
             
@@ -1208,9 +1208,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             
         fi;
         
-        if ForAll( [ "UniversalMorphismIntoZeroObject",
+        if (ForAll( [ "UniversalMorphismIntoZeroObject",
                      "UniversalMorphismIntoDirectSum" ],
-                     f -> CanCompute( range_category, f ) ) and
+                     f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category )) and
            ForAll( [ "DistinguishedObjectOfHomomorphismStructure",
                          "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" ],
                          f -> CanCompute( underlying_category, f ) ) and
@@ -1245,8 +1245,8 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
             
         fi;
         
-        if ForAll( [ "UniversalMorphismIntoDirectSum" ],
-                     f -> CanCompute( range_category, f ) ) and
+        if (ForAll( [ "UniversalMorphismIntoDirectSum" ],
+                     f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category )) and
            ForAll( [ "DistinguishedObjectOfHomomorphismStructure",
                          "InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure" ],
                          f -> CanCompute( underlying_category, f ) ) and
@@ -1297,9 +1297,9 @@ InstallGlobalFunction( INSTALL_FUNCTIONS_FOR_ADDITIVE_CLOSURE,
         if ForAll( [ "HomomorphismStructureOnObjects",
                      "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism" ],
                      f -> CanCompute( underlying_category, f ) ) and
-           ForAll( [ "PreCompose",
+           (ForAll( [ "PreCompose",
                          "ProjectionInFactorOfDirectSum" ],
-                         f -> CanCompute( range_category, f ) ) then
+                         f -> CanCompute( range_category, f ) ) or IsIdenticalObj( range_category, category )) then
             
             ##
             AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( category,

--- a/FreydCategoriesForCAP/gap/CategoryOfRows.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows.gi
@@ -41,9 +41,6 @@ InstallMethod( CategoryOfRows,
         
         SetIsRigidSymmetricCoclosedMonoidalCategory( cat, true );
         
-        # since methods have been added before, we have to reevaluate the derivations
-        Reevaluate( cat!.derivations_weight_list );
-        
     fi;
     
     INSTALL_FUNCTIONS_FOR_CATEGORY_OF_ROWS( cat );

--- a/FreydCategoriesForCAP/gap/CategoryOfRows_as_AdditiveClosure_RingAsCategory.gi
+++ b/FreydCategoriesForCAP/gap/CategoryOfRows_as_AdditiveClosure_RingAsCategory.gi
@@ -30,8 +30,7 @@ InstallMethod( CategoryOfRows_as_AdditiveClosure_RingAsCategory,
     # These ring properties should actually be propagated to some categorical properties of `ring_as_category`
     # which the AdditiveClosure can use generically.
     # However, such categorical properties do not (yet) exist, so we have to set the categorical properties
-    # a posteriori here. Afterwards, we have to reevaluate the derivations because they might have changed
-    # by setting the properties.
+    # a posteriori here.
     if HasHasInvariantBasisProperty( homalg_ring ) and HasInvariantBasisProperty( homalg_ring ) then
         
         SetIsSkeletalCategory( add, true );
@@ -49,8 +48,6 @@ InstallMethod( CategoryOfRows_as_AdditiveClosure_RingAsCategory,
         SetIsAbelianCategoryWithEnoughInjectives( add, true );
         
     fi;
-    
-    Reevaluate( add!.derivations_weight_list );
     
     Finalize( add );
     


### PR DESCRIPTION
This has already been proposed a long time ago in https://github.com/homalg-project/CAP_project/issues/144. There is only one drawback: Applying `CanCompute` to unfinalized categories now only takes primitive operations into account. This might require some minor changes as can be seen in `AdditiveClosure.gi`.