### PR TITLE
SetRangeCategoryOfHomomorphismStructure in ReinterpretationOfCategory if it is set for its input

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2025.01-01",
+Version := "2025.02-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ReinterpretationOfCategory.gi
+++ b/CAP/gap/ReinterpretationOfCategory.gi
@@ -256,7 +256,7 @@ InstallMethod( ReinterpretationOfCategory,
         "InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism",
     ];
     
-    if HasRangeCategoryOfHomomorphismStructure( C ) and not IsEmpty( Intersection( list_of_operations_to_install, operations_of_homomorphism_structure ) ) then
+    if HasRangeCategoryOfHomomorphismStructure( C ) then
         
         HC := RangeCategoryOfHomomorphismStructure( C );
         
@@ -266,6 +266,17 @@ InstallMethod( ReinterpretationOfCategory,
             # so the range of the homomorphism structure of D should be D itself.
             # This prevents infinite recursions.
             HC := D;
+            
+        fi;
+        
+        SetRangeCategoryOfHomomorphismStructure( D, HC );
+        SetIsEquippedWithHomomorphismStructure( D, true );
+        
+    fi;
+    
+    if HasRangeCategoryOfHomomorphismStructure( C ) and not IsEmpty( Intersection( list_of_operations_to_install, operations_of_homomorphism_structure ) ) then
+        
+        if IsIdenticalObj( D, HC ) then
             
             # prepare for ExtendRangeOfHomomorphismStructureByFullEmbedding
             object_function := function ( C, HC, object )
@@ -313,9 +324,6 @@ InstallMethod( ReinterpretationOfCategory,
             ExtendRangeOfHomomorphismStructureByIdentityAsFullEmbedding( C );
             
         fi;
-        
-        SetRangeCategoryOfHomomorphismStructure( D, HC );
-        SetIsEquippedWithHomomorphismStructure( D, true );
         
         if "DistinguishedObjectOfHomomorphismStructure" in list_of_operations_to_install then
             AddDistinguishedObjectOfHomomorphismStructure( D,


### PR DESCRIPTION
making ReinterpretationOfCategory behave more like its input

this covers the cases when the Hom-structure is derived from
* MorphismsOfExternalHom, or
* BasisOfExternalHom and CoefficientsOfMorphism
