### PR TITLE
Clarify category of source/range objects in `ReinterpretationOfMorphism`

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2025.06-06",
+Version := "2025.06-07",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ReinterpretationOfCategory.gd
+++ b/CAP/gap/ReinterpretationOfCategory.gd
@@ -249,8 +249,8 @@ CapJitAddTypeSignature( "ModelingMorphism", [ IsCapCategory, IsCapCategoryMorphi
 end );
 
 #! @Description
-#!  Returns the reinterpretation in `R` with given source and range of a morphism <A>mor</A> in `ModelingCategory`(<A>R</A>).
-#! @Arguments R, source, obj, range
+#!  Returns the reinterpretation in `R` with given source and range in `R` of a morphism <A>mor</A> in `ModelingCategory`(<A>R</A>).
+#! @Arguments R, source, mor, range
 #! @Returns a CAP category morphism
 DeclareOperation( "ReinterpretationOfMorphism", [ IsCapCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsCapCategoryObject ] );
 


### PR DESCRIPTION
I become constantly confused to which category `source` and `range` in a call to `ReinterpretationOfMorphism` belong to and the documentation does not clearly state this.