### PR TITLE
Add `G2J:julia-only` marker to `read.g` in `LinearClosuresForCAP`

### DIFF
--- a/LinearClosuresForCAP/PackageInfo.g
+++ b/LinearClosuresForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearClosuresForCAP",
 Subtitle := "Linear closures",
-Version := "2025.08-02",
+Version := "2025.08-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearClosuresForCAP/read.g
+++ b/LinearClosuresForCAP/read.g
@@ -9,3 +9,7 @@ ReadPackage( "LinearClosuresForCAP", "gap/LinearClosure.gi" );
 #= comment for Julia (Groups are not available in Julia)
 ReadPackage( "LinearClosuresForCAP", "gap/LinearClosureForGroupAsCategory.gi" );
 # =#
+
+# In GAP, `gap/HomomorphismStructure.gi` is loaded only if `FinSetsForCAP` is marked for loading (see PackageInfo.g).
+# In Julia, `FinSetsForCAP` is always a dependency, so we can include this file unconditionally.
+#% G2J:julia-only ReadPackage( "LinearClosuresForCAP", "gap/HomomorphismStructure.gi" );


### PR DESCRIPTION
 to ensure `gap/HomomorphismStructure.gi` is loaded in Julia.

In GAP, the file is loaded only if `FinSetsForCAP` is marked for loading, but in Julia it is always a dependency. This marker comment allows the GAP-to-Julia translator to convert the commented line into valid Julia code.

Bump `LinearClosuresForCAP` to v2025.08-03.