### PR TITLE
MonoidalCategories: Fix spacing in List ranges for Gap2Julia transpiler

### DIFF
--- a/MonoidalCategories/PackageInfo.g
+++ b/MonoidalCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "MonoidalCategories",
 Subtitle := "Monoidal and monoidal (co)closed categories",
-Version := "2026.07-02",
+Version := "2026.07-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/MonoidalCategories/gap/AdditiveMonoidalCategoriesDerivedMethods.gi
+++ b/MonoidalCategories/gap/AdditiveMonoidalCategoriesDerivedMethods.gi
@@ -27,7 +27,7 @@ AddDerivationToCAP( LeftDistributivityExpandingWithGivenObjects,
     
     projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSumWithGivenDirectSum( cat, summands, i, sum_of_summands ) );
     
-    projection_list_tensored := List( [1 .. nr_summands ],
+    projection_list_tensored := List( [ 1 .. nr_summands ],
                                       i -> TensorProductOnMorphismsWithGivenTensorProducts( cat,
                                                     factored_object,
                                                     id,
@@ -76,7 +76,7 @@ AddDerivationToCAP( LeftDistributivityFactoringWithGivenObjects,
     
     injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, summands, i, sum_of_summands ) );
     
-    injection_list_tensored := List( [1 .. nr_summands ],
+    injection_list_tensored := List( [ 1 .. nr_summands ],
                                      i -> TensorProductOnMorphismsWithGivenTensorProducts( cat,
                                                     diagram[i],
                                                     id,
@@ -125,7 +125,7 @@ AddDerivationToCAP( RightDistributivityExpandingWithGivenObjects,
     
     projection_list := List( [ 1 .. nr_summands ], i -> ProjectionInFactorOfDirectSumWithGivenDirectSum( cat, summands, i, sum_of_summands ) );
     
-    projection_list_tensored := List( [1 .. nr_summands ],
+    projection_list_tensored := List( [ 1 .. nr_summands ],
                                       i -> TensorProductOnMorphismsWithGivenTensorProducts( cat,
                                                     factored_object,
                                                     projection_list[i],
@@ -174,7 +174,7 @@ AddDerivationToCAP( RightDistributivityFactoringWithGivenObjects,
     
     injection_list := List( [ 1 .. nr_summands ], i -> InjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, summands, i, sum_of_summands ) );
     
-    injection_list_tensored := List( [1 .. nr_summands ],
+    injection_list_tensored := List( [ 1 .. nr_summands ],
                                      i -> TensorProductOnMorphismsWithGivenTensorProducts( cat,
                                                     diagram[i],
                                                     injection_list[i],


### PR DESCRIPTION
Normalize [1 .. nr_summands] to [ 1 .. nr_summands ] in the distributivity helpers.

Bump version to v2026.07-03