### PR TITLE
Make linear closure constructor accept filters

### DIFF
--- a/LinearClosuresForCAP/PackageInfo.g
+++ b/LinearClosuresForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "LinearClosuresForCAP",
 Subtitle := "Linear closures",
-Version := "2026.04-01",
+Version := "2026.06-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/LinearClosuresForCAP/gap/LinearClosure.gi
+++ b/LinearClosuresForCAP/gap/LinearClosure.gi
@@ -15,6 +15,10 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR_USING_CategoryOfRows,
   FunctionWithNamedArguments(
   [
     [ "FinalizeCategory", true ],
+    [ "category_filter", IsLinearClosure ],
+    [ "category_object_filter", IsLinearClosureObject ],
+    [ "category_morphism_filter", IsLinearClosureMorphism ],
+    [ "category_two_cell_filter", IsCapCategoryTwoCell ],
   ],
   function( CAP_NAMED_ARGUMENTS, rows, underlying_category, arg... ) ## rows = CategoryOfRows( ... )
     local ring, name, category, is_finite, sorting_function, with_nf, cocycle;
@@ -83,7 +87,11 @@ InstallGlobalFunction( LINEAR_CLOSURE_CONSTRUCTOR_USING_CategoryOfRows,
         
     fi;
     
-    category := CreateCapCategory( name, IsLinearClosure, IsLinearClosureObject, IsLinearClosureMorphism, IsCapCategoryTwoCell : overhead := false );
+    category := CreateCapCategory( name,
+                    CAP_NAMED_ARGUMENTS.category_filter,
+                    CAP_NAMED_ARGUMENTS.category_object_filter,
+                    CAP_NAMED_ARGUMENTS.category_morphism_filter,
+                    CAP_NAMED_ARGUMENTS.category_two_cell_filter : overhead := false );
     
     category!.compiler_hints := rec(
         category_attribute_names := [


### PR DESCRIPTION
Add named arguments for category, object, morphism, and two-cell filters with defaults matching previous behavior, and use them when creating the CAP category.

Bump version of **LinearClosuresForCAP** to v2026.06-01