### PR TITLE
CAP: Avoid duplicate methods for primitive replacements

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2026.07-03",
+Version := "2026.07-04",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/gap/CAP.gi
+++ b/CAP/gap/CAP.gi
@@ -333,6 +333,8 @@ InstallGlobalFunction( "CreateCapCategoryWithDataTypes", FunctionWithNamedArgume
     od;
     
     obj!.added_functions := rec( );
+
+    obj!.number_of_installed_methods := rec( );
     
     obj!.operations := rec( );
     

--- a/CAP/gap/InstallAdds.gd
+++ b/CAP/gap/InstallAdds.gd
@@ -8,6 +8,8 @@
 
 #! @Section InstallAdd Function
 
+DeclareInfoClass( "CapOperationInstallationInfo" );
+
 DeclareOperation( "AddCapOperation", [ IsString, IsCapCategory, IsFunction, IsInt ] );
 
 DeclareGlobalFunction( "CAP_INTERNAL_INSTALL_ADDS_FROM_RECORD" );

--- a/CAP/gap/InstallAdds.gi
+++ b/CAP/gap/InstallAdds.gi
@@ -23,7 +23,7 @@ InstallMethod( AddCapOperation,
     [ "IsPrecompiledDerivation", false ],
   ],
   function( CAP_NAMED_ARGUMENTS, function_name, category, func_to_install, weight )
-    local record, category_name, is_derivation, is_final_derivation, is_precompiled_derivation, type, replaced_filter_list,
+    local record, category_name, is_derivation, is_final_derivation, is_precompiled_derivation, type, replaces_primitive_installation, replaced_filter_list,
         input_human_readable_identifier_getter, input_sanity_check_functions, data_type, output_human_readable_identifier_getter,
         output_data_type, output_sanity_check_function, filter_string;
     
@@ -68,6 +68,8 @@ InstallMethod( AddCapOperation,
         type := "primitive_installation";
         
     fi;
+
+    replaces_primitive_installation := false;
     
     # Display a warning in various cases when overwriting existing functions
     if IsBound( category!.operations.(function_name) ) then
@@ -87,6 +89,20 @@ InstallMethod( AddCapOperation,
             
             return;
             
+        fi;
+
+        replaces_primitive_installation :=
+            category!.operations.( function_name ).type = "primitive_installation" and
+            type = "primitive_installation";
+
+        if replaces_primitive_installation then
+
+            Info( CapOperationInstallationInfo, 1,
+                  "Duplicate primitive installation for ", function_name,
+                  " in category \"", category_name,
+                  "\": replacing weight ", category!.operations.( function_name ).weight,
+                  " with weight ", weight, "." );
+
         fi;
         
         if category!.operations.( function_name ).type = "primitive_installation" then
@@ -221,6 +237,20 @@ InstallMethod( AddCapOperation,
         fi;
         
     fi;
+
+    if replaces_primitive_installation then
+
+        return;
+
+    fi;
+
+    if not IsBound( category!.number_of_installed_methods.( function_name ) ) then
+
+        category!.number_of_installed_methods.( function_name ) := 0;
+
+    fi;
+
+    category!.number_of_installed_methods.( function_name ) := category!.number_of_installed_methods.( function_name ) + 1;
     
     if not category!.overhead then
         
@@ -229,7 +259,7 @@ InstallMethod( AddCapOperation,
                             
             function( arg )
                 
-                return CallFuncList( func_to_install, arg );
+                return CallFuncList( category!.operations.( function_name ).func, arg );
                 
         end );
         
@@ -280,7 +310,7 @@ InstallMethod( AddCapOperation,
                 
             fi;
             
-            result := CallFuncList( func_to_install, arg );
+            result := CallFuncList( category!.operations.( function_name ).func, arg );
             
             if collect_timing_statistics then
                 

--- a/CompilerForCAP/PackageInfo.g
+++ b/CompilerForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CompilerForCAP",
 Subtitle := "Speed up and verify categorical algorithms",
-Version := "2026.06-06",
+Version := "2026.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -70,7 +70,7 @@ Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [
       [ "ToolsForHomalg", ">= 2026.04-01" ],
-      [ "CAP", ">= 2026.06-03" ],
+      [ "CAP", ">= 2026.07-04" ],
   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/CompilerForCAP/gap/ResolveOperations.gi
+++ b/CompilerForCAP/gap/ResolveOperations.gi
@@ -159,7 +159,7 @@ InstallGlobalFunction( CapJitResolvedOperations, function ( tree )
                     Info( InfoCapJit, 1, "####" );
                     Info( InfoCapJit, 1, Concatenation( "Resolve CAP operation ", operation_name, ", recurse compilation." ) );
                     
-                    CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( operation, Length( info.filter_list ), [ CapJitDataTypeOfCategory( category ).filter ], Length( category!.added_functions.(operation_name) ), { operation_name } -> Concatenation(
+                    CAP_JIT_INTERNAL_WARN_ABOUT_SIMILAR_METHODS( operation, Length( info.filter_list ), [ CapJitDataTypeOfCategory( category ).filter ], category!.number_of_installed_methods.(operation_name), { operation_name } -> Concatenation(
                         # COVERAGE_IGNORE_BLOCK_START
                         "WARNING: A method for the CAP operation ", operation_name, " was installed manually (e.g. using Install(Other)Method), ",
                         "but CompilerForCAP will always resolve the methods installed via CAP's Add-functions.\n"


### PR DESCRIPTION
When a primitive CAP operation is replaced by another primitive
implementation, update the category operation record without installing
another method with identical filters.

Installed dispatch methods now consult the current operation record, so
the latest implementation is used while preserving the added_functions
history. This avoids Julia method-overwrite errors during module
precompilation.

Add CapOperationInstallationInfo and emit a level-1 message when an
accepted primitive installation replaces another primitive
implementation. Include the operation, category, and old and new weights.

CompilerForCAP previously used the number of accepted Add-functions as
the expected number of installed GAP methods. These counts can differ
depending on whether implementations are primitive, derived, final
derived, or precompiled derived. In particular, replacing one primitive
implementation with another changes the function used by the existing
GAP method without installing a new method. Track the actual number of
methods installed by CAP per operation and use it when checking for
manually installed competing methods.

Bump CAP to v2026.07-04 and CompilerForCAP to v2026.07-01.