### PR TITLE
Construct `FiniteSkeletalDiscreteCategory` from a single integer argument

### DIFF
--- a/CAP/PackageInfo.g
+++ b/CAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CAP",
 Subtitle := "Categories, Algorithms, Programming",
-Version := "2026.07-04",
+Version := "2026.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/CAP/examples/FiniteSkeletalDiscreteCategory.g
+++ b/CAP/examples/FiniteSkeletalDiscreteCategory.g
@@ -5,10 +5,10 @@
 #! @Example
 LoadPackage( "CAP", false );
 #! true
-D := FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] );
-#! FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] )
+D := FiniteSkeletalDiscreteCategory( 5 );
+#! FiniteSkeletalDiscreteCategory( 5 )
 one := ObjectConstructor( D, 1 );
-#! <An object in FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] )>
+#! <An object in FiniteSkeletalDiscreteCategory( 5 )>
 IsWellDefinedForObjects( one );
 #! true
 ObjectDatum( one ) = 1;
@@ -18,7 +18,7 @@ Display( one );
 IsEqualForObjects( one, D[1] );
 #! true
 id_one := IdentityMorphism( D, one );
-#! <An identity morphism in FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] )>
+#! <An identity morphism in FiniteSkeletalDiscreteCategory( 5 )>
 IsWellDefinedForMorphisms( id_one );
 #! true
 MorphismDatum( id_one ) = fail;
@@ -26,7 +26,7 @@ MorphismDatum( id_one ) = fail;
 Display( id_one );
 #! 1
 #! |
-#! | A morphism in FiniteSkeletalDiscreteCategory( [ 1 .. 5 ] )
+#! | A morphism in FiniteSkeletalDiscreteCategory( 5 )
 #! v
 #! 1
 IsEqualForMorphisms( PreCompose( id_one, id_one ), id_one );

--- a/CAP/examples/FiniteSkeletalDiscreteCategory.g
+++ b/CAP/examples/FiniteSkeletalDiscreteCategory.g
@@ -5,8 +5,13 @@
 #! @Example
 LoadPackage( "CAP", false );
 #! true
-D := FiniteSkeletalDiscreteCategory( 5 );
+
+# Set 'overhead := false' so that the actual function installed
+# for IsEqualForMorphisms is executed in the CI and not just
+# its redirect function.
+D := FiniteSkeletalDiscreteCategory( 5 : overhead := false );
 #! FiniteSkeletalDiscreteCategory( 5 )
+
 one := ObjectConstructor( D, 1 );
 #! <An object in FiniteSkeletalDiscreteCategory( 5 )>
 IsWellDefinedForObjects( one );
@@ -18,7 +23,7 @@ Display( one );
 IsEqualForObjects( one, D[1] );
 #! true
 id_one := IdentityMorphism( D, one );
-#! <An identity morphism in FiniteSkeletalDiscreteCategory( 5 )>
+#! <A morphism in FiniteSkeletalDiscreteCategory( 5 )>
 IsWellDefinedForMorphisms( id_one );
 #! true
 MorphismDatum( id_one ) = fail;

--- a/CAP/gap/FiniteSkeletalDiscreteCategory.gd
+++ b/CAP/gap/FiniteSkeletalDiscreteCategory.gd
@@ -44,14 +44,18 @@ DeclareGlobalFunction( "FiniteSkeletalDiscreteCategory" );
 ########################################
 
 #! @Description
-#!  The underlying &GAP; objects of a finite skeletal discrete category.
+#!  The number of objects of a finite skeletal discrete category.
 #! @Returns a list of &CAP; objects
-DeclareAttribute( "UnderlyingListOfGapObjects", IsFiniteSkeletalDiscreteCategory );
+DeclareAttribute( "NumberOfObjects", IsFiniteSkeletalDiscreteCategory );
+
+CapJitAddTypeSignature( "NumberOfObjects", [ IsFiniteSkeletalDiscreteCategory ], IsBigInt );
 
 #! @Description
-#!  The underlying &GAP; object of an object in a finite skeletal discrete category.
-#! @Returns a &CAP; object
-DeclareAttribute( "UnderlyingGapObject", IsObjectInFiniteSkeletalDiscreteCategory );
+#!  The index of an object in a finite skeletal discrete category.
+#! @Returns an integer
+DeclareAttribute( "IndexOfObject", IsObjectInFiniteSkeletalDiscreteCategory );
+
+CapJitAddTypeSignature( "IndexOfObject", [ IsObjectInFiniteSkeletalDiscreteCategory ], IsBigInt );
 
 ####################################
 #

--- a/CAP/gap/FiniteSkeletalDiscreteCategory.gi
+++ b/CAP/gap/FiniteSkeletalDiscreteCategory.gi
@@ -19,24 +19,23 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
   [
     [ "FinalizeCategory", true ],
   ],
-  function( CAP_NAMED_ARGUMENTS, list_of_gap_objects )
+  function( CAP_NAMED_ARGUMENTS, number_of_objects )
     local name, D;
     
-    name := Concatenation( "FiniteSkeletalDiscreteCategory( ", String( list_of_gap_objects ), " )" );
+    name := Concatenation( "FiniteSkeletalDiscreteCategory( ", String( number_of_objects ), " )" );
     
     D := CreateCapCategoryWithDataTypes( name,
                                          IsFiniteSkeletalDiscreteCategory,
                                          IsObjectInFiniteSkeletalDiscreteCategory,
                                          IsMorphismInFiniteSkeletalDiscreteCategory,
                                          IsCapCategoryTwoCell,
-                                         rec( category := false,
-                                              filter := IsObject ),
+                                         IsBigInt,
                                          fail,
                                          fail );
     
-    D!.compiler_hints := rec( category_attribute_names := [ "UnderlyingListOfGapObjects" ] );
+    D!.compiler_hints := rec( category_attribute_names := [ "NumberOfObjects" ] );
     
-    SetUnderlyingListOfGapObjects( D, list_of_gap_objects );
+    SetNumberOfObjects( D, number_of_objects );
     
     SetIsFiniteCategory( D, true );
     
@@ -52,13 +51,13 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     
     ##
     AddObjectConstructor( D,
-      function( D, gap_object )
+      function( D, index )
         
         #% CAP_JIT_DROP_NEXT_STATEMENT
-        Assert( 0, gap_object in UnderlyingListOfGapObjects( D ) );
+        Assert( 0, 1 <= index and index <= NumberOfObjects( D ) );
         
         return CreateCapCategoryObjectWithAttributes( D,
-                                                      UnderlyingGapObject, gap_object );
+                                                      IndexOfObject, index );
         
     end );
     
@@ -66,7 +65,7 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     AddObjectDatum( D,
       function( D, object )
         
-        return UnderlyingGapObject( object );
+        return IndexOfObject( object );
         
     end );
     
@@ -93,7 +92,7 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     AddIsWellDefinedForObjects( D,
       function( D, object )
         
-        return UnderlyingGapObject( object ) in UnderlyingListOfGapObjects( D );
+        return 1 <= IndexOfObject( object ) and IndexOfObject( object ) <= NumberOfObjects( D );
         
     end );
     
@@ -108,7 +107,7 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     AddIsEqualForObjects( D,
       function( D, object_1, object_2 )
         
-        return UnderlyingGapObject( object_1 ) = UnderlyingGapObject( object_2 );
+        return IndexOfObject( object_1 ) = IndexOfObject( object_2 );
         
     end );
     
@@ -140,7 +139,7 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     AddSetOfObjectsOfCategory( D,
       function( D )
         
-        return List( UnderlyingListOfGapObjects( D ), obj -> ObjectConstructor( D, obj ) );
+        return List( [ 1 .. NumberOfObjects( D ) ], i -> ObjectConstructor( D, i ) );
         
     end );
     
@@ -161,6 +160,21 @@ InstallGlobalFunction( FiniteSkeletalDiscreteCategory,
     return D;
     
 end ) );
+
+####################################
+##
+## Attributes
+##
+####################################
+
+InstallMethodForCompilerForCAP( IndexOfObject,
+                                [ IsObjectInFiniteSkeletalDiscreteCategory ],
+                                
+  function( obj )
+    
+    return IndexOfObject( obj );
+    
+end );
 
 #################################
 #
@@ -201,7 +215,7 @@ InstallMethod( DisplayString,
 
   function( object )
     
-    return Concatenation( String( UnderlyingGapObject( object ) ), "\n" );
+    return Concatenation( String( IndexOfObject( object ) ), "\n" );
     
 end );
 


### PR DESCRIPTION
And not from a list of GAP objects. This streamlines it with `SkeletaFinSets`.

Additionally, set `overhead := false` in an example, to (hopefully) increase the code coverage.