### PR TITLE
Generalized the type of the 3- and 4-argument version of Iterated

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2026.05-07",
+Version := "2026.05-08",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/ToolsForCategories.gd
+++ b/CAP/gap/ToolsForCategories.gd
@@ -260,12 +260,25 @@ DeclareGlobalFunction( "CapJitTypedExpression" );
 DeclareGlobalFunction( "CapFixpoint" );
 
 #! @Description
-#!   Shorthand for `Iterated( Concatenation( [ <A>initial_value</A> ], <A>list</A> ), <A>func</A> )`.
+#!   This input is a homogeneous list of elements, i.e., having the same type,
+#!   a bivariate function <A>func</A>, and an object <A>initial_value</A>.
+#!   The type of the first argument of <A>func</A> must be equal to the type of <A>initial_value</A>.
+#!   The type of the second argument of <A>func</A> must be equal to the type of the entries of <A>list</A>.
+#!   The type of the output of <A>func</A> must be equal to the type of <A>initial_value</A>.
+#!   The installed method simply calls `Iterated( Concatenation( [ <A>initial_value</A> ], <A>list</A> ), <A>func</A> )`.
+#!   In particular, if <A>list</A> is empty, the output will be <A>initial_value</A>.
+#!   This allows for the implementation of compilable initialized for-loops in CAP.
 #! @Arguments list, func, initial_value
 DeclareOperation( "Iterated", [ IsList, IsFunction, IsObject ] );
 
 #! @Description
-#!   Shorthand for `Iterated( Concatenation( [ <A>initial_value</A> ], <A>list</A>, [ <A>terminal_value</A> ] ), <A>func</A> )`.
+#!   This input is a homogeneous list of elements, i.e., having the same type,
+#!   a bivariate function <A>func</A>, an object <A>initial_value</A>, and another object <A>terminal_entry</A>.
+#!   The type of the <A>terminal_entry</A> must be equal to the type of the entries of <A>list</A>.
+#!   The type of the first argument of <A>func</A> must be equal to the type of <A>initial_value</A>.
+#!   The type of the second argument of <A>func</A> must be equal to the type of the entries of <A>list</A>.
+#!   The type of the output of <A>func</A> must be equal to the type of <A>initial_value</A>.
+#!   The installed method simply calls `Iterated( Concatenation( [ <A>initial_value</A> ], <A>list</A>, [ <A>terminal_entry</A> ] ), <A>func</A> )`.
 #! @Arguments list, func, initial_value, terminal_value
 DeclareOperation( "Iterated", [ IsList, IsFunction, IsObject, IsObject ] );
 

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2026.05-01",
+Version := "2026.05-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -70,7 +70,7 @@ Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [
       [ "ToolsForHomalg", ">= 2026.04-01" ],
-      [ "CAP", ">= 2026.04-01" ],
+      [ "CAP", ">= 2026.05-08" ],
   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/CompilerForCAP/gap/InferDataTypes.gi
+++ b/CompilerForCAP/gap/InferDataTypes.gi
@@ -1483,11 +1483,11 @@ end );
 
 CapJitAddTypeSignature( "Iterated", [ IsList, IsFunction, IsObject ], function ( args, func_stack )
     
-    Assert( 0, args.1.data_type.element_type = args.3.data_type );
+    ## the type of the elements of the list might differ from the type of the initial value (third argument)
     
     args := ShallowCopy( args );
     
-    args.2 := CAP_JIT_INTERNAL_INFERRED_DATA_TYPES_OF_FUNCTION_BY_ARGUMENTS_TYPES( args.2, [ args.1.data_type.element_type, args.1.data_type.element_type ], func_stack );
+    args.2 := CAP_JIT_INTERNAL_INFERRED_DATA_TYPES_OF_FUNCTION_BY_ARGUMENTS_TYPES( args.2, [ args.3.data_type, args.1.data_type.element_type ], func_stack );
     
     if args.2 = fail then
         
@@ -1502,12 +1502,13 @@ end );
 
 CapJitAddTypeSignature( "Iterated", [ IsList, IsFunction, IsObject, IsObject ], function ( args, func_stack )
     
-    Assert( 0, args.1.data_type.element_type = args.3.data_type );
+    ## the type of the elements of the list might differ from the type of the initial value (third argument)
+    
     Assert( 0, args.1.data_type.element_type = args.4.data_type );
     
     args := ShallowCopy( args );
     
-    args.2 := CAP_JIT_INTERNAL_INFERRED_DATA_TYPES_OF_FUNCTION_BY_ARGUMENTS_TYPES( args.2, [ args.1.data_type.element_type, args.1.data_type.element_type ], func_stack );
+    args.2 := CAP_JIT_INTERNAL_INFERRED_DATA_TYPES_OF_FUNCTION_BY_ARGUMENTS_TYPES( args.2, [ args.3.data_type, args.1.data_type.element_type ], func_stack );
     
     if args.2 = fail then
         


### PR DESCRIPTION
Iterated can now be used to implement initialized for-loops in CAP, which are compilable
