### PR TITLE
Move computability check to the end of `Finalize`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2024.09-25",
+Version := "2024.09-26",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/Finalize.gi
+++ b/CAP/gap/Finalize.gi
@@ -306,14 +306,6 @@ InstallMethod( Finalize,
         
     fi;
     
-    # Warn about categories marked as being computable but not having an implementation of IsCongruentForMorphisms.
-    # Since IsCongruentForMorphisms currently is derived from IsEqualForMorphisms, the latter also has to be taken into account.
-    if category!.is_computable and not CanCompute( category, "IsEqualForMorphisms" ) and not CanCompute( category, "IsCongruentForMorphisms") then
-        
-        Print( "WARNING: The category with name \"", Name( category ), "\" is marked as being computable but has no implementation of `IsCongruentForMorphisms`.\n" );
-        
-    fi;
-    
     #= comment for Julia
     if ValueOption( "disable_derivations" ) = true then
         
@@ -514,6 +506,12 @@ InstallMethod( Finalize,
         #= comment for Julia
         REORDER_METHODS_SUSPENSION_LEVEL := original_REORDER_METHODS_SUSPENSION_LEVEL;
         # =#
+        
+    fi;
+    
+    if category!.is_computable and not CanCompute( category, "IsCongruentForMorphisms" ) then
+        
+        Print( "WARNING: The category with name \"", Name( category ), "\" is marked as being computable but has no implementation of `IsCongruentForMorphisms`.\n" );
         
     fi;
     


### PR DESCRIPTION
`IsCongruentForMorphisms` can be installed by a derivation.
