### PR TITLE
Add additive functor data builder with caching

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2026.05-06",
+Version := "2026.05-07",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CategoriesCategory.gd
+++ b/CAP/gap/CategoriesCategory.gd
@@ -359,6 +359,25 @@ DeclareAttribute( "FunctorCanonicalizeZeroMorphisms",
 DeclareAttribute( "NaturalIsomorphismFromIdentityToCanonicalizeZeroMorphisms",
                   IsCapCategory );
 
+#! @Description
+#! The arguments are two linear categories <A>source</A> and <A>range</A> over the same commutative ring,
+#! together with a function <A>F_o</A> on objects and a function <A>F_m</A> on basis morphisms.
+#! The operation returns the data needed to define the additive functor determined by these values,
+#! extending <A>F_m</A> from basis morphisms to arbitrary morphisms by linearity.
+#!
+#! The result is a list whose first two entries are the induced object function and morphism function.
+#! These functions cache values on objects and lazily cache values on basis morphisms via <C>LazyHList</C>.
+#!
+#! Two options can be passed. The option <C>known_values_on_objects</C> initializes the object cache with a pair of parallel lists.
+#! The option <C>is_full</C> controls whether two additional entries are returned, namely preimage
+#! functions on objects and morphisms.
+#!
+#! The last entry is always a record containing the internal cache data. If <C>is_full := true</C>,
+#! this record also contains the cached data for the preimage functions.
+#! @Arguments source, range, F_o, F_m[, options]
+#! @Returns a list consisting of two or four functions together with a final record storing cache data
+DeclareOperation( "AdditiveFunctorDataFromValuesOnBasisMorphisms",
+                  [ IsCapCategory, IsCapCategory, IsFunction, IsFunction ] );
 
 ####################################
 ##

--- a/CAP/gap/CategoriesCategory.gi
+++ b/CAP/gap/CategoriesCategory.gi
@@ -899,6 +899,249 @@ InstallMethod( NaturalIsomorphismFromIdentityToCanonicalizeZeroMorphisms,
     
 end );
 
+## Suppose the source category has 3 objects A, B, C and Hom(A, B) has basis { f_1, f_2 },
+## then the caching records looks like this:
+##
+## values_on_objects =
+##   [ [ A, B, C ],
+##     [ F(A), F(B), F(C) ] ]
+##
+## bases_of_source_category =
+##   [ [ A, B, C ],                             ## [1]: list of encountered source objects S
+##     [ [ [ B, [ f_1, f_2 ] ], ... ],           ## [2][1]: for S=A, list of [ T, BasisOfExternalHom(A,T) ]
+##       [ ... ],                                 ## [2][2]: for S=B
+##       [ ... ] ] ]                              ## [2][3]: for S=C
+##
+## values_on_bases_elements =
+##   [ [ A, B, C ],                                          ## [1]: list of encountered source objects S
+##     [ [ [ B, LazyHList( [ f_1, f_2 ], b -> F(b) ) ], ... ], ## [2][1]: for S=A, list of [ T, lazy list of basis images ]
+##       [ ... ],                                             ## [2][2]: for S=B
+##       [ ... ] ] ]                                          ## [2][3]: for S=C
+##
+InstallMethodWithCache( AdditiveFunctorDataFromValuesOnBasisMorphisms,
+        [ IsCapCategory, IsCapCategory, IsFunction, IsFunction ],
+
+  FunctionWithNamedArguments(
+    [
+      [ "is_full", false ],
+      [ "known_values_on_objects", fail ],
+    ],
+    function( CAP_NAMED_ARGUMENTS, source_cat, target_cat, F_o, F_m )
+    local values_on_objects, values_on_bases_elements, bases_of_source_category,
+      cached_position, cached_target_position, ensure_source_cache_entry,
+      ensure_target_cache_entry, cached_F_o, cached_F_m, data, preimage_data,
+      preimage_object_function, preimage_morphism_function,
+      range_cat_of_HomStructure, distinguished_obj, data_rec;
+    
+    if not IsLinearCategoryOverCommutativeRingWithFinitelyGeneratedFreeExternalHoms( source_cat ) then
+      Error( "the source category must be linear over a commutative ring and have finitely generated free external homs!\n" );
+    fi;
+
+    if not ( ForAll( [ source_cat, target_cat ], IsLinearCategoryOverCommutativeRing )
+              and IsIdenticalObj( CommutativeSemiringOfLinearCategory( source_cat ), CommutativeSemiringOfLinearCategory( target_cat ) ) ) then
+      Error( "the source and target categories must be linear over the same commutative ring!\n" );
+    fi;
+    
+    values_on_objects := CAP_NAMED_ARGUMENTS.known_values_on_objects;
+    
+    if values_on_objects = fail then
+      values_on_objects := [[],[]];
+    fi;
+    
+    values_on_bases_elements := [[],[]];
+    bases_of_source_category := [[],[]];
+    
+    cached_position :=
+      function( list, object )
+        return PositionProperty( list, x -> IsIdenticalObj( x, object ) or IsEqualForObjects( x, object ) );
+    end;
+    
+    cached_target_position :=
+      function( list, object )
+        return PositionProperty( list, x -> IsIdenticalObj( x[1], object ) or IsEqualForObjects( x[1], object ) );
+    end;
+    
+    ensure_source_cache_entry :=
+      function( S )
+        local index_S;
+        
+        index_S := cached_position( values_on_bases_elements[1], S );
+        
+        if index_S = fail then
+          Add( bases_of_source_category[1], S );
+          Add( bases_of_source_category[2], [] );
+          
+          Add( values_on_bases_elements[1], S );
+          Add( values_on_bases_elements[2], [] );
+          
+          index_S := Length( values_on_bases_elements[1] );
+        fi;
+        
+        return index_S;
+    end;
+    
+    ensure_target_cache_entry :=
+      function( index_S, S, T )
+        local index_T, basis_of_hom;
+        
+        index_T := cached_target_position( values_on_bases_elements[2][index_S], T );
+        
+        if index_T = fail then
+          basis_of_hom := BasisOfExternalHom( source_cat, S, T );
+          
+          Add( bases_of_source_category[2][index_S], [ T, basis_of_hom ] );
+          Add( values_on_bases_elements[2][index_S], [
+            T,
+            LazyHList( basis_of_hom,
+              b -> F_m( cached_F_o( S ), b, cached_F_o( T ) ) ) ] );
+          
+          index_T := Length( values_on_bases_elements[2][index_S] );
+        fi;
+        
+        return index_T;
+    end;
+    
+    cached_F_o :=
+      function( o )
+        local p;
+        
+        p := cached_position( values_on_objects[1], o );
+        
+        if p = fail then
+          
+          Add( values_on_objects[1], o );
+          
+          Add( values_on_objects[2], F_o( o ) );
+          
+          p := Length( values_on_objects[2] );
+          
+        fi;
+        
+        return values_on_objects[2][p];
+        
+    end;
+    
+    cached_F_m :=
+      function( F_S, phi, F_T )
+        local S, T, index_S, index_T, coeffs, positions;
+        
+        S := Source( phi );
+        T := Target( phi );
+        
+        coeffs := CoefficientsOfMorphism( source_cat, phi );
+        
+        positions := PositionsProperty( coeffs, c -> not IsZero( c ) );
+
+        index_S := ensure_source_cache_entry( S );
+        index_T := ensure_target_cache_entry( index_S, S, T );
+
+        return LinearCombinationOfMorphisms(
+          target_cat,
+          F_S,
+          List( positions, p -> coeffs[ p ] ),
+          List( positions, p -> values_on_bases_elements[2][index_S][index_T][2][p] ),
+          F_T );
+    
+    end;
+    
+    data := [ cached_F_o, cached_F_m ];
+    
+    if CAP_NAMED_ARGUMENTS.is_full then
+      
+      range_cat_of_HomStructure := RangeCategoryOfHomomorphismStructure( target_cat );
+      distinguished_obj := DistinguishedObjectOfHomomorphismStructure( range_cat_of_HomStructure );
+      
+      preimage_object_function :=
+        function( o )
+          local p;
+          
+          p := cached_position( values_on_objects[2], o );
+          
+          if p = fail then
+            Error( "please make sure you applied the 'full' functor on all relevant objects in the source category!\n" );
+          fi;
+          
+          return values_on_objects[1][p];
+          
+      end;
+      
+      preimage_data := [[],[]];
+      
+      preimage_morphism_function :=
+        function( S, phi, T )
+          local index_S, index_T, num_new_entries, basis_values, Hom_ST, tau, u, coeffs;
+          
+          index_S := ensure_source_cache_entry( S );
+
+          num_new_entries := index_S - Length( preimage_data[1] );
+          if num_new_entries > 0 then
+            Append( preimage_data[1], ListWithIdenticalEntries( num_new_entries, fail ) );
+          fi;
+
+          num_new_entries := index_S - Length( preimage_data[2] );
+          if num_new_entries > 0 then
+            Append( preimage_data[2], ListWithIdenticalEntries( num_new_entries, fail ) );
+          fi;
+
+          if preimage_data[1][index_S] = fail then
+            preimage_data[1][index_S] := S;
+            preimage_data[2][index_S] := [];
+          fi;
+
+          index_T := ensure_target_cache_entry( index_S, S, T );
+
+          num_new_entries := index_T - Length( preimage_data[2][index_S] );
+          if num_new_entries > 0 then
+            Append( preimage_data[2][index_S], ListWithIdenticalEntries( num_new_entries, fail ) );
+          fi;
+
+          if preimage_data[2][index_S][index_T] = fail then
+            basis_values := values_on_bases_elements[2][index_S][index_T][2];
+            
+            Hom_ST := HomomorphismStructureOnObjects( target_cat, Source( phi ), Target( phi ) );
+            
+            tau := List( ListOfValues( basis_values ), m -> InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( target_cat, distinguished_obj, m, Hom_ST ) );
+            
+            u := UniversalMorphismFromDirectSum( range_cat_of_HomStructure, ListWithIdenticalEntries( Length( tau ), distinguished_obj ), Hom_ST, tau );
+            
+            u := PreInverseForMorphisms( range_cat_of_HomStructure, u );
+            
+            preimage_data[2][index_S][index_T] := [ T, u, Hom_ST ];
+            
+          fi;
+          
+          Hom_ST := preimage_data[2][index_S][index_T][3];
+          
+          coeffs := PreCompose( range_cat_of_HomStructure,
+                      InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( target_cat, distinguished_obj, phi, Hom_ST ),
+                      preimage_data[2][index_S][index_T][2] );
+          
+          coeffs := CoefficientsOfMorphism( range_cat_of_HomStructure, coeffs );
+          
+          return LinearCombinationOfMorphisms( source_cat, S, coeffs , bases_of_source_category[2][index_S][index_T][2], T );
+          
+        end;
+        
+        Add( data, preimage_object_function );
+        Add( data, preimage_morphism_function );
+        
+    fi;
+    
+    data_rec := rec(
+        values_on_objects := values_on_objects,
+        bases_of_source_category := bases_of_source_category,
+        values_on_bases_elements := values_on_bases_elements
+    );
+    
+    if CAP_NAMED_ARGUMENTS.is_full then
+      data_rec.preimage_data := preimage_data;
+    fi;
+    
+    return Concatenation( data, [ data_rec ] );
+    
+  end )
+);
+
 ###################################
 ##
 ## Natural transformations

--- a/FreydCategoriesForCAP/PackageInfo.g
+++ b/FreydCategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FreydCategoriesForCAP",
 Subtitle := "Freyd categories - Formal (co)kernels for additive categories",
-Version := "2026.04-01",
+Version := "2026.05-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -101,7 +101,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.13.0",
-  NeededOtherPackages := [ [ "CAP", ">= 2026.04-01" ],
+  NeededOtherPackages := [ [ "CAP", ">= 2026.05-07" ],
                            [ "MatricesForHomalg", ">= 2026.04-01" ],
                            [ "GradedRingForHomalg", ">= 2026.04-01" ],
                            [ "AdditiveClosuresForCAP", ">= 2026.04-01" ],

--- a/FreydCategoriesForCAP/examples/Basics.gi
+++ b/FreydCategoriesForCAP/examples/Basics.gi
@@ -224,4 +224,45 @@ interpretation := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphi
 IsCongruentForMorphisms( Opposite( gamma ),
 InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( Source( Opposite( gamma ) ), Range( Opposite( gamma ) ), interpretation ) );
 #! true
+
+QQ := HomalgFieldOfRationals( );;
+rows_QQ := CategoryOfRows( QQ );;
+freyd_QQ := FreydCategory( rows_QQ );;
+F_o := obj -> CokernelObject( RelationMorphism( obj ) );;
+F_m := { S, m, T } -> CokernelColift( rows_QQ, RelationMorphism( Source( m ) ), PreCompose( UnderlyingMorphism( m ), CokernelProjection( rows_QQ, RelationMorphism( Target( m ) ) ) ) );;
+data := AdditiveFunctorDataFromValuesOnBasisMorphisms( freyd_QQ, rows_QQ, F_o, F_m : is_full := true );;
+obj1 := HomalgMatrix( [ [ -180, 240, 100, 20, 90, -240, -10, 60, 30, 180 ], [ 300, -15, -20, 40, -30, -120, -60, -12, -180, 0 ] ], 2, 10, QQ ) / rows_QQ / freyd_QQ;;
+obj2 := HomalgZeroMatrix( 0, 4, QQ ) / rows_QQ / freyd_QQ;;
+m := FreydCategoryMorphism(
+        obj1,
+        HomalgMatrix(
+            [   [ 10328, -2748, -1803, -49840 ],
+                [ 62416, -88224, -85956, -183680 ],
+                [ 13860, 27720, 27720, -27720 ],
+                [ 0, 55440, 0, -27720 ],
+                [ -83160, 27720, 9240, 0 ],
+                [ 18480, -27720, 0, -97020 ],
+                [ 9240, 83160, -6930, -18480 ],
+                [ -4620, -110880, 27720, 0 ],
+                [ 9240, 5544, 0, 0 ],
+                [ -13860, 83160, 83160, 83160 ] ],
+            10, 4,
+            QQ ) / rows_QQ,
+        obj2 );;
+IsZeroForMorphisms( m );
+#! false
+image_m := F_m( F_o( Source( m ) ), m, F_o( Target( m ) ) );
+#! <A morphism in Rows( Q )>
+RankOfObject( Source( image_m ) );
+#! 8
+RankOfObject( Target( image_m ) );
+#! 4
+image_m = data[2]( data[1]( Source( m ) ), m, data[1]( Target( m ) ) );
+#! true
+data[3]( data[1]( Source( m ) ) ) = Source( m );
+#! true
+data[3]( data[1]( Target( m ) ) ) = Target( m );
+#! true
+data[4]( Source( m ), image_m, Target( m ) ) = m;
+#! true
 #! @EndExample


### PR DESCRIPTION
Introduce `AdditiveFunctorDataFromValuesOnBasisMorphisms` to construct additive functor data by writing morphisms as linear combinations of bases. Provides cached object/morphism maps with lazy evaluation; optional preimage maps via is_full; returns a record with cache data. Validates linear categories over the same ring with finitely generated free external homs. Add example demonstrating usage in **FreydCategoriesForCAP**.

Bump **CAP** to V2026.05-07
Bump **FreydCategoriesForCAP** to V2026.05-01

This function is currently provided by **ToolsForHigherHomologicalAlgebra** (under another name: _AdditiveFunctorByTwoFunctionsData_) and is required by **FunctorCategories**. After this PR, and once **FunctorCategories** has been updated to use this function, the **HigherHomologicalAlgebra** project will no longer be required for testing **CategoricalTowers**.