### PR TITLE
added derivation methods for `WeakKernelEmbedding` and `WeakCokernelProjection`

### DIFF
--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2025.05-01",
+Version := "2025.06-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
+++ b/FreydCategoriesForCAP/gap/FreydCategoriesDerivedMethods.gi
@@ -350,6 +350,68 @@ AddDerivationToCAP( WeakBiPushout,
     
 end );
 
+##
+AddDerivationToCAP( WeakKernelEmbedding,
+                    "WeakKernelEmbedding in additive closures of categories with finite number of objects and homomorphism structure",
+                    [ [ ObjectConstructor, 2 ],
+                      [ BasisOfSolutionsOfHomogeneousLinearSystemInLinearCategory, 2 ],
+                      [ IdentityMorphism, 2 ],
+                      [ SetOfObjectsOfCategory, 1, UnderlyingCategory ],
+                      [ DirectSum, 1 ],
+                      [ UniversalMorphismFromDirectSumWithGivenDirectSum, 1 ]
+                      ],
+                    
+  function ( cat, phi )
+    local underlying_cat, objs, tau, diagram, S;
+    
+    underlying_cat := UnderlyingCategory( cat );
+    
+    objs := List( SetOfObjectsOfCategory( underlying_cat ), o -> ObjectConstructor( cat, [ o ] ) );
+    
+    tau := Concatenation( List( objs,
+            o -> Concatenation( BasisOfSolutionsOfHomogeneousLinearSystemInLinearCategory( cat, [ [  IdentityMorphism( cat, o ) ] ], [ [ phi ] ] ) ) ) );
+    
+    diagram := List( tau, m -> Source( m ) );
+    
+    S := DirectSum( cat, diagram );
+    
+    return UniversalMorphismFromDirectSumWithGivenDirectSum( cat, diagram, Source( phi ), tau, S );
+    
+  end : CategoryGetters := rec( underlying_cat := UnderlyingCategory ),
+        CategoryFilter := cat -> HasUnderlyingCategory( cat ) and HasIsObjectFiniteCategory( UnderlyingCategory( cat ) ) and IsObjectFiniteCategory( UnderlyingCategory( cat ) )
+);
+
+##
+AddDerivationToCAP( WeakCokernelProjection,
+                    "WeakCokernelProjection in additive closures of categories with finite number of objects and homomorphism structure",
+                    [ [ ObjectConstructor, 2 ],
+                      [ BasisOfSolutionsOfHomogeneousLinearSystemInLinearCategory, 2 ],
+                      [ IdentityMorphism, 2 ],
+                      [ SetOfObjectsOfCategory, 1, UnderlyingCategory ],
+                      [ DirectSum, 1 ],
+                      [ UniversalMorphismIntoDirectSumWithGivenDirectSum, 1 ]
+                      ],
+                    
+  function ( cat, phi )
+    local underlying_cat, objs, tau, diagram, S;
+    
+    underlying_cat := UnderlyingCategory( cat );
+    
+    objs := List( SetOfObjectsOfCategory( underlying_cat ), o -> ObjectConstructor( cat, [ o ] ) );
+    
+    tau := Concatenation( List( objs,
+              o -> Concatenation( BasisOfSolutionsOfHomogeneousLinearSystemInLinearCategory( cat, [ [ phi ] ], [ [  IdentityMorphism( cat, o ) ] ]  ) ) ) );
+    
+    diagram := List( tau, m -> Target( m ) );
+    
+    S := DirectSum( cat, diagram );
+    
+    return UniversalMorphismIntoDirectSumWithGivenDirectSum( cat, diagram, Target( phi ), tau, S );
+    
+  end : CategoryGetters := rec( underlying_cat := UnderlyingCategory ),
+        CategoryFilter := cat -> HasUnderlyingCategory( cat ) and HasIsObjectFiniteCategory( UnderlyingCategory( cat ) ) and IsObjectFiniteCategory( UnderlyingCategory( cat ) )
+);
+
 ## Final derivations
 
 ##


### PR DESCRIPTION
in additive categories where the underlying category has finite number of objects and is equipped with homomorphism structure.

Bump version to v2025.06-01