### PR TITLE
Install \[\] method for FiniteSkeletalDiscreteCategories

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2025.07-08",
+Version := "2025.07-09",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/FiniteSkeletalDiscreteCategory.g
+++ b/CAP/examples/FiniteSkeletalDiscreteCategory.g
@@ -15,7 +15,7 @@ ObjectDatum( one ) = 1;
 #! true
 Display( one );
 #! 1
-IsEqualForObjects( one, D.1 );
+IsEqualForObjects( one, D[1] );
 #! true
 id_one := IdentityMorphism( D, one );
 #! <An identity morphism in FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] )>

--- a/CAP/gap/FiniteSkeletalDiscreteCategory.gi
+++ b/CAP/gap/FiniteSkeletalDiscreteCategory.gi
@@ -169,15 +169,13 @@ end ) );
 #################################
 
 ##
-InstallOtherMethod( \/,
-               "for a string and a finite skeletal discrete category",
-               [ IsStringRep, IsFiniteSkeletalDiscreteCategory ],
+InstallOtherMethod( \[\],
+               "for a finite skeletal discrete category and a positive integer",
+               [ IsFiniteSkeletalDiscreteCategory, IsInt ],
                
-  function ( string, D )
-    local index, objects;
-    
-    index := Int( string );
-    
+  function ( D, index )
+    local objects;
+
     objects := SetOfObjectsOfCategory( D );
     
     if index <= 0 or index > Length( objects ) then
@@ -190,18 +188,6 @@ InstallOtherMethod( \/,
     return objects[index];
     
 end );
-
-#= comment for Julia
-InstallMethod( \.,
-               "for a finite skeletal discrete category and a positive integer",
-               [ IsFiniteSkeletalDiscreteCategory, IsInt ],
-               
-  function ( D, index_as_string )
-    
-    return NameRNam( index_as_string )  / D;
-    
-end );
-# =#
 
 #################################
 #


### PR DESCRIPTION
and adjust a test file:

```
D := FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] );
one := ObjectConstructor( D, 1 );
IsEqualForObjects( one, D.1 ) ==> IsEqualForObjects( one, D[1] );
```
because D.1 raises a ParseError in Julia (object.integer is not allowed in Julia, however object.some_symbol or object."some_string" are allowed)

Bump CAP to v2025.07-09