### PR TITLE
Cache subgroup filter to avoid resolver loop

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2026.05-04",
+Version := "2026.05-05",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gi
+++ b/CAP/gap/ToolsForCategories.gi
@@ -1208,19 +1208,26 @@ InstallGlobalFunction( CapJitDataTypeOfGroup, function ( group )
     
 end );
 
+## Cache the filter object so that repeated calls to CapJitDataTypeOfSubgroup
+## return data_type records with an identical filter object. GAP compares filters
+## by identity, so creating `IsGroup and HasParent` anew each call would produce
+## non-equal data_type records even when they represent the same type, causing
+## the compiler's resolving phase to loop forever.
+BindGlobal( "CAP_JIT_INTERNAL_SUBGROUP_FILTER", IsGroup and HasParent );
+
 InstallGlobalFunction( CapJitDataTypeOfSubgroup, function ( group )
   local type;
     
     if IsIdenticalObj( group, false ) then
         
         type := rec(
-            filter := IsGroup and HasParent,
+            filter := CAP_JIT_INTERNAL_SUBGROUP_FILTER,
         );
         
     else
         
         type := rec(
-            filter := IsGroup and HasParent,
+            filter := CAP_JIT_INTERNAL_SUBGROUP_FILTER,
             group := group, ## do not call this parentgroup
         );
         


### PR DESCRIPTION
Bind a single global filter object for subgroups and reuse it in CapJitDataTypeOfSubgroup. GAP compares filters by identity; constructing a new composite filter per call led to non-equal data_type records and an infinite loop during the compiler’s resolving phase.

Bump version of CAP to V2026.05-05