### PR TITLE
Use the underlying category of matrices of a semisimple category in a test

### DIFF
--- a/GroupRepresentationsForCAP/PackageInfo.g
+++ b/GroupRepresentationsForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GroupRepresentationsForCAP",
 Subtitle := "Skeletal category of group representations for CAP",
-Version := "2025.07-01",
+Version := "2025.07-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/GroupRepresentationsForCAP/examples/SemisimpleCategoryTest.g
+++ b/GroupRepresentationsForCAP/examples/SemisimpleCategoryTest.g
@@ -38,6 +38,12 @@ beta := VectorSpaceMorphism( M3, matrix_2, M2 );
 
 mor := SemisimpleCategoryMorphism( a, [ [ MorphismIntoZeroObject( M1 ), chi_1 ], [ alpha, chi_2 ], [ beta, chi_3 ] ], b  );
 
+TensorProductOnObjects( a, b );
+
+tp_mor := TensorProductOnMorphisms( mor, mor );
+
+Display( tp_mor );
+
 #AssociatorLeftToRight( b, b, b );
 
 L := [ ob1, ob2, ob3 ];

--- a/GroupRepresentationsForCAP/examples/SemisimpleCategoryTest.g
+++ b/GroupRepresentationsForCAP/examples/SemisimpleCategoryTest.g
@@ -1,5 +1,6 @@
 LoadPackage( "GroupRepresentationsForCAP" );
 LoadPackage( "RingsForHomalg" );
+
 Q := HomalgFieldOfRationalsInSingular();
 
 G := SymmetricGroup( 3 );
@@ -11,28 +12,31 @@ irr := Irr( G );
 membership_function := IsGIrreducibleObject;
 
 chi_1 := GIrreducibleObject( irr[1] );
-
 chi_2 := GIrreducibleObject( irr[2] );
-
 chi_3 := GIrreducibleObject( irr[3] );
 
 semisimple_cat := SemisimpleCategory( Q, membership_function, chi_3, "S3Ass.g", true );
 
-a := SemisimpleCategoryObject( [ [ 1, chi_1 ], [ 2, chi_2 ], [ 3, chi_3 ] ], semisimple_cat );
+ob1 := SemisimpleCategoryObject( [ [ 1, chi_1 ] ], semisimple_cat );
+ob2 := SemisimpleCategoryObject( [ [ 1, chi_2 ] ], semisimple_cat );
+ob3 := SemisimpleCategoryObject( [ [ 1, chi_3 ] ], semisimple_cat );
 
+Qmat := UnderlyingCategoryForSemisimpleCategory( semisimple_cat );
+
+a := SemisimpleCategoryObject( [ [ 1, chi_1 ], [ 2, chi_2 ], [ 3, chi_3 ] ], semisimple_cat );
 b := SemisimpleCategoryObject( [ [ 1, chi_2 ], [ 2, chi_3 ] ], semisimple_cat );
 
-alpha := VectorSpaceMorphism( VectorSpaceObject( 2, Q ), HomalgMatrix( [ [ 1 ], [ -1 ] ], 2, 1, Q ), VectorSpaceObject( 1, Q ) );
+M1 := MatrixCategoryObject( Qmat, 1 );
+M2 := MatrixCategoryObject( Qmat, 2 );
+M3 := MatrixCategoryObject( Qmat, 3 );
 
-beta := VectorSpaceMorphism( VectorSpaceObject( 3, Q ), HomalgMatrix( [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ], 3, 2, Q ), VectorSpaceObject( 2, Q ) );
+matrix_1 := HomalgMatrix( [ [ 1 ], [ -1 ] ], 2, 1, Q );
+matrix_2 := HomalgMatrix( [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ], 3, 2, Q );
 
-mor := SemisimpleCategoryMorphism( a, [ [ MorphismIntoZeroObject( VectorSpaceObject( 1, Q ) ), chi_1 ], [ alpha, chi_2 ], [ beta, chi_3 ] ], b  );
+alpha := VectorSpaceMorphism( M2, matrix_1, M1 );
+beta := VectorSpaceMorphism( M3, matrix_2, M2 );
 
-ob1 := SemisimpleCategoryObject( [ [ 1, chi_1 ] ], semisimple_cat );
-
-ob2 := SemisimpleCategoryObject( [ [ 1, chi_2 ] ], semisimple_cat );
-
-ob3 := SemisimpleCategoryObject( [ [ 1, chi_3 ] ], semisimple_cat );
+mor := SemisimpleCategoryMorphism( a, [ [ MorphismIntoZeroObject( M1 ), chi_1 ], [ alpha, chi_2 ], [ beta, chi_3 ] ], b  );
 
 #AssociatorLeftToRight( b, b, b );
 


### PR DESCRIPTION
I want to test Sepp's `TensorProductOn*` against mine to check for bugs, and appending

```gap
 TensorProductOnMorphisms( mor, mor );
```
to `GroupRepresentationsForCAP/examples/SemisimpleCategoryTest.g` previously resulted in errors, because the matrix categories mismatched.