### PR TITLE
Declare CallFuncListAtRuntime as a synonym of CallFuncList.

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2025.09-03",
+Version := "2025.09-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -352,19 +352,19 @@ InstallGlobalFunction( CAP_INTERNAL_INSTALL_ADDS_FROM_RECORD,
             
             if filter_list[2] in [ "object", "morphism", "twocell" ] then
                 
-                get_convenience_function := oper -> { arg } -> CallFuncList( oper, Concatenation( [ CapCategory( arg[1] ) ], arg ) );
+                get_convenience_function := oper -> { arg } -> CallFuncListAtRuntime( oper, Concatenation( [ CapCategory( arg[1] ) ], arg ) );
                 
             elif filter_list[2] = "list_of_objects" or filter_list[2] = "list_of_morphisms" then
                 
-                get_convenience_function := oper -> { arg } -> CallFuncList( oper, Concatenation( [ CapCategory( arg[1][1] ) ], arg ) );
+                get_convenience_function := oper -> { arg } -> CallFuncListAtRuntime( oper, Concatenation( [ CapCategory( arg[1][1] ) ], arg ) );
                 
             elif filter_list[3] in [ "object", "morphism", "twocell" ] then
                 
-                get_convenience_function := oper -> { arg } -> CallFuncList( oper, Concatenation( [ CapCategory( arg[2] ) ], arg ) );
+                get_convenience_function := oper -> { arg } -> CallFuncListAtRuntime( oper, Concatenation( [ CapCategory( arg[2] ) ], arg ) );
                 
             elif filter_list[4] = "list_of_objects" or filter_list[4] = "list_of_morphisms" then
                 
-                get_convenience_function := oper -> { arg } -> CallFuncList( oper, Concatenation( [ CapCategory( arg[3][1] ) ], arg ) );
+                get_convenience_function := oper -> { arg } -> CallFuncListAtRuntime( oper, Concatenation( [ CapCategory( arg[3][1] ) ], arg ) );
                 
             else
                 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -431,3 +431,8 @@ InstallGlobalFunction( BigInt, IdFunc );
 #!   Shorthand for `ObjectifyWithAttributes( rec( ), type, [attribute1, value1, ...] )`.
 #! @Arguments type, [attribute1, value1, ...]
 DeclareGlobalFunction( "CreateGapObjectWithAttributes" );
+
+#= comment for Julia
+# This is relevant only in Julia to avoid world-age conflicts
+DeclareSynonym( "CallFuncListAtRuntime", CallFuncList );
+# =#


### PR DESCRIPTION
This is used to avoid Julia world-age conflicts by delegating calls to Base.invokelatest(func, arg...).
Use it for installing convenience methods for the CAP operations

bump CAP to v2025.09-04
