### PR TITLE
the the -> the

### DIFF
--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2025.02-01",
+Version := "2025.06-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CompilerForCAP/gap/Tools.gd
+++ b/CompilerForCAP/gap/Tools.gd
@@ -106,7 +106,7 @@ DeclareGlobalFunction( "CapJitAddBinding" );
 DeclareGlobalFunction( "CapJitValueOfBinding" );
 
 #! @Description
-#!   Unbinds the the binding named <A>name</A> from a syntax tree <A>bindings</A> of type `FVAR_BINDING_SEQ`.
+#!   Unbinds the binding named <A>name</A> from a syntax tree <A>bindings</A> of type `FVAR_BINDING_SEQ`.
 #! @Arguments bindings, name
 DeclareGlobalFunction( "CapJitUnbindBinding" );
 

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2025.06-01",
+Version := "2025.06-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/FreydCategoriesForCAP/gap/AdditiveClosure.gd
+++ b/FreydCategoriesForCAP/gap/AdditiveClosure.gd
@@ -194,7 +194,7 @@ CapJitAddTypeSignature( "MorphismMatrix", [ IsAdditiveClosureMorphism ], functio
 end );
 
 #! @Description
-#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the source.
+#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the source.
 #! @Arguments alpha
 #! @Returns a non-negative integer
 DeclareAttribute( "NumberRows",
@@ -202,7 +202,7 @@ DeclareAttribute( "NumberRows",
 CapJitAddTypeSignature( "NumberRows", [ IsAdditiveClosureMorphism ], IsInt );
 
 #! @Description
-#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the the range.
+#! The argument is a morphism $\alpha:A\to B$ between formal direct sums. The output is the number of summands of the range.
 #! @Arguments alpha
 #! @Returns a non-negative integer
 DeclareAttribute( "NumberColumns",


### PR DESCRIPTION
Correct the unimportant typo `the the`.